### PR TITLE
Fix: deleting a wallet should clear the flag that indicates older transactions has been downloaded

### DIFF
--- a/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
@@ -130,6 +130,7 @@ extension SettingsCoordinator: AccountsCoordinatorDelegate {
 
 	func didDeleteAccount(account: Wallet, in coordinator: AccountsCoordinator) {
 		storage.deleteAll()
+		TransactionsTracker(sessionID: session.sessionID).fetchingState = .initial
 		delegate?.didUpdateAccounts(in: self)
 		guard !coordinator.accountsViewController.hasWallets else { return }
 		coordinator.navigationController.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
When a wallet is created/imported, transactions are downloaded in 2 "directions":

1. The most recent transactions are download first and stored in the database. This is repeated to get new transactions by getting newer transactions than the newest in the database.
2. Then older transactions are fetched by fetching transactions that are older than the oldest in the database. This is repeated until we don't get any more transactions, and we'll set a flag in `UserDefaults` to indicate all old transactions has been fetched for this wallet.

The flag in (2) isn't cleared when a wallet is deleted. So deleting a wallet that has downloaded all transactions and importing it again will not download old transactions.

This PR fixes this by clearing the flag when the wallet is deleted.