### PR TITLE
After import via universal link, adding token might fail due to connectivity. Make sure auto detect at launch picks it up

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -572,7 +572,7 @@ extension InCoordinator: TokensCoordinatorDelegate {
 
     func addImported(contract: String) {
         let tokensCoordinator = coordinators.first { $0 is TokensCoordinator } as? TokensCoordinator
-        tokensCoordinator?.addToken(for: contract)
+        tokensCoordinator?.addImportedToken(for: contract)
     }
 }
 

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -139,10 +139,18 @@ class TokensCoordinator: Coordinator {
         }
     }
 
-    func addToken(for contract: String) {
+    //Adding a token may fail if we lose connectivity while fetching the contract details (e.g. name and balance). So we remove the contract from the hidden list (if it was there) so that the app has the chance to add it automatically upon auto detection at startup
+    func addImportedToken(for contract: String) {
+        delete(hiddenContract: contract)
         addToken(for: contract) {
             self.tokensViewController.fetch()
         }
+    }
+
+    private func delete(hiddenContract contract: String) {
+        guard let hiddenContract = storage.hiddenContracts.first(where: { $0.contract.sameContract(as: contract) }) else { return }
+        //TODO we need to make sure it's all uppercase?
+        storage.delete(hiddenContracts: [hiddenContract])
     }
 
     func newTokenViewController() -> NewTokenViewController {

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -322,6 +322,12 @@ class TokensDataStore {
         }
     }
 
+    func delete(hiddenContracts: [HiddenContract]) {
+        realm.beginWrite()
+        realm.delete(hiddenContracts)
+        try! realm.commitWrite()
+    }
+
     enum TokenUpdate {
         case value(BigInt)
         case isDisabled(Bool)


### PR DESCRIPTION
For #503 

After importing a token successfully, adding the token to the datastore may fail if we lose connectivity while fetching the contract details (e.g. name and balance). So we remove the contract from the hidden list (if it was there because the token was previously deleted) so that the app has the chance to add it automatically upon auto detection at startup