### PR TITLE
The wallet account imported should be marked as already-backed up, and not to remind user to backup

### DIFF
--- a/Trust/Wallet/Coordinators/WalletCoordinator.swift
+++ b/Trust/Wallet/Coordinators/WalletCoordinator.swift
@@ -123,6 +123,7 @@ extension WalletCoordinator: WelcomeViewControllerDelegate {
 
 extension WalletCoordinator: ImportWalletViewControllerDelegate {
     func didImportAccount(account: Wallet, in viewController: ImportWalletViewController) {
+        Config().addToWalletAddressesAlreadyPromptedForBackup(address: account.address.eip55String)
         didCreateAccount(account: account)
     }
 }


### PR DESCRIPTION
Especially relevant with #259.