### PR TITLE
Prettify sign message confirmation

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		5E7C71D1D16FE09032EB4B7E /* TokenObjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C702A684DF27DC8ED4E42 /* TokenObjectTest.swift */; };
 		5E7C71D40F530871D95170C6 /* BookmarkViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E7C72CEFD7E32ACE303AB1F /* BookmarkViewCell.xib */; };
 		5E7C71DAA5DAFF764F92587D /* SetTransferTokensCardExpiryDateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C727433F7B8E322B3C68A /* SetTransferTokensCardExpiryDateViewController.swift */; };
+		5E7C71DBB4AD309920C45556 /* ConfirmSignMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78421F01D14741DDF5BF /* ConfirmSignMessageViewController.swift */; };
 		5E7C71DC13B2040F5408BF3C /* ImportMagicTokenCardRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */; };
 		5E7C71F8050CCF990539B293 /* LockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79D674D45A07E694CE31 /* LockView.swift */; };
 		5E7C7208A83399C27AE57E44 /* ImportWalletHelpBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C70CC85B337061151724E /* ImportWalletHelpBubbleView.swift */; };
@@ -308,6 +309,7 @@
 		5E7C74B99922D0CAB635970E /* PasscodeCharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B9220E616F82EDA956F /* PasscodeCharacterView.swift */; };
 		5E7C74BD08801CABF9695853 /* LocaleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79778E4BFE1322711EA6 /* LocaleViewModel.swift */; };
 		5E7C74C1C2AB84F9AFAC630E /* TokenCardRowViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C12E88EB0B73AA1E562 /* TokenCardRowViewModelProtocol.swift */; };
+		5E7C74C6110D4E93C759D5DB /* ConfirmSignMessageTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B080E387A79058430B9 /* ConfirmSignMessageTableViewCellViewModel.swift */; };
 		5E7C74DBAE43954C185057B3 /* ChooseTokenCardTransferModeViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BA578BE5FB0E613A6D6 /* ChooseTokenCardTransferModeViewControllerViewModel.swift */; };
 		5E7C74E7DC2D79785240D757 /* GetERC875Balance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7251DB61EB9468910C81 /* GetERC875Balance.swift */; };
 		5E7C75450126F3BAA726EC50 /* web3.min.js in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F7C7E37B5CD147EF784 /* web3.min.js */; };
@@ -344,10 +346,10 @@
 		5E7C76E816E216D5C69D3D7B /* AssetDefinitionBackingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C963C42DE81F82732E5 /* AssetDefinitionBackingStore.swift */; };
 		5E7C76F8CB67466725C590CE /* TokenViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79ED9F842D3FC102AC54 /* TokenViewCellViewModel.swift */; };
 		5E7C7705B09D780E84E2FDA5 /* XMLHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C702300BB7DB0FD7788EF /* XMLHandlerTest.swift */; };
+		5E7C772EC476993A170C840B /* GenerateSellMagicLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7892A9FC3F53B13498D9 /* GenerateSellMagicLinkViewController.swift */; };
 		5E7C773E3E3BBEB65C51DF2A /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7D2C43C15D0762C7F374 /* UIStackView.swift */; };
 		5E7C774B5332AC0DC19C5B1B /* EthTokenViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74B82783A94091A43470 /* EthTokenViewCellViewModel.swift */; };
 		5E7C776BE1B19F824954962D /* BaseTokenCardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F5C10E3895E805EA7E0 /* BaseTokenCardTableViewCell.swift */; };
-		5E7C776CF721EBBD43195926 /* GenerateSellMagicLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79CF6150E4CD4A276FC0 /* GenerateSellMagicLinkViewController.swift */; };
 		5E7C777A50A02B7EC9DBEB0A /* FetchAssetDefinitionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C736169A5251141791726 /* FetchAssetDefinitionsCoordinator.swift */; };
 		5E7C7788984F7ADCFE5B4DE0 /* AddressTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75B5AF76279A71395FC7 /* AddressTextField.swift */; };
 		5E7C7788FA549A0402BB33CB /* HiddenContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C01F8C42D7A43792C26 /* HiddenContract.swift */; };
