### PR TITLE
Modify fetching transactions to work better with Etherscan API

### DIFF
--- a/AlphaWallet/EtherClient/TrustClient/TrustClient.swift
+++ b/AlphaWallet/EtherClient/TrustClient/TrustClient.swift
@@ -5,11 +5,16 @@ import Moya
 
 enum TrustService {
     case prices
-    case getTransactions(address: String, startBlock: Int, endBlock: Int)
+    case getTransactions(address: String, startBlock: Int, endBlock: Int, sortOrder: SortOrder)
     case getTransaction(ID: String)
     case register(device: PushDevice)
     case unregister(device: PushDevice)
     case marketplace(chainID: Int)
+
+    enum SortOrder: String {
+        case asc
+        case desc
+    }
 }
 
 extension TrustService: TargetType {
@@ -55,13 +60,14 @@ extension TrustService: TargetType {
 
     var task: Task {
         switch self {
-        case .getTransactions(let address, let startBlock, let endBlock):
+        case .getTransactions(let address, let startBlock, let endBlock, let sortOrder):
             return .requestParameters(parameters: [
                 "module": "account",
                 "action": "txlist",
                 "address": address,
                 "startblock": startBlock,
                 "endblock": endBlock,
+                "sort": sortOrder.rawValue,
             ], encoding: URLEncoding())
         case .getTransaction:
             return .requestPlain


### PR DESCRIPTION
For #752 

This PR makes fetching transactions less likely to block the entire app:

* Start with only fetching the newest "page" of transactions (and not both old and new transactions) if there are no transactions cached. This could be a new account or a freshly imported account (with potentially many transactions)
* Make sure we don't fetch the newest "page" of transactions multiple times because fetching a large page (10,0000 transactions. Especially common if a newly imported wallet with a long transaction history). This happened when the next scheduled refresh happens before the results from the previous fetch was returned
* Limit the number of transactions checked to send pushes for notifying ether has been received. And only look at transactions in the last 24 hours. Trying to comb through too many transactions kills performance. Trying to send too many notifications at one go will make iOS kill the app