### PR TITLE
Fix: Storing ERC20 tokens in database should always store address in EIP55

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -140,16 +140,18 @@ class TokensCoordinator: Coordinator {
                     completion()
                 }
             case .fungibleTokenComplete(let name, let symbol, let decimals):
-                let token = TokenObject(
-                        contract: contract,
-                        name: name,
-                        symbol: symbol,
-                        decimals: Int(decimals),
-                        value: "0",
-                        type: .erc20
-                )
-                strongSelf.storage.add(tokens: [token])
-                completion()
+                if let address = Address(string: contract) {
+                    let token = TokenObject(
+                            contract: address.eip55String,
+                            name: name,
+                            symbol: symbol,
+                            decimals: Int(decimals),
+                            value: "0",
+                            type: .erc20
+                    )
+                    strongSelf.storage.add(tokens: [token])
+                    completion()
+                }
             case .delegateTokenComplete:
                 strongSelf.storage.add(delegateContracts: [DelegateContract(contract: contract)])
                 completion()


### PR DESCRIPTION
By not storing contract addresses in a consistent format, we might accidentally add the same token twice in the database.

This PR makes storing of ERC20 tokens addresses in the database in the format defined by EIP55.