@@ -378,11 +380,13 @@
 		5E7C7A205F8F66D8486FAD49 /* OpenSeaNonFungibleTokenCardTableViewCellWithCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F66EE7899E4573C64AE /* OpenSeaNonFungibleTokenCardTableViewCellWithCheckbox.swift */; };
 		5E7C7A3FEE2826C05AB42656 /* Web3Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C76535DC145679D0C0286 /* Web3Swift.swift */; };
 		5E7C7A4384A8E3F22D3F8249 /* SetSellTokensCardExpiryDateViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C700CD3E43689E88FBE9B /* SetSellTokensCardExpiryDateViewControllerViewModel.swift */; };
+		5E7C7A67B6143DFB9B1CF02B /* ConfirmSignMessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7DD9C564F2C7DE435894 /* ConfirmSignMessageTableViewCell.swift */; };
 		5E7C7A6C28C59DB62DEE2D63 /* BookmarkViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C706658D72CC1C8BB698C /* BookmarkViewCell.swift */; };
 		5E7C7A91D0F6CBDA3C89DEAC /* LocaleViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79E3BC4CACB123840A42 /* LocaleViewCell.swift */; };
 		5E7C7A9D757269A9386B9F1F /* ContractERC20Transfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E81029EED4B560DA523 /* ContractERC20Transfer.swift */; };
 		5E7C7AB2ECFB589632F2A26C /* WalletFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E2DCCE0D775ECF83088 /* WalletFilter.swift */; };
 		5E7C7AB6950E43BD6E8D0CBE /* TokensViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B3302309706CA0F972A /* TokensViewController.swift */; };
+		5E7C7AC88DB7EB58FDAF1B21 /* ConfirmSignMessageViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B6380E6EB88AF8810CD /* ConfirmSignMessageViewControllerViewModel.swift */; };
 		5E7C7ACBFEEE07105CC513C3 /* BaseOpenSeaNonFungibleTokenCardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C761E148B46943FC38979 /* BaseOpenSeaNonFungibleTokenCardTableViewCell.swift */; };
 		5E7C7AD1BA92A8FFF930F8DC /* BrowserURLParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C8CA3706DC14167786C /* BrowserURLParserTests.swift */; };
 		5E7C7AE1389D3179239249F0 /* ImportWalletTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C743172FCBDCD362C03A6 /* ImportWalletTabBar.swift */; };
