### PR TITLE
Fix: asset definition store was calling completion block with .cached even if XML has not been cached yet

### DIFF
--- a/AlphaWallet/AssetDefinition/AssetDefinitionStore.swift
+++ b/AlphaWallet/AssetDefinition/AssetDefinitionStore.swift
@@ -66,7 +66,7 @@ class AssetDefinitionStore {
     /// useCacheAndFetch: when true, the completionHandler will be called immediately and a second time if an updated XML is fetched. When false, the completionHandler will only be called up fetching an updated XML
     func fetchXML(forContract contract: String, useCacheAndFetch: Bool = false, completionHandler: ((Result) -> Void)? = nil) {
         let contract = contract.add0x.lowercased()
-        if useCacheAndFetch {
+        if useCacheAndFetch && self[contract] != nil {
             completionHandler?(.cached)
         }
         guard let url = urlToFetch(contract: contract) else { return }

--- a/AlphaWalletTests/AssetDefinition/AssetDefinitionStoreTests.swift
+++ b/AlphaWalletTests/AssetDefinition/AssetDefinitionStoreTests.swift
@@ -16,4 +16,44 @@ class AssetDefinitionStoreTests: XCTestCase {
         store["0x1"] = "xml1"
         XCTAssertEqual(store["0x1"], "xml1")
     }
+
+    func testShouldNotCallCompletionBlockWithCacheCaseIfNotAlreadyCached() {
+        let contractAddress = "0x1"
+        let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
+        let expectation = XCTestExpectation(description: "cached case should not be called")
+        expectation.isInverted = true
+        store.fetchXML(forContract: contractAddress, useCacheAndFetch: true) { [weak self] result in
+            guard let strongSelf = self else {
+                return
+            }
+            switch result {
+            case .cached:
+                expectation.fulfill()
+                break
+            case .updated, .unmodified, .error:
+                break
+            }
+        }
+        wait(for: [expectation], timeout: 0)
+    }
+
+    func testShouldCallCompletionBlockWithCacheCaseIfAlreadyCached() {
+        let contractAddress = "0x1"
+        let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
+        store[contractAddress] = "something"
+        let expectation = XCTestExpectation(description: "cached case should be called")
+        store.fetchXML(forContract: contractAddress, useCacheAndFetch: true) { [weak self] result in
+            guard let strongSelf = self else {
+                return
+            }
+            switch result {
+            case .cached:
+                expectation.fulfill()
+                break
+            case .updated, .unmodified, .error:
+                break
+            }
+        }
+        wait(for: [expectation], timeout: 0)
+    }
 }


### PR DESCRIPTION
Shouldn't affect current app, but future changes might rely on the correct behaviour