### PR TITLE
Stalling when importing a wallet which has many transactions involving the same contract

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -32,7 +32,8 @@ class GetContractInteractions {
                         return ""
                     }
                     let nonEmptyContracts = contracts.filter { !$0.isEmpty }
-                    completion(nonEmptyContracts)
+                    let uniqueNonEmptyContracts = Array(Set(nonEmptyContracts))
+                    completion(uniqueNonEmptyContracts)
                 case .failure(let error):
                     print(error)
                     completion([])


### PR DESCRIPTION
For #521 Filter out duplicates when auto detecting list of contracts a wallet has interacted with