### PR TITLE
Indicate in the Ether received notification if testnet

### DIFF
--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -237,7 +237,12 @@ class TransactionDataCoordinator {
     private func notifyUserEtherReceived(for transactionId: String, amount: String) {
         let notificationCenter = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
-        content.body = R.string.localizable.transactionsReceivedEther(amount)
+        switch Trust.Config().server {
+        case .main:
+            content.body = R.string.localizable.transactionsReceivedEther(amount)
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .custom:
+            content.body = R.string.localizable.transactionsReceivedEther("\(amount) (\(Trust.Config().server.name))")
+        }
         content.sound = .default()
         let identifier = Constants.etherReceivedNotificationIdentifier
         let request = UNNotificationRequest(identifier: "\(identifier):\(transactionId)", content: content, trigger: nil)


### PR DESCRIPTION
For #822 "it should tell the differences between different network, Ropsten, Mainnet etc."

<img width="457" alt="screen shot 2018-10-22 at 12 36 06 pm" src="https://user-images.githubusercontent.com/56189/47277938-87fddd80-d5f7-11e8-8463-10e8250c51d0.png">