### PR TITLE
remove gas related Constants and use max for gas limit

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -589,7 +589,6 @@ extension InCoordinator: TokensCoordinatorDelegate {
     // transfer from a buddy), the user can send the data to a paymaster.
     // This function deal with the special case that the token price = 0
     // but not sent to the paymaster because the user has ether.
-
     func importPaidSignedOrder(signedOrder: SignedOrder, tokenObject: TokenObject, completion: @escaping (Bool) -> Void) {
         let web3 = self.web3()
         web3.start()
@@ -613,9 +612,9 @@ extension InCoordinator: TokensCoordinatorDelegate {
                         value: BigInt(signedOrder.order.price),
                         to: address,
                         data: Data(bytes: payload.hexa2Bytes),
-                        gasLimit: Constants.gasLimit,
+                        gasLimit: GasLimitConfiguration.max,
                         tokenId: .none,
-                        gasPrice: Constants.gasPriceDefaultERC875,
+                        gasPrice: GasLimitConfiguration.default,
                         nonce: .none,
                         v: v,
                         r: r,
@@ -670,7 +669,7 @@ extension InCoordinator: TokensCoordinatorDelegate {
                         to: signTransaction.to,
                         nonce: signTransaction.nonce,
                         data: signTransaction.data,
-                        gasPrice: Constants.gasPriceDefaultERC875,
+                        gasPrice: GasPriceConfiguration.default,
                         gasLimit: signTransaction.gasLimit,
                         chainID: strongSelf.config.chainID
                 )

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -8,8 +8,6 @@ public struct Constants {
     public static let shapeShiftPublicKey = "c4097b033e02163da6114fbbc1bf15155e759ddfd8352c88c55e7fef162e901a800e7eaecf836062a0c075b2b881054e0b9aa2324be7bc3694578493faf59af4"
     public static let changellyRefferalID = "968d4f0f0bf9"
     public static let keychainKeyPrefix = "alphawallet"
-    public static let gasLimit = BigInt(300000)
-    public static let gasPriceDefaultERC875 = BigInt("22000000000")!
     
     //link formats
     public static let oldFormat: UInt8 = 0x00

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -52,7 +52,7 @@ class TransactionConfigurator {
 
         self.configuration = TransactionConfiguration(
             gasPrice: min(max(transaction.gasPrice ?? GasPriceConfiguration.default, GasPriceConfiguration.min), GasPriceConfiguration.max),
-            gasLimit: transaction.gasLimit ?? GasLimitConfiguration.default,
+            gasLimit: transaction.gasLimit ?? GasLimitConfiguration.max,
             data: transaction.data ?? Data()
         )
     }
@@ -106,7 +106,7 @@ class TransactionConfigurator {
             estimateGasLimit()
             configuration = TransactionConfiguration(
                     gasPrice: calculatedGasPrice,
-                    gasLimit: GasLimitConfiguration.default,
+                    gasLimit: GasLimitConfiguration.max,
                     data: transaction.data ?? configuration.data
             )
             completion(.success(()))
@@ -117,7 +117,7 @@ class TransactionConfigurator {
                     let data = Data(hex: res.drop0x)
                     self.configuration = TransactionConfiguration(
                             gasPrice: self.calculatedGasPrice,
-                            gasLimit: Constants.gasLimit,
+                            gasLimit: GasLimitConfiguration.max,
                             data: data
                     )
                     completion(.success(()))
@@ -133,7 +133,7 @@ class TransactionConfigurator {
                     let data = Data(hex: res.drop0x)
                     self.configuration = TransactionConfiguration(
                             gasPrice: self.calculatedGasPrice,
-                            gasLimit: Constants.gasLimit,
+                            gasLimit: GasLimitConfiguration.max,
                             data: data
                     )
                     completion(.success(()))
@@ -150,7 +150,7 @@ class TransactionConfigurator {
                     let data = Data(hex: res.drop0x)
                     self.configuration = TransactionConfiguration(
                             gasPrice: self.calculatedGasPrice,
-                            gasLimit: Constants.gasLimit,
+                            gasLimit: GasLimitConfiguration.max,
                             data: data
                     )
                     completion(.success(()))
@@ -167,7 +167,7 @@ class TransactionConfigurator {
                     let data = Data(hex: res.drop0x)
                     self.configuration = TransactionConfiguration(
                             gasPrice: self.calculatedGasPrice,
-                            gasLimit: Constants.gasLimit,
+                            gasLimit: GasLimitConfiguration.max,
                             data: data
                     )
                     completion(.success(()))


### PR DESCRIPTION
for #768

Gas is already being estimated but might fail sometimes when the gas price exceeds the limit of default. Removed the default and used the max for gas limit, also removed the Constants that were duplicate. 

