### PR TITLE
Fix: import ticket UI should not change to prompt for import again shortly after importing paid link

### DIFF
--- a/Trust/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/Trust/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -18,6 +18,7 @@ class UniversalLinkCoordinator: Coordinator {
 	var importTicketViewController: ImportTicketViewController?
     var ethPrice: Subscribable<Double>?
     var ethBalance: Subscribable<BigInt>?
+    var hasCompleted = false
 
 	func start()
     {
@@ -246,6 +247,7 @@ class UniversalLinkCoordinator: Coordinator {
 	}
 
 	private func updateImportTicketController(with state: ImportTicketViewControllerViewModel.State, ticketHolder: TicketHolder? = nil, ethCost: String? = nil, dollarCost: String? = nil) {
+        guard !hasCompleted else { return }
 		if let vc = importTicketViewController, var viewModel = vc.viewModel {
 			viewModel.state = state
             if let ticketHolder = ticketHolder {
@@ -259,6 +261,7 @@ class UniversalLinkCoordinator: Coordinator {
             }
 			vc.configure(viewModel: viewModel)
 		}
+        hasCompleted = state.hasCompleted
 	}
 
 	private func promptImportUniversalLink(ticketHolder: TicketHolder, ethCost: String, dollarCost: String? = nil) {

--- a/Trust/Market/ViewModels/ImportTicketViewControllerViewModel.swift
+++ b/Trust/Market/ViewModels/ImportTicketViewControllerViewModel.swift
@@ -9,6 +9,15 @@ struct ImportTicketViewControllerViewModel {
         case processing
         case succeeded
         case failed(errorMessage: String)
+
+        var hasCompleted: Bool {
+            switch self {
+            case .succeeded, .failed:
+                return true
+            case .validating, .processing, .promptImport:
+                return false
+            }
+        }
     }
     var state: State
     var ticketHolder: TicketHolder?


### PR DESCRIPTION
Reported by Victor:

1. Tap paid link to import
2. Imported successfully
3. Within a few seconds, the UI would refresh and prompt for import again (triggered by fetching ETH-USD price).