### PR TITLE
Fix: OpenSea token card layout broken if rendered as collapsed twice in a row

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/OpenSeaNonFungibleTokenCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/OpenSeaNonFungibleTokenCardRowViewModel.swift
@@ -109,15 +109,15 @@ struct OpenSeaNonFungibleTokenCardRowViewModel {
     }
 
     var isAttributesTitleHidden: Bool {
-        return attributes.isEmpty
+        return !areDetailsVisible || attributes.isEmpty
     }
 
     var isRankingsTitleHidden: Bool {
-        return rankings.isEmpty
+        return !areDetailsVisible || rankings.isEmpty
     }
 
     var isStatsTitleHidden: Bool {
-        return stats.isEmpty
+        return !areDetailsVisible || stats.isEmpty
     }
 
     var subtitleFont: UIFont {

--- a/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
@@ -217,7 +217,7 @@ class OpenSeaNonFungibleTokenCardRowView: UIView {
         thumbnailRelatedConstraints = [
             thumbnailImageView.widthAnchor.constraint(equalToConstant: 150),
             thumbnailImageView.widthAnchor.constraint(equalTo: thumbnailImageView.heightAnchor),
-            thumbnailImageView.heightAnchor.constraint(equalTo: col0.heightAnchor),
+            thumbnailImageView.heightAnchor.constraint(greaterThanOrEqualTo: col0.heightAnchor),
         ]
 
         let marginForBigImageView = CGFloat(1)
@@ -499,23 +499,17 @@ class OpenSeaNonFungibleTokenCardRowView: UIView {
             urlButtonHolder.isHidden = true
         }
 
-        if viewModel.isAttributesTitleHidden {
-            attributesLabel.isHidden = true
-            spacers.belowDescription.isHidden = true
-            spacers.belowAttributesLabel.isHidden = true
-        }
+        attributesLabel.isHidden = viewModel.isAttributesTitleHidden
+        spacers.belowDescription.isHidden = viewModel.isAttributesTitleHidden
+        spacers.belowAttributesLabel.isHidden = viewModel.isAttributesTitleHidden
 
-        if viewModel.isRankingsTitleHidden {
-            rankingsLabel.isHidden = true
-            spacers.aboveRankingsLabel.isHidden = true
-            spacers.belowRankingsLabel.isHidden = true
-        }
+        rankingsLabel.isHidden = viewModel.isRankingsTitleHidden
+        spacers.aboveRankingsLabel.isHidden = viewModel.isRankingsTitleHidden
+        spacers.belowRankingsLabel.isHidden = viewModel.isRankingsTitleHidden
 
-        if viewModel.isStatsTitleHidden {
-            statsLabel.isHidden = true
-            spacers.aboveStatsLabel.isHidden = true
-            spacers.belowStatsLabel.isHidden = true
-        }
+        statsLabel.isHidden = viewModel.isStatsTitleHidden
+        spacers.aboveStatsLabel.isHidden = viewModel.isStatsTitleHidden
+        spacers.belowStatsLabel.isHidden = viewModel.isStatsTitleHidden
     }
 
     //So collection views know the width to calculate their "full" height so they don't need to scroll


### PR DESCRIPTION
e.g.

1. Tap ERC721 token card from OpenSea in wallet tab
2. Tokens are shown collapsed the first time
3. Tap on row 0. Row 1 is rended as collapsed a second time
4. Scroll to reveal row 1 completely. Layout of row 1 is broken