### PR TITLE
Format HTML markup in OpenSea token ID description

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/OpenSeaNonFungibleTokenCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/OpenSeaNonFungibleTokenCardRowViewModel.swift
@@ -184,8 +184,11 @@ struct OpenSeaNonFungibleTokenCardRowViewModel {
         return value
     }
 
-    var description: String {
-        return tokenHolder.values["description"] as? String ?? ""
+    var description: NSAttributedString {
+        let string = tokenHolder.values["description"] as? String ?? ""
+        let htmlData = string.data(using: .utf8)
+        let options = [NSAttributedString.DocumentReadingOptionKey.documentType: NSAttributedString.DocumentType.html]
+        return (try? NSMutableAttributedString(data: htmlData ?? Data(), options: options, documentAttributes: nil)) ?? NSAttributedString(string: string)
     }
 
     var thumbnailImageUrl: URL? {

--- a/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
@@ -399,7 +399,7 @@ class OpenSeaNonFungibleTokenCardRowView: UIView {
             each.constant = -bleedForBigImage
         }
 
-        descriptionLabel.text = viewModel.description
+        descriptionLabel.attributedText = viewModel.description
 
         titleLabel.text = viewModel.title
 


### PR DESCRIPTION
Some token IDs have a description like:

    "Control Atlantean: <strong>deadly</strong>"