### PR TITLE
Fix: auto-sizing cells has wrong height in iOS 10

### DIFF
--- a/AlphaWallet/Redeem/ViewControllers/RedeemTokenViewController.swift
+++ b/AlphaWallet/Redeem/ViewControllers/RedeemTokenViewController.swift
@@ -48,6 +48,7 @@ class RedeemTokenViewController: UIViewController, TokenVerifiableStatusViewCont
         tableView.separatorStyle = .none
         tableView.backgroundColor = Colors.appWhite
         tableView.tableHeaderView = header
+        tableView.estimatedRowHeight = TokensCardViewController.anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10
         tableView.rowHeight = UITableViewAutomaticDimension
         roundedBackground.addSubview(tableView)
 

--- a/AlphaWallet/Sell/ViewControllers/SellTokensCardViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/SellTokensCardViewController.swift
@@ -42,6 +42,7 @@ class SellTokensCardViewController: UIViewController, TokenVerifiableStatusViewC
         tableView.separatorStyle = .none
         tableView.backgroundColor = Colors.appWhite
         tableView.tableHeaderView = header
+        tableView.estimatedRowHeight = TokensCardViewController.anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10
         tableView.rowHeight = UITableViewAutomaticDimension
         roundedBackground.addSubview(tableView)
 

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -21,6 +21,8 @@ protocol TokensCardViewControllerDelegate: class, CanOpenURL {
 }
 
 class TokensCardViewController: UIViewController, TokenVerifiableStatusViewController {
+    static let anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10 = CGFloat(100)
+
     private let tokenObject: TokenObject
     private var viewModel: TokensCardViewModel
     private let tokensStorage: TokensDataStore
@@ -66,6 +68,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         tableView.separatorStyle = .none
         tableView.backgroundColor = Colors.appWhite
         tableView.tableHeaderView = header
+        tableView.estimatedRowHeight = TokensCardViewController.anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10
         tableView.rowHeight = UITableViewAutomaticDimension
         roundedBackground.addSubview(tableView)
 

--- a/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
@@ -46,6 +46,7 @@ class TransactionsViewController: UIViewController {
         tableView.dataSource = self
         tableView.separatorStyle = .none
         tableView.backgroundColor = Colors.appBackground
+        tableView.estimatedRowHeight = TokensCardViewController.anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10
         tableView.rowHeight = UITableViewAutomaticDimension
         view.addSubview(tableView)
 

--- a/AlphaWallet/Transfer/ViewControllers/TransferTokensCardViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransferTokensCardViewController.swift
@@ -44,6 +44,7 @@ class TransferTokensCardViewController: UIViewController, TokenVerifiableStatusV
         tableView.separatorStyle = .none
         tableView.backgroundColor = Colors.appWhite
         tableView.tableHeaderView = header
+        tableView.estimatedRowHeight = TokensCardViewController.anArbitaryRowHeightSoAutoSizingCellsWorkIniOS10
         tableView.rowHeight = UITableViewAutomaticDimension
         roundedBackground.addSubview(tableView)
 


### PR DESCRIPTION
For #870 

PS: Wanted to include a snapshot test. But couldn't any test to run correctly in iOS 12. Sigh.