### PR TITLE
Fix: Should not show ERC721 tokens from OpenSea when on testnets

### DIFF
--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -30,6 +30,16 @@ class OpenSea {
 
     ///Uses a promise to make sure we don't fetch from OpenSea multiple times concurrently
     func makeFetchPromise(owner: String) -> PromiseResult {
+        switch Config().server {
+        case .main:
+            break
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .custom(_):
+            fetch = Promise { seal in
+                seal.fulfill(.success([:]))
+            }
+            return fetch
+        }
+
         trimCachedPromises()
         if let cachedPromise = cachedPromise(forOwner: owner) {
             return cachedPromise


### PR DESCRIPTION
For #819 