### PR TITLE
Make Realm migration blocks more consistent. Just if(s) and no switch

### DIFF
--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -22,10 +22,8 @@ class MigrationInitializer: Initializer {
     func perform() {
         config.schemaVersion = 49
         config.migrationBlock = { migration, oldSchemaVersion in
-            switch oldSchemaVersion {
-            case 0...32:
+            if oldSchemaVersion < 33 {
                 migration.enumerateObjects(ofType: TokenObject.className()) { oldObject, newObject in
-
                     guard let oldObject = oldObject else { return }
                     guard let newObject = newObject else { return }
                     guard let value = oldObject["contract"] as? String else { return }
@@ -33,7 +31,6 @@ class MigrationInitializer: Initializer {
 
                     newObject["contract"] = address.description
                 }
-            default: break
             }
             if oldSchemaVersion < 44 {
                 migration.enumerateObjects(ofType: TokenObject.className()) { oldObject, newObject in


### PR DESCRIPTION
A little misleading that there's a switch because we really want something like the following, and if `old` is 9 to run through all 3 blocks, with no early returns:

    if old < 10 {
    }
    if old < 20 {
    }
    if old < 30 {
    }