### PR TITLE
WIP: Make Travis cache cocoapods gem again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ env:
   - LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 
 cache:
-    # - cocoapods
+  - cocoapods
   - bundler
 
 before_install:
-  - gem install cocoapods -v '1.5.3'
   - pod install --repo-update
   - brew update
   - brew install swiftlint || true


### PR DESCRIPTION
WIP: Our Travis config used to cache the cocoapods gem. That was disabled when we upgraded to cocoa pods 1.5.3.