### PR TITLE
Update Localizable.strings

### DIFF
--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "a.wallet.contents.filter.assetsOnly.title" = "资产类";
 "a.wallet.contents.issuer.title" = "发行方";
 "a.wallet.next.button.title" = "下一步";
-"a.wallet.no.tokens" = "You don't have any tokens";
+"a.wallet.no.tokens" = "你没有这类Token";
 "a.help.navigation.title" = "帮助";
 "a.help.contact.footer.button.title" = "需要进一步帮助? 联系我们";
 "a.help.contact.email.subject" = "帮助/建议";


### PR DESCRIPTION
Please help translate "You don't have any tokens". Shown when user taps on a ERC 721/875 token in Wallet tab, but doesn't actually have any token (tickets, etc).

at: https://github.com/James-Sangalli/alpha-wallet-ios/blob/master/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings#L208

translated