### PR TITLE
Fix: strange scrolling effect in screens with ticket list after tapping on ticket row

### DIFF
--- a/Trust/Redeem/ViewControllers/RedeemTicketsViewController.swift
+++ b/Trust/Redeem/ViewControllers/RedeemTicketsViewController.swift
@@ -108,9 +108,7 @@ class RedeemTicketsViewController: UIViewController {
     }
 
     private func animateRowHeightChanges(for indexPaths: [IndexPath], in tableview: UITableView) {
-        tableView.reloadRows(at: indexPaths, with: .automatic)
-        tableView.beginUpdates()
-        tableView.endUpdates()
+        tableView.reloadData()
     }
 }
 

--- a/Trust/Sell/ViewControllers/SellTicketsViewController.swift
+++ b/Trust/Sell/ViewControllers/SellTicketsViewController.swift
@@ -104,9 +104,7 @@ class SellTicketsViewController: UIViewController {
     }
 
     private func animateRowHeightChanges(for indexPaths: [IndexPath], in tableview: UITableView) {
-        tableView.reloadRows(at: indexPaths, with: .automatic)
-        tableView.beginUpdates()
-        tableView.endUpdates()
+        tableView.reloadData()
     }
 }
 

--- a/Trust/Tokens/ViewControllers/TicketsViewController.swift
+++ b/Trust/Tokens/ViewControllers/TicketsViewController.swift
@@ -172,9 +172,7 @@ class TicketsViewController: UIViewController {
     }
 
     private func animateRowHeightChanges(for indexPaths: [IndexPath], in tableview: UITableView) {
-        tableView.reloadRows(at: indexPaths, with: .automatic)
-        tableView.beginUpdates()
-        tableView.endUpdates()
+        tableView.reloadData()
     }
 }
 

--- a/Trust/Transfer/ViewControllers/TransferTicketsViewController.swift
+++ b/Trust/Transfer/ViewControllers/TransferTicketsViewController.swift
@@ -104,9 +104,7 @@ class TransferTicketsViewController: UIViewController {
     }
 
     private func animateRowHeightChanges(for indexPaths: [IndexPath], in tableview: UITableView) {
-        tableView.reloadRows(at: indexPaths, with: .automatic)
-        tableView.beginUpdates()
-        tableView.endUpdates()
+        tableView.reloadData()
     }
 }
 


### PR DESCRIPTION
Fixes: In the ticket list as well as sell, redeem, transfer screens, 

1. scroll a little
2. tap on a ticket row
3. The screen will scroll mysterious, and automatically

(reported by Victor)