### PR TITLE
Fix: universal link doesn't get imported if user has opened any screen on top of the tab bar

### DIFF
--- a/Trust/AppDelegate.swift
+++ b/Trust/AppDelegate.swift
@@ -94,6 +94,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
 extension AppDelegate: UniversalLinkCoordinatorDelegate {
     func viewControllerForPresenting(in coordinator: UniversalLinkCoordinator) -> UIViewController? {
-        return window?.rootViewController
+        if var top = window?.rootViewController {
+            while let vc = top.presentedViewController {
+                top = vc
+            }
+            return top
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
For #146 