### PR TITLE
Align import from clipboard behavior with Android's.

### DIFF
--- a/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
@@ -15,9 +15,7 @@ class UniversalLinkInPasteboardCoordinator: Coordinator {
         guard contents.hasPrefix(UniversalLinkHandler().urlPrefix) else { return }
         guard contents.count > UniversalLinkHandler().urlPrefix.count else { return }
         guard let url = URL(string: contents) else { return }
-        var config = Config()
-        guard config.lastImportURLOnClipboard != url.absoluteString else { return }
-        config.lastImportURLOnClipboard = url.absoluteString
+        UIPasteboard.general.string = ""
         delegate?.importUniversalLink(url: url, for: self)
     }
 }

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -14,7 +14,6 @@ struct Config {
         static let dAppBrowser = "dAppBrowser"
         static let walletAddressesAlreadyPromptedForBackUp = "walletAddressesAlreadyPromptedForBackUp "
         static let locale = "locale"
-        static let lastImportURLOnClipboard = "lastImportURLOnClipboard"
     }
 
     let defaults: UserDefaults
@@ -129,11 +128,6 @@ struct Config {
 
     var ticketContractAddress: String? {
         return createDefaultTicketToken()?.contract.eip55String
-    }
-
-    var lastImportURLOnClipboard: String? {
-        get { return defaults.string(forKey: Keys.lastImportURLOnClipboard) }
-        set { defaults.set(newValue, forKey: Keys.lastImportURLOnClipboard) }
     }
 
     func createDefaultTicketToken() -> ERCToken? {


### PR DESCRIPTION
For #476 

Instead of remembering the last URL in clipboard and refusing to open it if it's unchanged, just clear the clipboard if we identify that it's a MagicLink and use it