@@ -934,7 +938,9 @@
 		5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportMagicTokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7828BD821B6F04B71C00 /* SendHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendHeaderView.swift; sourceTree = "<group>"; };
 		5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonFungibleTokenViewCell.swift; sourceTree = "<group>"; };
+		5E7C78421F01D14741DDF5BF /* ConfirmSignMessageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageViewController.swift; sourceTree = "<group>"; };
 		5E7C784984649DD8E02B50B8 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
+		5E7C7892A9FC3F53B13498D9 /* GenerateSellMagicLinkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateSellMagicLinkViewController.swift; sourceTree = "<group>"; };
 		5E7C78B001F9F95F404D5FEF /* HowDoIGetMyMoneyInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HowDoIGetMyMoneyInfoViewController.swift; sourceTree = "<group>"; };
 		5E7C78B63FDE2FAF25389260 /* TransferTokensCardViaWalletAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTokensCardViaWalletAddressViewController.swift; sourceTree = "<group>"; };
 		5E7C78E5C8FAEA752B32626D /* UIActivityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityViewController.swift; sourceTree = "<group>"; };
@@ -946,7 +952,6 @@
 		5E7C79778E4BFE1322711EA6 /* LocaleViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleViewModel.swift; sourceTree = "<group>"; };
 		5E7C7981AB6584B25C72D46B /* LockEnterPasscodeCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockEnterPasscodeCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7982FA14CBFDFD93B3D0 /* AssetDefinitionStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionStore.swift; sourceTree = "<group>"; };
-		5E7C79CF6150E4CD4A276FC0 /* GenerateSellMagicLinkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateSellMagicLinkViewController.swift; sourceTree = "<group>"; };
 		5E7C79D674D45A07E694CE31 /* LockView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockView.swift; sourceTree = "<group>"; };
 		5E7C79DCBECE3385649FAFDF /* MasterBrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterBrowserViewController.swift; sourceTree = "<group>"; };
 		5E7C79E3BC4CACB123840A42 /* LocaleViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleViewCell.swift; sourceTree = "<group>"; };
@@ -968,10 +973,12 @@
 		5E7C7AE6FAE0DF969B4F52E9 /* ContactUsBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsBannerView.swift; sourceTree = "<group>"; };
 		5E7C7AF9A592D7224ED58016 /* OnboardingPageStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingPageStyle.swift; sourceTree = "<group>"; };
 		5E7C7AFE9AF9FE6B58C925D4 /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		5E7C7B080E387A79058430B9 /* ConfirmSignMessageTableViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7B089FD4C96810DD10FD /* HelpContentsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelpContentsViewController.swift; sourceTree = "<group>"; };
 		5E7C7B1FB2702A2A8A4EBD76 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7B29A9E728402D144C05 /* AppLocale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLocale.swift; sourceTree = "<group>"; };
 		5E7C7B3302309706CA0F972A /* TokensViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensViewController.swift; sourceTree = "<group>"; };
+		5E7C7B6380E6EB88AF8810CD /* ConfirmSignMessageViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C7B6FAFE62FBAADB85228 /* Web3Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Web3Error.swift; sourceTree = "<group>"; };
 		5E7C7B7A45EDFA8ED1E25863 /* SendHeaderViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendHeaderViewViewModel.swift; sourceTree = "<group>"; };
 		5E7C7B82CC07F290B9CAA4E4 /* StatusViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusViewController.swift; sourceTree = "<group>"; };
@@ -1015,6 +1022,7 @@
 		5E7C7DBF46316B08D3905C8E /* Web3Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Web3Request.swift; sourceTree = "<group>"; };
 		5E7C7DCB0BDDD30D10130AE7 /* GetIsERC875Encode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetIsERC875Encode.swift; sourceTree = "<group>"; };
 		5E7C7DCD31EC86A11E98FE6C /* ApproveERC20.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApproveERC20.swift; sourceTree = "<group>"; };
+		5E7C7DD9C564F2C7DE435894 /* ConfirmSignMessageTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageTableViewCell.swift; sourceTree = "<group>"; };
 		5E7C7E2486CDE31871C98FC7 /* TransferTokensCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTokensCardViewModel.swift; sourceTree = "<group>"; };
 		5E7C7E24936CC2190D2A16C2 /* OnboardingPageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingPageViewModel.swift; sourceTree = "<group>"; };
 		5E7C7E2DCCE0D775ECF83088 /* WalletFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WalletFilter.swift; path = Models/WalletFilter.swift; sourceTree = "<group>"; };
@@ -1999,6 +2007,7 @@
 				5E7C7D46C7CABC31A7477F37 /* GenerateTransferMagicLinkViewController.swift */,
 				5E7C78B63FDE2FAF25389260 /* TransferTokensCardViaWalletAddressViewController.swift */,
 				5E7C74159ED115D14384A1CB /* CanScanQRCode.swift */,
+				5E7C78421F01D14741DDF5BF /* ConfirmSignMessageViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -2017,6 +2026,8 @@
 				5E7C7BA578BE5FB0E613A6D6 /* ChooseTokenCardTransferModeViewControllerViewModel.swift */,
 				5E7C754C0E2E57F32A61F9A3 /* SetTransferTokensCardExpiryDateViewControllerViewModel.swift */,
 				5E7C76D3CFA12C2236E73E10 /* TransferTokensCardViaWalletAddressViewControllerViewModel.swift */,
+				5E7C7B6380E6EB88AF8810CD /* ConfirmSignMessageViewControllerViewModel.swift */,
+				5E7C7B080E387A79058430B9 /* ConfirmSignMessageTableViewCellViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -2628,7 +2639,7 @@
 				5E7C7FF84A4377FC395772C3 /* SellTokensCardViewController.swift */,
 				5E7C7F610139D24D947B1625 /* EnterSellTokensCardPriceQuantityViewController.swift */,
 				5E7C7962AE417E12F13FF58E /* SetSellTokensCardExpiryDateViewController.swift */,
