### PR TITLE
Refactor: more type-safety for universal link handling, clearer paths for paid/free

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		5E7C797BE2C8DB7EF6F217B3 /* OnboardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7103135DCCCAB96EE5FC /* OnboardingPage.swift */; };
 		5E7C798E5F5EE00D405B91AE /* TicketRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7ACB94CEE493AC37487F /* TicketRowView.swift */; };
 		5E7C79D78AA5E774119BE49B /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CFDE7DEA8C06C4100AF /* TextField.swift */; };
+		5E7C79DE8864702C51C0A7CC /* ResultResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79FE0C70AC4198F2AEB7 /* ResultResult.swift */; };
 		5E7C79F30A324D75DF42DDDE /* SellTicketsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7EB14E787BC019660389 /* SellTicketsViewModel.swift */; };
 		5E7C7A242DDFB1F1C77DCBBF /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7393B08745287A266000 /* StringExtensionTests.swift */; };
 		5E7C7A4384A8E3F22D3F8249 /* SetSellTicketsExpiryDateViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C700CD3E43689E88FBE9B /* SetSellTicketsExpiryDateViewControllerViewModel.swift */; };
@@ -897,6 +898,7 @@
 		5E7C79E3BC4CACB123840A42 /* LocaleViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleViewCell.swift; sourceTree = "<group>"; };
 		5E7C79ED9F842D3FC102AC54 /* TokenViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenViewCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C79EF9D2C12F396364B92 /* AssetDefinitionDiskBackingStoreWithOverridesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionDiskBackingStoreWithOverridesTests.swift; sourceTree = "<group>"; };
+		5E7C79FE0C70AC4198F2AEB7 /* ResultResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultResult.swift; sourceTree = "<group>"; };
 		5E7C7A16ABC8BD5D508AA641 /* ImportWalletHelpBubbleViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportWalletHelpBubbleViewViewModel.swift; sourceTree = "<group>"; };
 		5E7C7A65F6033318F7C8AEB0 /* DateEntryField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateEntryField.swift; sourceTree = "<group>"; };
 		5E7C7AB3440C01136DF4F3E9 /* LockCreatePasscodeCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockCreatePasscodeCoordinator.swift; sourceTree = "<group>"; };
@@ -2399,6 +2401,7 @@
 			children = (
 				5E7C76AF81B8DFF605558499 /* UniversalLinkCoordinator.swift */,
 				5E7C7F3DD81D44A996789FC4 /* UniversalLinkInPasteboardCoordinator.swift */,
+				5E7C79FE0C70AC4198F2AEB7 /* ResultResult.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -3684,6 +3687,7 @@
 				76F1D7F08263A663C3A67926 /* GetIsERC721ContractCoordinator.swift in Sources */,
 				76F1DF0A4667F618D2BAE78C /* GetIsERC721Encode.swift in Sources */,
 				76F1D439D545AA9B7E686DCC /* ContractERC721Transfer.swift in Sources */,
