### PR TITLE
Rename references to the word 'keystore' when backing up or importing a wallet to make it easier to understand

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -67,7 +67,7 @@
 "wallet.create.button.title" = "Create Wallet";
 "wallet.create.inProgress" = "Creating wallet...";
 "wallet.import.button.title" = "Import Wallet";
-"wallets.backup.alertSheet.title" = "Backup Keystore";
+"wallets.backup.alertSheet.title" = "Backup Encrypted Wallet";
 "transactions.tabbar.item.title" = "My Transactions";
 "transaction.navigation.title" = "Transaction";
 "import.navigation.title" = "Import Wallet";
@@ -83,9 +83,9 @@
 "importWallet.import.button.title" = "Import";
 "importWallet.import.invalidAddress" = "Invalid Ethereum Address";
 "importWallet.import.invalidPrivateKey" = "Private Key has to be 64 characters long";
-"Keystore JSON" = "Keystore JSON";
+"Keystore JSON" = "Encrypted Wallet";
 "More Details" = "More Details";
-"Keystore" = "Keystore";
+"Keystore" = "From Backup";
 "Private Key" = "Private Key";
 "settings.currency.button.title" = "Currency";
 "settings.network.test.label.title" = "Test";


### PR DESCRIPTION
For #495 

This PR:

* when choosing to backup, change from "Backup Keystore" to "Backup Encrypted Wallet"
* when importing a wallet, change the tab title from "Keystore" to "From Backup" (along with "Private Key" and "Watch") and the label from "Keystore JSON" to "Encrypted Wallet"

Better?