-				5E7C79CF6150E4CD4A276FC0 /* GenerateSellMagicLinkViewController.swift */,
+				5E7C7892A9FC3F53B13498D9 /* GenerateSellMagicLinkViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -2800,6 +2811,7 @@
 			isa = PBXGroup;
 			children = (
 				5E7C7828BD821B6F04B71C00 /* SendHeaderView.swift */,
+				5E7C7DD9C564F2C7DE435894 /* ConfirmSignMessageTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3859,7 +3871,6 @@
 				5E7C7D2948B4B9724F2E509E /* TimeEntryField.swift in Sources */,
 				5E7C7669BBE6255A2377E070 /* SetSellTokensCardExpiryDateViewController.swift in Sources */,
 				5E7C7A4384A8E3F22D3F8249 /* SetSellTokensCardExpiryDateViewControllerViewModel.swift in Sources */,
-				5E7C776CF721EBBD43195926 /* GenerateSellMagicLinkViewController.swift in Sources */,
 				5E7C7B0367CFB413C6885474 /* GenerateSellMagicLinkViewControllerViewModel.swift in Sources */,
 				5E7C7692C981580CD32228EB /* ChooseTokenCardTransferModeViewController.swift in Sources */,
 				5E7C74DBAE43954C185057B3 /* ChooseTokenCardTransferModeViewControllerViewModel.swift in Sources */,
@@ -3993,6 +4004,11 @@
 				5E7C7896E99049F4B124FDF5 /* OpenSeaNonFungibleTokenDisplayHelper.swift in Sources */,
 				5E7C7D28171AB1C7FF5379A7 /* OpenSeaNonFungibleTokenViewCell.swift in Sources */,
 				5E7C7E02785866606FF298F3 /* OpenSeaNonFungibleTokenViewCellViewModel.swift in Sources */,