+				5E7C79DE8864702C51C0A7CC /* ResultResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -75,9 +75,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     @discardableResult private func handleUniversalLink(url: URL) -> Bool {
         appCoordinator.createInitialWallet()
         appCoordinator.closeWelcomeWindow()
-        universalLinkCoordinator = UniversalLinkCoordinator(config: Config())
-        universalLinkCoordinator.ethPrice = appCoordinator.ethPrice
-        universalLinkCoordinator.ethBalance = appCoordinator.ethBalance
+        guard let ethPrice = appCoordinator.ethPrice, let ethBalance = appCoordinator.ethBalance else { return false }
+
+        universalLinkCoordinator = UniversalLinkCoordinator(config: Config(), ethPrice: ethPrice, ethBalance: ethBalance)
         universalLinkCoordinator.delegate = self
         universalLinkCoordinator.start()
         let handled = universalLinkCoordinator.handleUniversalLink(url: url)

--- a/AlphaWallet/Market/Coordinators/ResultResult.swift
+++ b/AlphaWallet/Market/Coordinators/ResultResult.swift
@@ -1,0 +1,9 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import Result
+
+/// This is a workaround to workaround a Swift bug so we can use Result.Result in a .swift file when Alamofire is also used in that file
+struct ResultResult<T, Error : Swift.Error> {
+    typealias t = Result<T, Error>
+}

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -15,26 +15,37 @@ protocol UniversalLinkCoordinatorDelegate: class {
 }
 
 class UniversalLinkCoordinator: Coordinator {
+    private enum TransactionType {
+        case freeTransfer(query: String, parameters: Parameters)
+        case paid(signedOrder: SignedOrder, tokenObject: TokenObject)
+    }
+
 	var coordinators: [Coordinator] = []
-    let config: Config
+    private let config: Config
 	weak var delegate: UniversalLinkCoordinatorDelegate?
-	var importTicketViewController: ImportTicketViewController?
-    var ethPrice: Subscribable<Double>?
-    var ethBalance: Subscribable<BigInt>?
-    var hasCompleted = false
-    var addressOfNewWallet: String?
+	private var importTicketViewController: ImportTicketViewController?
+    private let ethPrice: Subscribable<Double>
+    private let ethBalance: Subscribable<BigInt>
+    private var hasCompleted = false
+    private var addressOfNewWallet: String?
     private var getERC875TokenBalanceCoordinator: GetERC875BalanceCoordinator?
     //TODO better to make sure ticketHolder is non-optional. But be careful that ImportTicketViewController also handles when viewModel always has a TicketHolder. Needs good defaults in TicketHolder that can be displayed
-    var ticketHolder: TokenHolder?
+    private var ticketHolder: TokenHolder?
+    private var transactionType: TransactionType?
+    private var isShowingImportUserInterface: Bool {
+        return delegate?.viewControllerForPresenting(in: self) != nil
+    }
 
-    init(config: Config) {
+    init(config: Config, ethPrice: Subscribable<Double>, ethBalance: Subscribable<BigInt>) {
         self.config = config
+        self.ethPrice = ethPrice
+        self.ethBalance = ethBalance
     }
 
 	func start() {
 	}
     
-    func createHTTPParametersForPaymentServer(signedOrder: SignedOrder, isForTransfer: Bool) -> Parameters {
+    private func createHTTPParametersForPaymentServer(signedOrder: SignedOrder, isForTransfer: Bool) -> Parameters {
         // form the json string out of the order for the paymaster server
         // James S. wrote
         let keystore = try! EtherKeystore()
@@ -61,61 +72,39 @@ class UniversalLinkCoordinator: Coordinator {
         return parameters
     }
 
-    func handlePaidUniversalLink(signedOrder: SignedOrder) -> Bool {
-        //TODO localize
-        //TODO improve. Not an obvious link between the variables used in the if-statement and the body
-        if delegate?.viewControllerForPresenting(in: self) != nil {
-            if let vc = importTicketViewController {
-                vc.signedOrder = signedOrder
-                //TODO: not always ERC875
-                vc.tokenObject = TokenObject(contract: signedOrder.order.contractAddress,
-                                                name: Constants.event,
-                                                symbol: "FIFA",
-                                                decimals: 0,
-                                                value: signedOrder.order.price.description,
-                                                isCustom: true,
-                                                isDisabled: false,
-                                                type: .erc875
-                )
-            }
-            if let price = ethPrice {
-                let ethCost = self.convert(ethCost: signedOrder.order.price)
-                self.promptImportUniversalLink(ethCost: ethCost.description)
-                price.subscribe { [weak self] value in
-                    if let price = price.value {
-                        if let celf = self {
-                            let (ethCost, dollarCost) = celf.convert(ethCost: signedOrder.order.price, rate: price)
-                            celf.promptImportUniversalLink(
-                                    ethCost: ethCost.description,
-                                    dollarCost: dollarCost.description
-                            )
-                        }
-                    }
-                }
-            } else {
-                //No wallet and should be handled by client code, but we'll just be careful
-                //TODO pass in error message
-                showImportError(errorMessage: R.string.localizable.aClaimTicketFailedTitle())
-            }
+    @discardableResult private func handlePaidImportsImpl(signedOrder: SignedOrder) -> Bool {
+        guard isShowingImportUserInterface else { return false }
+
+        //TODO: not always ERC875
+        let tokenObject = TokenObject(contract: signedOrder.order.contractAddress,
+                name: Constants.event,
+                symbol: "FIFA",
+                decimals: 0,
+                value: signedOrder.order.price.description,
+                isCustom: true,
+                isDisabled: false,
+                type: .erc875
+        )
+        transactionType = .paid(signedOrder: signedOrder, tokenObject: tokenObject)
+
+        let ethCost = convert(ethCost: signedOrder.order.price)
+        promptImportUniversalLink(cost: .paid(eth: ethCost, dollar: nil))
+        ethPrice.subscribe { [weak self] value in
+            guard let celf = self else { return }
+            guard let price = celf.ethPrice.value else { return }
+            let (ethCost, dollarCost) = celf.convert(ethCost: signedOrder.order.price, rate: price)
+            celf.promptImportUniversalLink(cost: .paid(eth: ethCost, dollar: dollarCost))
         }
         return true
     }
 
-    func usePaymentServerForFreeTransferLinks(signedOrder: SignedOrder) -> Bool {
+    @discardableResult private func usePaymentServerForFreeTransferLinks(signedOrder: SignedOrder) -> Bool {
+        guard isShowingImportUserInterface else { return false }
+
         let parameters = createHTTPParametersForPaymentServer(signedOrder: signedOrder, isForTransfer: true)
         let query = Constants.paymentServer
-        //TODO improve. Not an obvious link between the variables used in the if-statement and the body
-        if delegate?.viewControllerForPresenting(in: self) != nil {
-            if let vc = importTicketViewController {
-                vc.query = query
-                vc.parameters = parameters
-            }
-            //nil or "" implies free, if using payment server it is always free
-            self.promptImportUniversalLink(
-                    ethCost: "",
-                    dollarCost: ""
-            )
-        }
+        transactionType = .freeTransfer(query: query, parameters: parameters)
+        promptImportUniversalLink(cost: .free)
         return true
     }
 
@@ -125,33 +114,21 @@ class UniversalLinkCoordinator: Coordinator {
         let matchedPrefix = url.description.hasPrefix(prefix)
         preparingToImportUniversalLink()
         guard matchedPrefix, url.absoluteString.count > prefix.count else {
-            self.showImportError(errorMessage: R.string.localizable.aClaimTicketInvalidLinkTryAgain())
+            showImportError(errorMessage: R.string.localizable.aClaimTicketInvalidLinkTryAgain())
             return false
         }
         guard let signedOrder = UniversalLinkHandler().parseUniversalLink(url: url.absoluteString) else {
-            self.showImportError(errorMessage: R.string.localizable.aClaimTicketInvalidLinkTryAgain())
+            showImportError(errorMessage: R.string.localizable.aClaimTicketInvalidLinkTryAgain())
             return false
         }
         let isVerified = XMLHandler(contract: signedOrder.order.contractAddress).isVerified(for: config.server)
         let isStormBirdContract = isVerified
         importTicketViewController?.url = url
         importTicketViewController?.contract = signedOrder.order.contractAddress
-        //need to hash message here because the web3swift implementation adds prefix
-        let messageHash = Data(bytes: signedOrder.message).sha3(.keccak256)
-        //note: web3swift takes the v value as v - 27, so we need to manually convert this
-        let vValue = signedOrder.signature.drop0x.substring(from: 128)
-        let vInt = Int(vValue, radix: 16)! - 27
-        let vString = "0" + String(vInt)
-        let signature = "0x" + signedOrder.signature.drop0x.substring(to: 128) + vString
-        let nodeURL = Config().rpcURL
-        let recoveredSigner = web3(provider: Web3HttpProvider(nodeURL, network: config.server.web3Network)!).personal.ecrecover(
-            hash: messageHash,
-            signature: Data(bytes: signature.hexa2Bytes)
-        )
+        let recoveredSigner = ecrecover(signedOrder: signedOrder)
         switch recoveredSigner {
         case .success(let ethereumAddress):
             //TODO extract method for the whole .success? Quite long
-            //TODO return false?
             guard let recoverAddress = Address(string: ethereumAddress.address) else { return false }
             let contractAsAddress = Address(string: signedOrder.order.contractAddress)!
             //gather signer address balance
@@ -166,6 +143,7 @@ class UniversalLinkCoordinator: Coordinator {
                 )
                 if filteredTokens.isEmpty {
                     self.showImportError(errorMessage: R.string.localizable.aClaimTicketInvalidLinkTryAgain())
+                    return
                 }
 
                 self.makeTicketHolder(
@@ -177,44 +155,57 @@ class UniversalLinkCoordinator: Coordinator {
                 if signedOrder.order.price > 0 || !isStormBirdContract {
                     self.handlePaidImports(signedOrder: signedOrder)
                 } else {
-                    //free transfer
-                    let _ = self.usePaymentServerForFreeTransferLinks(signedOrder: signedOrder)
+                    self.usePaymentServerForFreeTransferLinks(signedOrder: signedOrder)
                 }
             }
         case .failure(let error):
             //TODO handle. Show error maybe?
             NSLog("xxx error during ecrecover: \(error.localizedDescription)")
-            //TODO return true or false?
             return false
         }
         return true
     }
+
+    private func ecrecover(signedOrder: SignedOrder) -> ResultResult<web3swift.EthereumAddress, web3swift.Web3Error>.t {
+        //need to hash message here because the web3swift implementation adds prefix
+        let messageHash = Data(bytes: signedOrder.message).sha3(.keccak256)
+        //note: web3swift takes the v value as v - 27, so we need to manually convert this
+        let vValue = signedOrder.signature.drop0x.substring(from: 128)
+        let vInt = Int(vValue, radix: 16)! - 27
+        let vString = "0" + String(vInt)
+        let signature = "0x" + signedOrder.signature.drop0x.substring(to: 128) + vString
+        let nodeURL = config.rpcURL
+        return web3(provider: Web3HttpProvider(nodeURL, network: config.server.web3Network)!).personal.ecrecover(
+                hash: messageHash,
+                signature: Data(bytes: signature.hexa2Bytes)
+        )
+    }
     
     private func handlePaidImports(signedOrder: SignedOrder) {
-        if let balance = self.ethBalance {
-            balance.subscribeOnce { value in
-                if value > signedOrder.order.price {
-                    let _ = self.handlePaidUniversalLink(signedOrder: signedOrder)
-                } else {
-                    if let price = self.ethPrice {
-                        if price.value == nil {
-                            let ethCost = self.convert(ethCost: signedOrder.order.price)
-                            self.showImportError(
-                                errorMessage: R.string.localizable.aClaimTicketFailedNotEnoughEthTitle(),
-                                ethCost: ethCost.description
-                            )
-                        }
-                        price.subscribe { [weak self] value in
-                            if let celf = self {
-                                if let price = price.value {
-                                    let (ethCost, dollarCost) = celf.convert(ethCost: signedOrder.order.price, rate: price)
-                                    celf.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedNotEnoughEthTitle(), ethCost: ethCost.description, dollarCost: dollarCost.description)
-                                }
-                            }
-                        }
-                    }
-                }
+        ethBalance.subscribeOnce { [weak self] value in
+            guard let celf = self else { return }
+            if value > signedOrder.order.price {
+                celf.handlePaidImportsImpl(signedOrder: signedOrder)
+            } else {
+                celf.notEnoughEthForPaidImport(signedOrder: signedOrder)
             }
+        }
+    }
+
+    private func notEnoughEthForPaidImport(signedOrder: SignedOrder) {
+        if ethPrice.value == nil {
+            let ethCost = convert(ethCost: signedOrder.order.price)
+            showImportError(
+                errorMessage: R.string.localizable.aClaimTicketFailedNotEnoughEthTitle(),
+                cost: .paid(eth: ethCost, dollar: nil)
+            )
+        }
+        ethPrice.subscribe { [weak self] value in
+            guard let celf = self else { return }
+            guard let price = celf.ethPrice.value else { return }
+            let (ethCost, dollarCost) = celf.convert(ethCost: signedOrder.order.price, rate: price)
+            celf.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedNotEnoughEthTitle(),
+                    cost: .paid(eth: ethCost, dollar: dollarCost))
         }
     }
 
@@ -222,7 +213,7 @@ class UniversalLinkCoordinator: Coordinator {
         return indices.map(String.init).joined(separator: ",")
     }
     
-    func checkERC875TokensAreAvailable(indices: [UInt16], balance: [String]) -> [String] {
+    private func checkERC875TokensAreAvailable(indices: [UInt16], balance: [String]) -> [String] {
         var filteredTokens = [String]()
         if balance.count < indices.count {
             return [String]()
@@ -265,7 +256,7 @@ class UniversalLinkCoordinator: Coordinator {
                 tickets.append(ticket)
             }
         }
-        self.ticketHolder = TokenHolder(
+        ticketHolder = TokenHolder(
                 tickets: tickets,
                 status: .available,
                 contractAddress: contractAddress
@@ -273,44 +264,38 @@ class UniversalLinkCoordinator: Coordinator {
     }
 
 	private func preparingToImportUniversalLink() {
-		if let viewController = delegate?.viewControllerForPresenting(in: self) {
-			importTicketViewController = ImportTicketViewController(config: config)
-			if let vc = importTicketViewController {
-				vc.delegate = self
-				vc.configure(viewModel: .init(state: .validating))
-				viewController.present(UINavigationController(rootViewController: vc), animated: true)
-			}
-		}
+		guard let viewController = delegate?.viewControllerForPresenting(in: self) else { return }
+        importTicketViewController = ImportTicketViewController(config: config)
+        guard let vc = importTicketViewController else { return }
+        vc.delegate = self
+        vc.configure(viewModel: .init(state: .validating))
+        viewController.present(UINavigationController(rootViewController: vc), animated: true)
 	}
 
     private func updateTicketFields() {
         guard let ticketHolder = ticketHolder else { return }
-        if let vc = importTicketViewController, var viewModel = vc.viewModel {
-            viewModel.ticketHolder = ticketHolder
-            vc.configure(viewModel: viewModel)
-        }
+        guard let vc = importTicketViewController, case .ready(var viewModel) = vc.state else { return }
+        viewModel.ticketHolder = ticketHolder
+        vc.configure(viewModel: viewModel)
     }
 
-	private func updateImportTicketController(with state: ImportTicketViewControllerViewModel.State, ethCost: String? = nil, dollarCost: String? = nil) {
+    private func updateImportTicketController(with state: ImportTicketViewControllerViewModel.State, cost: ImportTicketViewControllerViewModel.Cost? = nil) {
         guard !hasCompleted else { return }
-		if let vc = importTicketViewController, var viewModel = vc.viewModel {
-			viewModel.state = state
+        if let vc = importTicketViewController, case .ready(var viewModel) = vc.state {
+            viewModel.state = state
             if let ticketHolder = ticketHolder {
                 viewModel.ticketHolder = ticketHolder
             }
-            if let ethCost = ethCost {
-                viewModel.ethCost = ethCost
+            if let cost = cost {
+                viewModel.cost = cost
             }
-            if let dollarCost = dollarCost {
-                viewModel.dollarCost = dollarCost
-            }
-			vc.configure(viewModel: viewModel)
-		}
+            vc.configure(viewModel: viewModel)
+        }
         hasCompleted = state.hasCompleted
-	}
+    }
 
-	private func promptImportUniversalLink(ethCost: String, dollarCost: String? = nil) {
-		updateImportTicketController(with: .promptImport, ethCost: ethCost, dollarCost: dollarCost)
+	private func promptImportUniversalLink(cost: ImportTicketViewControllerViewModel.Cost) {
+		updateImportTicketController(with: .promptImport, cost: cost)
     }
 
 	private func showImportSuccessful() {
@@ -326,32 +311,27 @@ class UniversalLinkCoordinator: Coordinator {
 		coordinator.start()
 	}
 
-    private func showImportError(errorMessage: String, ethCost: String? = nil, dollarCost: String? = nil) {
-        updateImportTicketController(with: .failed(errorMessage: errorMessage), ethCost: ethCost, dollarCost: dollarCost)
+    private func showImportError(errorMessage: String, cost: ImportTicketViewControllerViewModel.Cost? = nil) {
+        updateImportTicketController(with: .failed(errorMessage: errorMessage), cost: cost)
 	}
-    
-    func importPaidSignedOrder(signedOrder: SignedOrder, tokenObject: TokenObject) {
+
+    private func importPaidSignedOrder(signedOrder: SignedOrder, tokenObject: TokenObject) {
         updateImportTicketController(with: .processing)
         delegate?.importPaidSignedOrder(signedOrder: signedOrder, tokenObject: tokenObject) { successful in
-            if self.importTicketViewController != nil {
-                if let vc = self.importTicketViewController, var _ = vc.viewModel {
-                    if successful {
-                        self.delegate?.didImported(contract: signedOrder.order.contractAddress, in: self)
-                        self.showImportSuccessful()
-                    } else {
-                        //TODO Pass in error message
-                        self.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedTitle())
-                    }
-                }
+            guard let vc = self.importTicketViewController, case .ready = vc.state else { return }
+            if successful {
+                self.delegate?.didImported(contract: signedOrder.order.contractAddress, in: self)
+                self.showImportSuccessful()
+            } else {
+                //TODO Pass in error message
+                self.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedTitle())
             }
         }
-        
     }
 
-    //handling free transfers, sell links cannot be handled here
-	private func importUniversalLink(query: String, parameters: Parameters) {
+	private func importFreeTransfer(query: String, parameters: Parameters) {
 		updateImportTicketController(with: .processing)
-        
+
         Alamofire.request(
                 query,
                 method: .post,
@@ -368,16 +348,14 @@ class UniversalLinkCoordinator: Coordinator {
                 }
             }
 
-            //TODO improve. Not an obvious link between the variables used in the if-statement and the body
-            if let vc = self.importTicketViewController, vc.viewModel != nil {
-                // TODO handle http response
-                print(result)
-                if successful {
-                    self.showImportSuccessful()
-                } else {
-                    //TODO Pass in error message
-                    self.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedTitle())
-                }
+            guard let vc = self.importTicketViewController, case .ready(var viewModel) = vc.state else { return }
+            // TODO handle http response
+            print(result)
+            if successful {
+                self.showImportSuccessful()
+            } else {
+                //TODO Pass in error message
+                self.showImportError(errorMessage: R.string.localizable.aClaimTicketFailedTitle())
             }
         }
     }
@@ -403,16 +381,12 @@ extension UniversalLinkCoordinator: ImportTicketViewControllerDelegate {
 	}
 
 	func didPressImport(in viewController: ImportTicketViewController) {
-        if let signedOrder = viewController.signedOrder {
-            self.delegate?.didImported(contract: signedOrder.order.contractAddress, in: self)
-        }
-
-        if let query = viewController.query, let parameters = viewController.parameters {
-            importUniversalLink(query: query, parameters: parameters)
-        } else {
-            if let signedOrder = viewController.signedOrder, let tokenObj = viewController.tokenObject {
-                importPaidSignedOrder(signedOrder: signedOrder, tokenObject: tokenObj)
-            }
+        guard let transactionType = transactionType else { return }
+        switch transactionType {
+        case .freeTransfer(let query, let parameters):
+            importFreeTransfer(query: query, parameters: parameters)
+        case .paid(let signedOrder, let tokenObject):
+            importPaidSignedOrder(signedOrder: signedOrder, tokenObject: tokenObject)
         }
 	}
 }

--- a/AlphaWallet/Market/ViewControllers/ImportTicketViewController.swift
+++ b/AlphaWallet/Market/ViewControllers/ImportTicketViewController.swift
@@ -10,6 +10,11 @@ protocol ImportTicketViewControllerDelegate: class {
 
 //class ImportTicketViewController: UIViewController, VerifiableStatusViewController {
 class ImportTicketViewController: UIViewController, OptionalTicketVerifiableStatusViewController {
+    enum State {
+        case ready(ImportTicketViewControllerViewModel)
+        case notReady
+    }
+
     let config: Config
     weak var delegate: ImportTicketViewControllerDelegate?
     let roundedBackground = RoundedBackground()
@@ -25,11 +30,7 @@ class ImportTicketViewController: UIViewController, OptionalTicketVerifiableStat
     let buttonSeparator = UIView()
     let actionButton = UIButton(type: .system)
     let cancelButton = UIButton(type: .system)
-    var viewModel: ImportTicketViewControllerViewModel?
-    var query: String?
-    var parameters: Parameters?
-    var signedOrder: SignedOrder?
-    var tokenObject: TokenObject?
+    private var viewModel: ImportTicketViewControllerViewModel?
     var contract: String? {
         didSet {
             guard url != nil else { return }
@@ -39,6 +40,13 @@ class ImportTicketViewController: UIViewController, OptionalTicketVerifiableStat
     var url: URL? {
         didSet {
             updateNavigationRightBarButtons(isVerified: true, hasShowInfoButton: false)
+        }
+    }
+    var state: State {
+        if let viewModel = viewModel {
+            return .ready(viewModel)
+        } else {
+            return .notReady
         }
     }
 

--- a/AlphaWallet/Market/ViewModels/ImportTicketViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportTicketViewControllerViewModel.swift
@@ -19,10 +19,14 @@ struct ImportTicketViewControllerViewModel {
             }
         }
     }
+    enum Cost {
+        case free
+        case paid(eth: Decimal, dollar: Decimal?)
+    }
+
     var state: State
     var ticketHolder: TokenHolder?
-    var ethCost: String?
-    var dollarCost: String?
+    var cost: Cost?
 
     var backgroundColor: UIColor {
         return Colors.appBackground
@@ -177,10 +181,11 @@ struct ImportTicketViewControllerViewModel {
     }
 
     var ethCostLabelText: String {
-        guard let ethCost = ethCost else { return R.string.localizable.aClaimTicketEthCostFreeTitle() }
-        if ethCost.isEmpty {
+        guard let cost = cost else { return R.string.localizable.aClaimTicketEthCostFreeTitle() }
+        switch cost {
+        case .free:
             return R.string.localizable.aClaimTicketEthCostFreeTitle()
-        } else {
+        case .paid(let ethCost, _):
             return "\(ethCost) ETH"
         }
     }
@@ -206,10 +211,11 @@ struct ImportTicketViewControllerViewModel {
     }
 
     var dollarCostLabelText: String {
-        guard let dollarCost = dollarCost else { return "" }
-        if dollarCost.isEmpty {
+        guard let cost = cost else { return "" }
+        switch cost {
+        case .free:
             return ""
-        } else {
+        case .paid(_, let dollarCost):
             return "$\(dollarCost)"
         }
     }
@@ -276,16 +282,23 @@ struct ImportTicketViewControllerViewModel {
     }
 
     var transactionIsFree: Bool {
-        guard let ethCost = ethCost else { return true }
-        return ethCost.isEmpty
+        guard let cost = cost else { return true }
+        switch cost {
+        case .free:
+            return true
+        case .paid:
+            return false
+        }
     }
 
     var hideDollarCost: Bool {
-        if transactionIsFree {
+        guard let cost = cost else { return true }
+        switch cost {
+        case .free:
             return true
+        case .paid:
+            return false
         }
-        guard let dollarCost = dollarCost else { return true }
-        return dollarCost.trimmed.isEmpty
     }
 
     init(state: State) {


### PR DESCRIPTION
* Codify free transfers and paid links types into enums
* Codify state of import ticket view controller into an enum
* Reduce impossible states by making ethCost and ethBalance subscribables non-optional