### PR TITLE
Fix: filter in wallet tab is ignored after reloading

### DIFF
--- a/Trust/Tokens/ViewControllers/TokensViewController.swift
+++ b/Trust/Tokens/ViewControllers/TokensViewController.swift
@@ -16,6 +16,7 @@ class TokensViewController: UIViewController {
 
     var viewModel: TokensViewModel = TokensViewModel(tokens: [], tickers: .none) {
         didSet {
+            viewModel.filter = oldValue.filter
             refreshView(viewModel: viewModel)
         }
     }

--- a/Trust/Tokens/ViewModels/TokensViewModel.swift
+++ b/Trust/Tokens/ViewModels/TokensViewModel.swift
@@ -3,7 +3,8 @@
 import Foundation
 import UIKit
 
-struct TokensViewModel {
+//Must be a class, and not a struct, otherwise changing `filter` will silently create a copy of TokensViewModel when user taps to change the filter in the UI and break filtering
+class TokensViewModel {
     var tokens: [TokenObject] = [] {
         willSet {
 			tokens = reorderTokensSoFIFAAtIndex1(tokens: newValue)


### PR DESCRIPTION
Changing filter in wallet then reloading (either automatically or pull down to refresh) shows all results, ignoring the filter

s/than/then.