### PR TITLE
Fix: token balance stops updating after switching language in-app, until app is restarted

### DIFF
--- a/AlphaWallet/Settings/Models/LiveLocaleSwitcherBundle.swift
+++ b/AlphaWallet/Settings/Models/LiveLocaleSwitcherBundle.swift
@@ -17,7 +17,12 @@ class LiveLocaleSwitcherBundle: Bundle {
     override func url(forResource name: String?, withExtension ext: String?) -> URL? {
         //We want to match "html", but exclude "nib" (for "xib"). Safe to whitelist instead of blacklist
         if ext == "html", let languageBundle = objc_getAssociatedObject(self, &liveLocaleSwitcherBundleKey) as? Bundle {
-            return languageBundle.url(forResource: name, withExtension: ext)
+            //Some resources are not localized. Eg. HTML files used by Web3Swift. Rather than whitelist/blacklist, we just fall back to the right bundle
+            if let url = languageBundle.url(forResource: name, withExtension: ext) {
+                return url
+            } else {
+                return super.url(forResource: name, withExtension: ext)
+            }
         } else {
             return super.url(forResource: name, withExtension: ext)
         }

--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -65,4 +65,24 @@ class ConfigTests: XCTestCase {
         //Must change this back to system, otherwise other tests will break either immediately or the next run
         config.locale = AppLocale.system.id
     }
+
+    func testWeb3StillLoadsAfterSwitchingLocale() {
+        var config: Config = .make()
+
+        config.locale = AppLocale.english.id
+        config.locale = AppLocale.simplifiedChinese.id
+
+        let expectation = XCTestExpectation(description: "web3 loaded")
+        let web3 = Web3Swift()
+        web3.start()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            if web3.isLoaded {
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 4)
+
+        //Must change this back to system, otherwise other tests will break either immediately or the next run
+        config.locale = AppLocale.system.id
+    }
 }


### PR DESCRIPTION
For #399 