+				5E7C71DBB4AD309920C45556 /* ConfirmSignMessageViewController.swift in Sources */,
+				5E7C772EC476993A170C840B /* GenerateSellMagicLinkViewController.swift in Sources */,
+				5E7C7AC88DB7EB58FDAF1B21 /* ConfirmSignMessageViewControllerViewModel.swift in Sources */,
+				5E7C7A67B6143DFB9B1CF02B /* ConfirmSignMessageTableViewCell.swift in Sources */,
+				5E7C74C6110D4E93C759D5DB /* ConfirmSignMessageTableViewCellViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Browser/Coordinators/BrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/BrowserCoordinator.swift
@@ -152,7 +152,7 @@ final class BrowserCoordinator: NSObject, Coordinator {
         }
     }
 
-    func signMessage(with type: SignMesageType, account: Account, callbackID: Int) {
+    func signMessage(with type: SignMessageType, account: Account, callbackID: Int) {
         let coordinator = SignMessageCoordinator(
             navigationController: navigationController,
             keystore: keystore,

--- a/AlphaWallet/Tokens/Views/TokensCardViewControllerTitleHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokensCardViewControllerTitleHeader.swift
@@ -24,12 +24,11 @@ class TokensCardViewControllerTitleHeader: UIView {
         // TODO extract constant. Maybe StyleLayout.sideMargin
         NSLayoutConstraint.activate([
             background.leadingAnchor.constraint(equalTo: leadingAnchor),
-//            background.topAnchor.constraint(equalTo: topAnchor),
             background.centerYAnchor.constraint(equalTo: centerYAnchor),
             backgroundWidthConstraint,
 
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 21),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -21),
+            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 0),
+            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: 0),
             stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: 16),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: background.bottomAnchor, constant: -16),
         ])

--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -6,7 +6,7 @@ import TrustKeystore
 import CryptoSwift
 import Result
 
-enum SignMesageType {
+enum SignMessageType {
     case message(Data)
     case personalMessage(Data)
     case typedMessage([EthTypedData])
@@ -20,7 +20,7 @@ class SignMessageCoordinator: Coordinator {
     private let navigationController: UINavigationController
     private let keystore: Keystore
     private let account: Account
-    private var message: SignMesageType?
+    private var message: SignMessageType?
 
     var coordinators: [Coordinator] = []
     weak var delegate: SignMessageCoordinatorDelegate?
@@ -36,13 +36,13 @@ class SignMessageCoordinator: Coordinator {
         self.account = account
     }
 
-    func start(with message: SignMesageType) {
+    func start(with message: SignMessageType) {
         self.message = message
         let alertController = makeAlertController(with: message)
         navigationController.present(alertController, animated: true, completion: nil)
     }
 
-    private func makeAlertController(with type: SignMesageType) -> UIViewController {
+    private func makeAlertController(with type: SignMessageType) -> UIViewController {
         let vc = ConfirmSignMessageViewController()
         vc.delegate = self
         vc.configure(viewModel: .init(message: type))
@@ -51,7 +51,7 @@ class SignMessageCoordinator: Coordinator {
         return vc
     }
 
-    private func handleSignedMessage(with type: SignMesageType) {
+    private func handleSignedMessage(with type: SignMessageType) {
         let result: Result<Data, KeystoreError>
         switch type {
         case .message(let data):

--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -20,6 +20,7 @@ class SignMessageCoordinator: Coordinator {
     private let navigationController: UINavigationController
     private let keystore: Keystore
     private let account: Account
+    private var message: SignMesageType?
 
     var coordinators: [Coordinator] = []
     weak var delegate: SignMessageCoordinatorDelegate?
@@ -35,53 +36,19 @@ class SignMessageCoordinator: Coordinator {
         self.account = account
     }
 
-    func start(with type: SignMesageType) {
-        let alertController = makeAlertController(with: type)
+    func start(with message: SignMesageType) {
+        self.message = message
+        let alertController = makeAlertController(with: message)
         navigationController.present(alertController, animated: true, completion: nil)
     }
 
-    private func makeAlertController(with type: SignMesageType) -> UIAlertController {
-        let alertController = UIAlertController(
-            title: R.string.localizable.confirmSignMessage(),
-            message: message(for: type),
-            preferredStyle: .alert
-        )
-        let signAction = UIAlertAction(
-            title: R.string.localizable.oK(),
-            style: .default
-        ) { [weak self] _ in
-            guard let strongSelf = self else { return }
-            strongSelf.handleSignedMessage(with: type)
-        }
-        let cancelAction = UIAlertAction(title: R.string.localizable.cancel(), style: .cancel) { [weak self] _ in
-            guard let strongSelf = self else { return }
-            strongSelf.didComplete?(.failure(AnyError(DAppError.cancelled)))
-            strongSelf.delegate?.didCancel(in: strongSelf)
-        }
-        alertController.addAction(signAction)
-        alertController.addAction(cancelAction)
-        return alertController
-    }
-
-    func message(for type: SignMesageType) -> String {
-        switch type {
-        case .message(let data),
-             .personalMessage(let data):
-            guard let message = String(data: data, encoding: .utf8) else {
-                return data.hexEncoded
-            }
-            return message
-        case .typedMessage(let (typedData)):
-            let string = typedData.map {
-                return "\($0.name) : \($0.value.string)"
-            }.joined(separator: "\n")
-            return string
-        }
-    }
-
-    private func isMessage(data: Data) -> Bool {
-        guard let _ = String(data: data, encoding: .utf8) else { return false }
-        return true
+    private func makeAlertController(with type: SignMesageType) -> UIViewController {
+        let vc = ConfirmSignMessageViewController()
+        vc.delegate = self
+        vc.configure(viewModel: .init(message: type))
+        vc.modalPresentationStyle = .overFullScreen
+        vc.modalTransitionStyle = .crossDissolve
+        return vc
     }
 
     private func handleSignedMessage(with type: SignMesageType) {
@@ -104,5 +71,19 @@ class SignMessageCoordinator: Coordinator {
         case .failure(let error):
             didComplete?(.failure(AnyError(error)))
         }
+    }
+}
+
+extension SignMessageCoordinator: ConfirmSignMessageViewControllerDelegate {
+    func didPressProceed(in viewController: ConfirmSignMessageViewController) {
+        navigationController.dismiss(animated: true)
+        guard let message = message else { return }
+        handleSignedMessage(with: message)
+    }
+
+    func didPressCancel(in viewController: ConfirmSignMessageViewController) {
+        navigationController.dismiss(animated: true)
+        didComplete?(.failure(AnyError(DAppError.cancelled)))
+        delegate?.didCancel(in: self)
     }
 }

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
@@ -1,0 +1,175 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+
+protocol ConfirmSignMessageViewControllerDelegate: class {
+    func didPressProceed(in viewController: ConfirmSignMessageViewController)
+    func didPressCancel(in viewController: ConfirmSignMessageViewController)
+}
+
+//TODO make more reusable as an alert?
+class ConfirmSignMessageViewController: UIViewController {
+    private let background = UIView()
+	private let header = TokensCardViewControllerTitleHeader()
+    private let detailsBackground = UIView()
+    private let singleMessageLabel = UILabel()
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let actionButton = UIButton()
+    private let cancelButton = UIButton()
+    private var viewModel: ConfirmSignMessageViewControllerViewModel?
+    lazy private var tableViewHeightConstraint = tableView.heightAnchor.constraint(equalToConstant: 0)
+    private var tableViewContentSizeObserver: NSKeyValueObservation?
+
+    weak var delegate: ConfirmSignMessageViewControllerDelegate?
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        view.backgroundColor = .clear
+
+        let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+        visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+        view.insertSubview(visualEffectView, at: 0)
+
+        view.addSubview(background)
+        background.translatesAutoresizingMaskIntoConstraints = false
+
+        singleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        tableView.register(ConfirmSignMessageTableViewCell.self, forCellReuseIdentifier: ConfirmSignMessageTableViewCell.identifier)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.separatorStyle = .none
+
+        detailsBackground.translatesAutoresizingMaskIntoConstraints = false
+        background.addSubview(detailsBackground)
+
+        actionButton.addTarget(self, action: #selector(proceed), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(cancel), for: .touchUpInside)
+
+        let stackView = [
+			header,
+            .spacer(height: 20),
+            tableView,
+            singleMessageLabel,
+            .spacer(height: 30),
+            actionButton,
+            .spacer(height: 10),
+            cancelButton,
+            .spacer(height: 1)
+        ].asStackView(axis: .vertical)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        background.addSubview(stackView)
+
+        tableView.isScrollEnabled = false
+        NSLayoutConstraint.activate([
+            header.heightAnchor.constraint(equalToConstant: 60),
+            //Strange repositioning of header horizontally while typing without this
+            header.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+
+            visualEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            visualEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            visualEffectView.topAnchor.constraint(equalTo: view.topAnchor),
+            visualEffectView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            detailsBackground.leadingAnchor.constraint(equalTo: background.leadingAnchor),
+            detailsBackground.trailingAnchor.constraint(equalTo: background.trailingAnchor),
+            detailsBackground.topAnchor.constraint(lessThanOrEqualTo: singleMessageLabel.topAnchor, constant: -12),
+            detailsBackground.bottomAnchor.constraint(greaterThanOrEqualTo: singleMessageLabel.bottomAnchor, constant: 12),
+            detailsBackground.topAnchor.constraint(lessThanOrEqualTo: tableView.topAnchor, constant: -12),
+            detailsBackground.bottomAnchor.constraint(greaterThanOrEqualTo: tableView.bottomAnchor, constant: 12),
+
+            tableViewHeightConstraint,
+
+            actionButton.heightAnchor.constraint(equalToConstant: 47),
+            cancelButton.heightAnchor.constraint(equalTo: actionButton.heightAnchor),
+
+            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 30),
+            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -30),
+            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: 16),
+            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -16),
+
+            background.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
+            background.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),
+            background.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(viewModel: ConfirmSignMessageViewControllerViewModel) {
+        self.viewModel = viewModel
+        if let viewModel = self.viewModel {
+            background.backgroundColor = viewModel.contentsBackgroundColor
+            background.layer.cornerRadius = 20
+
+            header.configure(title: viewModel.headerTitle)
+
+            singleMessageLabel.textAlignment = .center
+            singleMessageLabel.numberOfLines = 0
+            singleMessageLabel.textColor = viewModel.singleMessageLabelTextColor
+            singleMessageLabel.font = viewModel.singleMessageLabelFont
+            singleMessageLabel.text = viewModel.singleMessageLabelText
+
+            tableView.backgroundColor = viewModel.detailsBackgroundBackgroundColor
+            tableView.reloadData()
+            tableViewContentSizeObserver = tableView.observe(\UITableView.contentSize, options: [.new]) { [weak self] (_, change) in
+                guard let strongSelf = self else { return }
+                guard let newSize = change.newValue else { return }
+                strongSelf.tableViewHeightConstraint.constant = newSize.height
+            }
+
+            detailsBackground.backgroundColor = viewModel.detailsBackgroundBackgroundColor
+
+            actionButton.setTitleColor(viewModel.actionButtonTitleColor, for: .normal)
+            actionButton.setBackgroundColor(viewModel.actionButtonBackgroundColor, forState: .normal)
+            actionButton.titleLabel?.font = viewModel.actionButtonTitleFont
+            actionButton.setTitle(viewModel.actionButtonTitle, for: .normal)
+            actionButton.layer.masksToBounds = true
+
+            cancelButton.setTitleColor(viewModel.cancelButtonTitleColor, for: .normal)
+            cancelButton.setBackgroundColor(viewModel.cancelButtonBackgroundColor, forState: .normal)
+            cancelButton.titleLabel?.font = viewModel.cancelButtonTitleFont
+            cancelButton.setTitle(viewModel.cancelButtonTitle, for: .normal)
+            cancelButton.layer.masksToBounds = true
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        actionButton.layer.cornerRadius = actionButton.frame.size.height / 2
+    }
+
+    @objc func proceed() {
+        delegate?.didPressProceed(in: self)
+    }
+
+    @objc func cancel() {
+        if let delegate = delegate {
+            delegate.didPressCancel(in: self)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}
+
+extension ConfirmSignMessageViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: ConfirmSignMessageTableViewCell.identifier, for: indexPath) as! ConfirmSignMessageTableViewCell
+        if let viewModel = viewModel {
+            cell.configure(viewModel: viewModel.viewModelForTypedMessage(at: indexPath.row))
+        }
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if let viewModel = viewModel {
+            return viewModel.typedMessagesCount
+        } else {
+            return 0
+        }
+    }
+}

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageTableViewCellViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageTableViewCellViewModel.swift
@@ -1,0 +1,13 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+
+struct ConfirmSignMessageTableViewCellViewModel {
+    let backgroundColor: UIColor
+    let nameTextFont: UIFont
+    let valueTextFont: UIFont
+    let valueTextColor: UIColor
+    let name: String
+    let value: String
+}

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
@@ -4,9 +4,9 @@ import UIKit
 
 //TODO make more reusable as an alert?
 struct ConfirmSignMessageViewControllerViewModel {
-    private let message: SignMesageType
+    private let message: SignMessageType
 
-    init(message: SignMesageType) {
+    init(message: SignMessageType) {
         self.message = message
     }
 

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
@@ -1,0 +1,126 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import UIKit
+
+//TODO make more reusable as an alert?
+struct ConfirmSignMessageViewControllerViewModel {
+    private let message: SignMesageType
+
+    init(message: SignMesageType) {
+        self.message = message
+    }
+
+    var contentsBackgroundColor: UIColor {
+        return Colors.appWhite
+    }
+
+	var headerTitle: String {
+        return R.string.localizable.confirmSignMessage()
+	}
+
+    var actionButtonTitleColor: UIColor {
+        return Colors.appWhite
+    }
+
+    var actionButtonBackgroundColor: UIColor {
+        return Colors.appBackground
+    }
+
+    var actionButtonTitleFont: UIFont {
+        return Fonts.regular(size: 20)!
+    }
+
+    var cancelButtonTitleColor: UIColor {
+        return Colors.appRed
+    }
+
+    var cancelButtonBackgroundColor: UIColor {
+        return .clear
+    }
+
+    var cancelButtonTitleFont: UIFont {
+        return Fonts.regular(size: 20)!
+    }
+
+    var actionButtonTitle: String {
+        //TODO better to be "Sign" ?
+        return R.string.localizable.oK()
+    }
+
+    var cancelButtonTitle: String {
+        return R.string.localizable.aWalletTokenSellConfirmCancelButtonTitle()
+    }
+
+    var singleMessageLabelFont: UIFont {
+        return Fonts.semibold(size: 21)!
+    }
+
+    var singleMessageLabelTextColor: UIColor {
+        return Colors.appBackground
+    }
+
+    var nameTextFont: UIFont {
+        return Fonts.semibold(size: 16)!
+    }
+
+    var valueTextFont: UIFont {
+        return Fonts.semibold(size: 21)!
+    }
+
+    var detailsBackgroundBackgroundColor: UIColor {
+        return UIColor(red: 236, green: 236, blue: 236)
+    }
+
+    var singleMessageLabelText: String? {
+        switch message {
+        case .message(let data), .personalMessage(let data):
+            guard let message = String(data: data, encoding: .utf8) else {
+                return data.hexEncoded
+            }
+            return message
+        case .typedMessage(let (typedData)):
+            return nil
+        }
+    }
+
+    var typedMessagesCount: Int {
+        switch message {
+        case .message, .personalMessage:
+            return 0
+        case .typedMessage(let typedMessage):
+            return typedMessage.count
+        }
+    }
+
+    private func typedMessage(at index: Int) -> EthTypedData? {
+        switch message {
+        case .message, .personalMessage:
+            return nil
+        case .typedMessage(let typedMessage):
+            if index < typedMessage.count {
+                return typedMessage[index]
+            } else {
+                return nil
+            }
+        }
+    }
+
+    private func typedMessageName(at index: Int) -> String? {
+        return typedMessage(at: index)?.name
+    }
+
+    private func typedMessageValue(at index: Int) -> String? {
+        return typedMessage(at: index)?.value.string
+    }
+
+    func viewModelForTypedMessage(at index: Int) -> ConfirmSignMessageTableViewCellViewModel {
+        return.init(
+                backgroundColor: detailsBackgroundBackgroundColor,
+                nameTextFont: nameTextFont,
+                valueTextFont: valueTextFont,
+                valueTextColor: singleMessageLabelTextColor,
+                name: typedMessageName(at: index) ?? "",
+                value: typedMessageValue(at: index) ?? ""
+        )
+    }
+}

--- a/AlphaWallet/Transfer/Views/ConfirmSignMessageTableViewCell.swift
+++ b/AlphaWallet/Transfer/Views/ConfirmSignMessageTableViewCell.swift
@@ -1,0 +1,30 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+
+class ConfirmSignMessageTableViewCell: UITableViewCell {
+    static let identifier = "ConfirmSignMessageTableViewCell"
+
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(viewModel: ConfirmSignMessageTableViewCellViewModel) {
+        contentView.backgroundColor = viewModel.backgroundColor
+        selectionStyle = .none
+
+        textLabel?.font = viewModel.nameTextFont
+
+        detailTextLabel?.numberOfLines = 0
+        detailTextLabel?.font = viewModel.valueTextFont
+        detailTextLabel?.textColor = viewModel.valueTextColor
+
+        textLabel?.text = viewModel.name
+        detailTextLabel?.text = viewModel.value
+    }
+}


### PR DESCRIPTION
Related to #760.

This PR makes the prompt to sign message/personal/typed message confirmation nicer and more consistent with the rest of the app.

Just a thought while writing this: Maybe it's good to have another PR after this to display the wallet address for which key we are signing with?

Before:

![simulator screen shot - iphone x - 2018-10-25 at 17 08 09](https://user-images.githubusercontent.com/56189/47490393-349bc180-d87b-11e8-8c36-48491cd655f2.png)
![simulator screen shot - iphone x - 2018-10-25 at 17 08 27](https://user-images.githubusercontent.com/56189/47490394-349bc180-d87b-11e8-9a1a-6716fc09d0fc.png)

After:

![simulator screen shot - iphone x - 2018-10-25 at 17 09 12](https://user-images.githubusercontent.com/56189/47490407-39607580-d87b-11e8-8bfc-f8752628b910.png)
![simulator screen shot - iphone x - 2018-10-25 at 17 10 13](https://user-images.githubusercontent.com/56189/47490408-39f90c00-d87b-11e8-956a-2a5ca753ebb5.png)
