### PR TITLE
Call contract functions for asset attributes for spawnable meetup contract

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		5E7C733638D7596F93DEE2A9 /* OnboardingCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75CE3F1D6B7993E7A840 /* OnboardingCollectionViewController.swift */; };
 		5E7C7364BF4F6EC3F15804C2 /* GetIsERC721Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CA7D65743AEE3411F3A /* GetIsERC721Encode.swift */; };
 		5E7C7376B566E5A59CC8F463 /* ImportMagicTokenViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C72D0E7CA03ADE5CFAE7A /* ImportMagicTokenViewControllerViewModel.swift */; };
+		5E7C73CA81FB2CE9BCAFC992 /* CallForAssetAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C787CA216AFED8023A35F /* CallForAssetAttribute.swift */; };
 		5E7C73FC3990D110C474C3D6 /* WalletFilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75CC640BAFFE0E789F44 /* WalletFilterViewModel.swift */; };
 		5E7C73FD5BD75D90C8D0EF3C /* WalletFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C58586099F082973073 /* WalletFilterView.swift */; };
 		5E7C73FDC874F983EC83B820 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C72BCB25F6212B3029E34 /* HistoryViewModel.swift */; };
@@ -344,6 +345,7 @@
 		5E7C772EC476993A170C840B /* GenerateSellMagicLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7892A9FC3F53B13498D9 /* GenerateSellMagicLinkViewController.swift */; };
 		5E7C773E3E3BBEB65C51DF2A /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7D2C43C15D0762C7F374 /* UIStackView.swift */; };
 		5E7C774B5332AC0DC19C5B1B /* EthTokenViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74B82783A94091A43470 /* EthTokenViewCellViewModel.swift */; };
+		5E7C77552A957D1B144D9209 /* CallForAssetAttributeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7322ADC54452545C345A /* CallForAssetAttributeCoordinator.swift */; };
 		5E7C776BE1B19F824954962D /* BaseTokenCardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F5C10E3895E805EA7E0 /* BaseTokenCardTableViewCell.swift */; };
 		5E7C777A50A02B7EC9DBEB0A /* FetchAssetDefinitionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C736169A5251141791726 /* FetchAssetDefinitionsCoordinator.swift */; };
 		5E7C7788984F7ADCFE5B4DE0 /* AddressTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75B5AF76279A71395FC7 /* AddressTextField.swift */; };
@@ -400,6 +402,7 @@
 		5E7C7C0FAC500A6651E663FD /* TransferTokensCardQuantitySelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C703BA1D0E9ACB7399155 /* TransferTokensCardQuantitySelectionViewModel.swift */; };
 		5E7C7C21E5CAF122AA4F6617 /* HowDoIGetMyMoneyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78B001F9F95F404D5FEF /* HowDoIGetMyMoneyInfoViewController.swift */; };
 		5E7C7C7142C4519873B2BB4E /* ImportWalletTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C2872E213BBB05D55BA /* ImportWalletTabBarViewModel.swift */; };
+		5E7C7C8BC4763CFDD3EE119D /* AssetAttributeFunctionCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75C1D4D61A74BACAFF69 /* AssetAttributeFunctionCall.swift */; };
 		5E7C7C98EAF40E8110241DBD /* NonFungibleTokenViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */; };
 		5E7C7C9E89056069C8FEFA76 /* AlphaWalletSettingsSwitchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7534FB6BF4D199643246 /* AlphaWalletSettingsSwitchRow.swift */; };
 		5E7C7CBB48D096078A2B233E /* AssetDefinitionInMemoryBackingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7D07B7D0738A1832AB58 /* AssetDefinitionInMemoryBackingStore.swift */; };
@@ -862,6 +865,7 @@
 		5E7C72FBC0D2787AAA804098 /* OpenSeaNonFungibleTokenViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSeaNonFungibleTokenViewCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7318B6059C18BE87ECAE /* ABIValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABIValue.swift; sourceTree = "<group>"; };
 		5E7C731B6F01534683227123 /* NonFungibleTokenViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonFungibleTokenViewCellViewModel.swift; sourceTree = "<group>"; };
+		5E7C7322ADC54452545C345A /* CallForAssetAttributeCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallForAssetAttributeCoordinator.swift; sourceTree = "<group>"; };
 		5E7C734D61C0347C1638A1F7 /* BaseTokenListFormatTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTokenListFormatTableViewCell.swift; sourceTree = "<group>"; };
 		5E7C736169A5251141791726 /* FetchAssetDefinitionsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchAssetDefinitionsCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7382EAC8B9CE5EE0668D /* OpenSeaNonFungible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSeaNonFungible.swift; sourceTree = "<group>"; };
@@ -898,6 +902,7 @@
 		5E7C7596408BA84E95C90ADA /* AssetAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetAttribute.swift; sourceTree = "<group>"; };
 		5E7C759D3BBDDFB39AD262AA /* AssetAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetAttributeTests.swift; sourceTree = "<group>"; };
 		5E7C75B5AF76279A71395FC7 /* AddressTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressTextField.swift; sourceTree = "<group>"; };
+		5E7C75C1D4D61A74BACAFF69 /* AssetAttributeFunctionCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetAttributeFunctionCall.swift; sourceTree = "<group>"; };
 		5E7C75CBBFF0273EF476F95B /* LockEnterPasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockEnterPasscodeViewController.swift; sourceTree = "<group>"; };
 		5E7C75CC640BAFFE0E789F44 /* WalletFilterViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletFilterViewModel.swift; sourceTree = "<group>"; };
 		5E7C75CE3F1D6B7993E7A840 /* OnboardingCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCollectionViewController.swift; sourceTree = "<group>"; };
@@ -931,6 +936,7 @@
 		5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonFungibleTokenViewCell.swift; sourceTree = "<group>"; };
 		5E7C78421F01D14741DDF5BF /* ConfirmSignMessageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageViewController.swift; sourceTree = "<group>"; };
 		5E7C784984649DD8E02B50B8 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
+		5E7C787CA216AFED8023A35F /* CallForAssetAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallForAssetAttribute.swift; sourceTree = "<group>"; };
 		5E7C7892A9FC3F53B13498D9 /* GenerateSellMagicLinkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateSellMagicLinkViewController.swift; sourceTree = "<group>"; };
 		5E7C78B001F9F95F404D5FEF /* HowDoIGetMyMoneyInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HowDoIGetMyMoneyInfoViewController.swift; sourceTree = "<group>"; };
 		5E7C78B63FDE2FAF25389260 /* TransferTokensCardViaWalletAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTokensCardViaWalletAddressViewController.swift; sourceTree = "<group>"; };
@@ -1771,6 +1777,7 @@
 				5E7C758EEBD945A3451C96C8 /* OpenSeaNonFungibleTokenHandling.swift */,
 				5E7C7B6FAFE62FBAADB85228 /* Web3Error.swift */,
 				5E7C72DDBF109139E4C661D5 /* DelegateContract.swift */,
+				5E7C75C1D4D61A74BACAFF69 /* AssetAttributeFunctionCall.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -2156,6 +2163,7 @@
 				76F1DF5CF4A922E6FFCB7B2A /* GetContractInteractions.swift */,
 				76F1D473FF303828D93C95EB /* GetERC721BalanceCoordinator.swift */,
 				76F1D4F77311FBF3A442E4B5 /* GetIsERC721ContractCoordinator.swift */,
+				5E7C7322ADC54452545C345A /* CallForAssetAttributeCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -2732,6 +2740,7 @@
 				5E7C7CA7D65743AEE3411F3A /* GetIsERC721Encode.swift */,
 				5E7C7DCB0BDDD30D10130AE7 /* GetIsERC875Encode.swift */,
 				5E7C72CD0C22247A6AF7C95E /* GetERC721BalanceEncode.swift */,
+				5E7C787CA216AFED8023A35F /* CallForAssetAttribute.swift */,
 			);
 			path = "web3swift-pod";
 			sourceTree = "<group>";
@@ -3942,6 +3951,9 @@
 				5E7C7131E338A806132D989B /* DateEntryField.swift in Sources */,
 				5E7C7E7AEF01B9D170228342 /* TimeEntryField.swift in Sources */,
 				5E7C7719948721FE9120B5B2 /* PeekOpenSeaNonFungibleTokenViewController.swift in Sources */,
+				5E7C73CA81FB2CE9BCAFC992 /* CallForAssetAttribute.swift in Sources */,
+				5E7C77552A957D1B144D9209 /* CallForAssetAttributeCoordinator.swift in Sources */,
+				5E7C7C8BC4763CFDD3EE119D /* AssetAttributeFunctionCall.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -5,6 +5,8 @@ import AWSSNS
 //import AWSCognito
 import AWSCore
 import UserNotifications
+import TrustKeystore
+import web3swift
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
@@ -165,5 +167,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         let handled = appCoordinator.handleUniversalLink(url: url)
         return handled
     }
-
 }

--- a/AlphaWallet/AssetDefinition/AssetAttribute.swift
+++ b/AlphaWallet/AssetDefinition/AssetAttribute.swift
@@ -1,20 +1,39 @@
 // Copyright © 2018 Stormbird PTE. LTD.
 
 import UIKit
-import SwiftyXMLParser
 import BigInt
+import PromiseKit
+import SwiftyXMLParser
 
 protocol AssetAttributeValue {}
 extension String: AssetAttributeValue {}
 extension Int: AssetAttributeValue {}
 extension GeneralisedTime: AssetAttributeValue {}
 extension Array: AssetAttributeValue {}
+extension Bool: AssetAttributeValue {}
+struct SubscribableAssetAttributeValue: AssetAttributeValue {
+    let subscribable: Subscribable<AssetAttributeValue>
+}
 
 enum AssetAttributeSyntax: String {
     case directoryString = "1.3.6.1.4.1.1466.115.121.1.15"
     case generalisedTime = "1.3.6.1.4.1.1466.115.121.1.24"
     case iA5String = "1.3.6.1.4.1.1466.115.121.1.26"
     case integer = "1.3.6.1.4.1.1466.115.121.1.27"
+    case bool = "1.3.6.1.4.1.1466.115.121.1.7"
+
+    var solidityReturnType: CallForAssetAttribute.SolidityType  {
+        switch self {
+        case .directoryString, .generalisedTime, .iA5String:
+            return .string
+        case .integer:
+            return .int
+        case .bool:
+            return .bool
+        default:
+            return .string
+        }
+    }
 
     func extract(from string: String, isMapping: Bool) -> Any? {
         switch self {
@@ -29,6 +48,8 @@ enum AssetAttributeSyntax: String {
             }
         case .integer:
             return Int(string)
+        case .bool:
+            return string == "1"
         }
     }
 }
@@ -36,6 +57,7 @@ enum AssetAttributeSyntax: String {
 enum AssetAttribute {
     case mapping(attribute: XML.Accessor, rootNamespacePrefix: String, syntax: AssetAttributeSyntax, lang: String, bitmask: BigUInt, bitShift: Int)
     case direct(attribute: XML.Accessor, rootNamespacePrefix: String, syntax: AssetAttributeSyntax, bitmask: BigUInt, bitShift: Int)
+    case function(attribute: XML.Accessor, rootNamespacePrefix: String, syntax: AssetAttributeSyntax, attributeName: String, functionName: String, inputs: [CallForAssetAttribute.Argument], output: CallForAssetAttribute.ReturnType)
 
     init(attribute: XML.Element, rootNamespacePrefix: String, lang: String) {
         self = {
@@ -55,24 +77,81 @@ enum AssetAttribute {
         }()
     }
 
-    func extract(from tokenValue: BigUInt) -> AssetAttributeValue {
+    //TODO combine with the `init()` above
+    init(attribute: XML.Element, rootNamespacePrefix: String) {
+        self = {
+            let attributeAccessor = XML.Accessor(attribute)
+            let functionElement = attributeAccessor["\(rootNamespacePrefix)origin"]["\(rootNamespacePrefix)function"]
+
+            if let attributeName = attributeAccessor.attributes["id"], case .singleElement(let origin) = attributeAccessor["\(rootNamespacePrefix)origin"], let rawSyntax = attributeAccessor.attributes["syntax"], let syntax = AssetAttributeSyntax(rawValue: rawSyntax), let functionName = functionElement.text?.dropParenthesis, !functionName.isEmpty {
+                let inputs: [CallForAssetAttribute.Argument]
+                let returnType = syntax.solidityReturnType
+                let output = CallForAssetAttribute.ReturnType(type: returnType)
+
+
+                switch functionElement["\(rootNamespacePrefix)value"] {
+                case .singleElement(let inputElement):
+                    if let inputTypeString = inputElement.text, !inputTypeString.isEmpty, let inputName = inputElement.attributes["ref"], !inputName.isEmpty, let inputType = CallForAssetAttribute.SolidityType(rawValue: inputTypeString) {
+                        inputs = [.init(name: inputName, type: inputType)]
+                    } else {
+                        inputs = []
+                    }
+                case .sequence(let inputElements):
+                    inputs = inputElements.compactMap {
+                        if let inputTypeString = $0.text, !inputTypeString.isEmpty, let inputName = $0.attributes["ref"], !inputName.isEmpty, let inputType = CallForAssetAttribute.SolidityType(rawValue: inputTypeString) {
+                            return .init(name: inputName, type: inputType)
+                        } else {
+                            return nil
+                        }
+                    }
+                case .failure:
+                    inputs = []
+                }
+
+                return .function(attribute: attributeAccessor, rootNamespacePrefix: rootNamespacePrefix, syntax: syntax, attributeName: attributeName, functionName: functionName, inputs: inputs, output: output)
+            } else {
+                //TODO maybe return an optional to indicate error instead?
+                return .direct(attribute: attributeAccessor, rootNamespacePrefix: rootNamespacePrefix, syntax: .iA5String, bitmask: BigUInt(0), bitShift: 0)
+            }
+        }()
+    }
+
+   func extract(from tokenValue: BigUInt, ofContract contract: String, config: Config, callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator?) -> AssetAttributeValue {
         switch self {
         case .mapping(_, _, let syntax, _, _, _), .direct(_, _, let syntax, _, _):
             switch syntax {
             case .directoryString, .iA5String:
-                let value: String = extract(from: tokenValue) ?? "N/A"
+                let value: String = extract(from: tokenValue, ofContract: contract, config: config, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) ?? "N/A"
                 return value
             case .generalisedTime:
-                let value: GeneralisedTime = extract(from: tokenValue) ?? .init()
+                let value: GeneralisedTime = extract(from: tokenValue, ofContract: contract, config: config, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) ?? .init()
                 return value
             case .integer:
-                let value: Int = extract(from: tokenValue) ?? 0
+                let value: Int = extract(from: tokenValue, ofContract: contract, config: config, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) ?? 0
                 return value
+            case .bool:
+                let value: Bool = extract(from: tokenValue, ofContract: contract, config: config, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) ?? false
+                return value
+            }
+        case .function(_, _, let syntax, _, _, _, _):
+            if let subscribableAttributeValue: SubscribableAssetAttributeValue = extract(from: tokenValue, ofContract: contract, config: config, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) {
+                return subscribableAttributeValue
+            } else {
+                switch syntax {
+                case .directoryString, .iA5String:
+                    return "N/A"
+                case .generalisedTime:
+                    return GeneralisedTime()
+                case .integer:
+                    return 0
+                case .bool:
+                    return false
+                }
             }
         }
     }
 
-    func extract<T>(from tokenValue: BigUInt) -> T? where T: AssetAttributeValue {
+    private func extract<T>(from tokenValue: BigUInt, ofContract contract: String, config: Config, callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator?) -> T? where T: AssetAttributeValue {
         switch self {
         case .mapping(let attribute, let rootNamespacePrefix, let syntax, let lang, _, _):
             guard let key = parseValue(tokenValue: tokenValue) else { return nil }
@@ -81,6 +160,31 @@ enum AssetAttribute {
         case .direct(_, _, let syntax, _, _):
             guard let value = parseValue(tokenValue: tokenValue) else { return nil }
             return syntax.extract(from: String(value), isMapping: false) as? T
+        case .function(_, _, _, let attributeName, let functionName, let inputs, let output):
+            let arguments: [AnyObject]
+            //TODO we only support tokenID for now
+            if inputs.count == 1 && (inputs[0].name == "tokenID" || inputs[0].name == "TokenID")  {
+                //TODO what format do we need to pass the tokenValue in?
+                arguments = [String(tokenValue) as NSString]
+            } else {
+                arguments = []
+            }
+
+            let functionCall = AssetAttributeFunctionCall(
+                    server: config.server,
+                    contract: contract,
+                    functionName: functionName,
+                    inputs: inputs,
+                    output: output,
+                    arguments: arguments
+            )
+            let subscribable = callSmartContractFunction(
+                    forAttributeName: attributeName,
+                    tokenId: tokenValue,
+                    functionCall: functionCall,
+                    callForAssetAttributeCoordinator: callForAssetAttributeCoordinator
+            )
+            return SubscribableAssetAttributeValue(subscribable: subscribable) as? T
         }
     }
 
@@ -88,6 +192,8 @@ enum AssetAttribute {
         switch self {
         case .direct(_, _, _, let bitmask, let bitShift), .mapping(_, _, _, _, let bitmask, let bitShift):
             return (bitmask & tokenValue) >> bitShift
+        case .function:
+            return nil
         }
     }
 
@@ -102,5 +208,17 @@ enum AssetAttribute {
             count += 1
         } while bitmask % (1 << count) == 0
         return count - 1
+    }
+
+    private func callSmartContractFunction(
+            forAttributeName attributeName: String,
+            tokenId: BigUInt,
+            functionCall: AssetAttributeFunctionCall,
+            callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator?
+    ) -> Subscribable<AssetAttributeValue> {
+        guard let callForAssetAttributeCoordinator = callForAssetAttributeCoordinator else {
+            return Subscribable<AssetAttributeValue>(nil)
+        }
+        return callForAssetAttributeCoordinator.getValue(forAttributeName: attributeName, tokenId: tokenId, functionCall: functionCall)
     }
 }

--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -20,7 +20,7 @@ class MigrationInitializer: Initializer {
     }
 
     func perform() {
-        config.schemaVersion = 49
+        config.schemaVersion = 50
         config.migrationBlock = { migration, oldSchemaVersion in
             if oldSchemaVersion < 33 {
                 migration.enumerateObjects(ofType: TokenObject.className()) { oldObject, newObject in

--- a/AlphaWallet/Extensions/String.swift
+++ b/AlphaWallet/Extensions/String.swift
@@ -73,6 +73,14 @@ extension String {
         }
     }
 
+    var dropParenthesis: String {
+        if hasSuffix("()") {
+            return String(dropLast(2))
+        } else {
+            return self
+        }
+    }
+
     func toInt() -> Int? {
         return Int(self) ?? nil
     }

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -31,6 +31,8 @@ enum Tabs {
 }
 
 class InCoordinator: Coordinator {
+    //TODO this is static and non-private so that we can update it from outside when the user switches wallet. Improve encapsulation. Maybe move it
+    static var callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator?
 
     private let initialWallet: Wallet
     private var config: Config
@@ -81,6 +83,7 @@ class InCoordinator: Coordinator {
         self.appTracker = appTracker
         self.assetDefinitionStore = assetDefinitionStore
         self.assetDefinitionStore.enableFetchXMLForContractInPasteboard()
+        enableAutoRefreshFunctionCallBasedAssetAttributesForAllTokens()
     }
 
     func start() {
@@ -126,6 +129,11 @@ class InCoordinator: Coordinator {
 
         let migration = MigrationInitializer(account: account, chainID: config.chainID)
         migration.perform()
+
+        //TODO this is bad because it is optional and effectively a global
+        if let tokensDataStore = createTokensDatastore() {
+            InCoordinator.callForAssetAttributeCoordinator = CallForAssetAttributeCoordinator(config: config, tokensDataStore: tokensDataStore)
+        }
 
         let web3 = self.web3()
         web3.start()
@@ -295,8 +303,10 @@ class InCoordinator: Coordinator {
         coordinator.stop()
         removeAllCoordinators()
         OpenSea.sharedInstance.reset()
+        InCoordinator.callForAssetAttributeCoordinator = nil
         showTabBar(for: account)
         fetchXMLAssetDefinitions()
+        refreshFunctionCallBasedAssetAttributesForAllTokens()
     }
 
     private func removeAllCoordinators() {
@@ -489,6 +499,29 @@ class InCoordinator: Coordinator {
     func addImported(contract: String) {
         let tokensCoordinator = coordinators.first { $0 is TokensCoordinator } as? TokensCoordinator
         tokensCoordinator?.addImportedToken(for: contract)
+    }
+
+    private func refreshFunctionCallBasedAssetAttributes(forToken token: TokenObject, withTokensDataStore tokensDataStore: TokensDataStore) {
+        guard let callForAssetAttributeCoordinator = InCoordinator.callForAssetAttributeCoordinator else { return }
+        callForAssetAttributeCoordinator.contractToRefetch = token.contract
+        TokenAdaptor(token: token).getTokenHolders()
+        callForAssetAttributeCoordinator.contractToRefetch = nil
+    }
+
+    //TODO auto refresh function-call-based asset attributes shouldn't be in InCoordinator
+    private func enableAutoRefreshFunctionCallBasedAssetAttributesForAllTokens() {
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshFunctionCallBasedAssetAttributesForAllTokens), name: .UIApplicationDidBecomeActive, object: nil)
+    }
+
+    //TODO the body of this function should be moved somewhere else
+    @objc private func refreshFunctionCallBasedAssetAttributesForAllTokens() {
+        //TODO this refresh mechanism isn't good
+        guard let tokensDataStore = createTokensDatastore() else { return }
+
+        //TODO should we check if no asset definition?
+        for each in tokensDataStore.objects {
+            refreshFunctionCallBasedAssetAttributes(forToken: each, withTokensDataStore: tokensDataStore)
+        }
     }
 }
 

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -294,10 +294,12 @@ class UniversalLinkCoordinator: Coordinator {
     private func makeTokenHolderImpl(name: String, bytes32Tokens: [String], contractAddress: String) {
         var tokens = [Token]()
         let xmlHandler = XMLHandler(contract: contractAddress)
+        //TODO should pass Config instance into this func instead
+        let config = Config()
         for i in 0..<bytes32Tokens.count {
             let token = bytes32Tokens[i]
             if let tokenId = BigUInt(token.drop0x, radix: 16) {
-                let token = xmlHandler.getToken(name: name, fromTokenId: tokenId, index: UInt16(i))
+                let token = xmlHandler.getToken(name: name, fromTokenId: tokenId, index: UInt16(i), config: config)
                 tokens.append(token)
             }
         }

--- a/AlphaWallet/Market/OrderHandler.swift
+++ b/AlphaWallet/Market/OrderHandler.swift
@@ -21,12 +21,17 @@ public struct SignedOrder {
 }
 
 extension String {
-    var hexa2Bytes: [UInt8] {
-        let hexa = Array(characters)
-        return stride(from: 0, to: count, by: 2).compactMap {
-            UInt8(String(hexa[$0..<$0.advanced(by: 2)]), radix: 16)
-        }
-    }
+	var hexa2Bytes: [UInt8] {
+		let hexa: Array<Character>
+		if count % 2 == 0 {
+			hexa = Array(characters)
+		} else {
+			hexa = Array(("0" + self).characters)
+		}
+		return stride(from: 0, to: count, by: 2).compactMap {
+			UInt8(String(hexa[$0..<$0.advanced(by: 2)]), radix: 16)
+		}
+	}
 }
 
 extension BinaryInteger {

--- a/AlphaWallet/RPC/Commands/web3swift-pod/CallForAssetAttribute.swift
+++ b/AlphaWallet/RPC/Commands/web3swift-pod/CallForAssetAttribute.swift
@@ -1,0 +1,55 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+
+struct CallForAssetAttribute {
+    enum SolidityType: String {
+        case bool
+        case int
+        case string
+        case uint256
+    }
+
+    struct Argument: Equatable {
+        let name: String
+        let type: SolidityType
+    }
+
+    struct ReturnType {
+        let type: SolidityType
+    }
+
+    static private let abiTemplate: [String: Any] = [
+        "type" : "function",
+        "name" : "<to provide>",
+        "inputs" : "<to provide>",
+        "outputs" : "<to provide>",
+        "payable" : false,
+        "stateMutability" : "view",
+        "constant" : true
+    ]
+
+    let abi: String
+    let name: String
+
+    init?(functionName: String, inputs: [Argument], output: ReturnType) {
+        var abiDictionary = CallForAssetAttribute.abiTemplate
+        abiDictionary["name" ] = functionName
+        abiDictionary["inputs"] = inputs.map {
+            [
+                "name": $0.name,
+                "type": $0.type.rawValue,
+            ]
+        }
+        abiDictionary["outputs"] = [
+            [
+                "name": "",
+                "type": output.type.rawValue,
+            ]
+        ] as Array<[String: String]>
+        name = functionName
+        guard let data = try? JSONSerialization.data(withJSONObject: abiDictionary, options: .prettyPrinted), let abi = String(data: data, encoding: .utf8) else { return nil}
+        self.abi = abi
+    }
+}
+

--- a/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
@@ -1,0 +1,157 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import BigInt
+import PromiseKit
+import Result
+import TrustKeystore
+import web3swift
+
+///This class uses 2 caches:
+///
+///1. Store the promises used to make function calls. This is so we don't make the same function calls (over network) + arguments combination multiple times concurrently. Once the call completes, we remove it from the cache.
+///2. Store function call result as a subscribable. This makes it easier to display the data fetched from the database as well as function call and when when a refresh (another function call) updates the value.
+class CallForAssetAttributeCoordinator {
+    private static var functionCallCache = [AssetAttributeFunctionCall: Subscribable<AssetAttributeValue>]()
+
+    private let config: Config
+    private var tokensDataStore: TokensDataStore
+    private var promiseCache = [AssetAttributeFunctionCall: Promise<AssetAttributeValue>]()
+
+    var contractToRefetch: String?
+
+    init(config: Config, tokensDataStore: TokensDataStore) {
+        self.config = config
+        self.tokensDataStore = tokensDataStore
+    }
+
+    //TODO too long
+    func getValue(
+            forAttributeName attributeName: String,
+            tokenId: BigUInt,
+            functionCall: AssetAttributeFunctionCall
+    ) -> Subscribable<AssetAttributeValue> {
+        let refreshContract = shouldRefresh(functionCall: functionCall)
+        let subscribable: Subscribable<AssetAttributeValue>
+        if let cachedResult = cache(forFunctionCall: functionCall) {
+            if refreshContract {
+                subscribable = cachedResult
+            } else {
+                return cachedResult
+            }
+        } else {
+            subscribable = Subscribable<AssetAttributeValue>(nil)
+        }
+
+        cache(functionCall: functionCall, result: subscribable)
+
+        if !refreshContract {
+            if let value = jsonAttributeValueInDatabase(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName) {
+                //Needed because types like NSTaggedPointerString and __NSCFBoolean (which are parsed from JSON) aren't convertible directly to AssetAttributeValue if we don't cast to String and Bool first
+                if let value = value as? Bool {
+                    subscribable.value = value
+                    return subscribable
+                } else if let value = value as? String {
+                    subscribable.value = value
+                    return subscribable
+                }
+            }
+        }
+
+        if promiseCache[functionCall] != nil {
+            return subscribable
+        }
+
+        let promise = Promise<AssetAttributeValue> { seal in
+            guard let contractAddress = EthereumAddress(functionCall.contract) else {
+                seal.reject(Web3Error(description: "Error converting contract address: \(functionCall.contract)"))
+                return
+            }
+
+            guard let webProvider = Web3HttpProvider(config.rpcURL, network: config.server.web3Network) else {
+                seal.reject(AnyError(Web3Error(description: "Error creating web provider for: \(config.rpcURL) + \(config.server.web3Network)")))
+                return
+            }
+
+            guard let function = CallForAssetAttribute(functionName: functionCall.functionName, inputs: functionCall.inputs, output: functionCall.output) else {
+                seal.reject(AnyError(Web3Error(description: "Failed to create CallForAssetAttribute instance for function: \(functionCall.functionName)")))
+                return
+            }
+
+            let web3 = web3swift.web3(provider: webProvider)
+            guard let contractInstance = web3swift.web3.web3contract(web3: web3, abiString: "[\(function.abi)]", at: contractAddress, options: web3.options) else {
+                seal.reject(AnyError(Web3Error(description: "Error creating web3swift contract instance to call \(function.name)()")))
+                return
+            }
+
+            guard let promise = contractInstance.method(function.name, parameters: functionCall.arguments, options: nil) else {
+                seal.reject(AnyError(Web3Error(description: "Error calling \(function.name)() on contract: \(functionCall.contract)")))
+                return
+            }
+
+            //Fine to store a strong reference to self here because it's still useful to cache the function call result
+            promise.callPromise(options: nil).done { dictionary in
+                if let value = dictionary["0"] {
+                    switch functionCall.output.type {
+                    case .bool:
+                        let result = value as? Bool ?? false
+                        seal.fulfill(result)
+                        self.updateDataStore(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName, value: result)
+                    case .string:
+                        let result = value as? String ?? ""
+                        seal.fulfill(result)
+                        self.updateDataStore(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName, value: result)
+                    case .int, .uint256:
+                        let result = value as? Int ?? 0
+                        seal.fulfill(result)
+                        self.updateDataStore(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName, value: result)
+                    }
+                } else {
+                    //TODO replace Web3Error here?
+                    seal.reject(Web3Error(description: "nil result from calling: \(function.name)() on contract: \(functionCall.contract)"))
+                }
+            }.catch { error in
+                seal.reject(AnyError(error))
+            }
+        }
+        promiseCache[functionCall] = promise
+
+        //TODO need to throttle smart contract function calls?
+        promise.done { [weak self] result in
+            guard let strongSelf = self else { return }
+            if let result = result as? AssetAttributeValue {
+                subscribable.value = result
+            }
+            strongSelf.promiseCache.removeValue(forKey: functionCall)
+        }.catch { [weak self] _ in
+            guard let strongSelf = self else { return }
+            strongSelf.promiseCache.removeValue(forKey: functionCall)
+        }
+
+        return subscribable
+    }
+
+    private func updateDataStore(forContract contract: String, tokenId: BigUInt, attributeName: String, value: AssetAttributeValue) {
+        tokensDataStore.update(contract: contract, tokenId: String(tokenId, radix: 16).add0x, action: .updateJsonProperty(attributeName, value))
+    }
+
+    private func jsonAttributeValueInDatabase(forContract contract: String, tokenId: BigUInt, attributeName: String) -> Any? {
+        return tokensDataStore.jsonAttributeValue(forContract: contract, tokenId: String(tokenId, radix: 16).add0x, attributeName: attributeName)
+    }
+
+    private func cache(functionCall: AssetAttributeFunctionCall, result: Subscribable<AssetAttributeValue>) {
+        CallForAssetAttributeCoordinator.functionCallCache[functionCall] = result
+    }
+
+    private func cache(forFunctionCall functionCall: AssetAttributeFunctionCall) -> Subscribable<AssetAttributeValue>? {
+        return CallForAssetAttributeCoordinator.functionCallCache[functionCall]
+    }
+
+    private func shouldRefresh(functionCall: AssetAttributeFunctionCall) -> Bool {
+        if let contractToRefetch = contractToRefetch, contractToRefetch.sameContract(as: functionCall.contract) {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -66,7 +66,12 @@ class TokenAdaptor {
     func bundle(tokens: [Token]) -> [TokenHolder] {
         switch token.type {
         case .ether, .erc20, .erc875:
-            break
+            //TODO handle bundling properly for meetup contracts
+            if !tokens.isEmpty && tokens[0].values["building"] != nil {
+                return tokens.map { getTokenHolder(for: [$0]) }
+            } else {
+                break
+            }
         case .erc721:
             return tokens.map { getTokenHolder(for: [$0]) }
         }

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -35,12 +35,14 @@ class TokenAdaptor {
     private func getNotSupportedByOpenSeaTokenHolders() -> [TokenHolder] {
         let balance = token.balance
         var tokens = [Token]()
+        //TODO should pass Config instance into this func instead
+        let config = Config()
         for (index, item) in balance.enumerated() {
             //id is the value of the bytes32 token
             let id = item.balance
             guard isNonZeroBalance(id) else { continue }
             if let tokenInt = BigUInt(id.drop0x, radix: 16) {
-                let token = getToken(name: self.token.name, for: tokenInt, index: UInt16(index))
+                let token = getToken(name: self.token.name, for: tokenInt, index: UInt16(index), config: config)
                 tokens.append(token)
             }
         }
@@ -131,8 +133,8 @@ class TokenAdaptor {
     }
 
     //TODO pass lang into here
-    private func getToken(name: String, for id: BigUInt, index: UInt16) -> Token {
-        return XMLHandler(contract: token.contract).getToken(name: name, fromTokenId: id, index: index)
+    private func getToken(name: String, for id: BigUInt, index: UInt16, config: Config) -> Token {
+        return XMLHandler(contract: token.contract).getToken(name: name, fromTokenId: id, index: index, config: config)
     }
 
     private func getTokenForOpenSeaNonFungible(forJSONString jsonString: String) -> Token? {

--- a/AlphaWallet/Tokens/Types/AssetAttributeFunctionCall.swift
+++ b/AlphaWallet/Tokens/Types/AssetAttributeFunctionCall.swift
@@ -1,0 +1,32 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+
+struct AssetAttributeFunctionCall: Equatable, Hashable {
+    let server: RPCServer
+    let contract: String
+    let functionName: String
+    let inputs: [CallForAssetAttribute.Argument]
+    let output: CallForAssetAttribute.ReturnType
+    let arguments: [AnyObject]
+    //To avoid handling Equatable and Hashable, we'll just store the arguments' description
+    private let argumentsDescription: String
+
+    var hashValue: Int {
+        return contract.hashValue ^ functionName.hashValue ^ inputs.count ^ output.type.rawValue.hashValue ^ argumentsDescription.hashValue ^ server.chainID
+    }
+
+    static func ==(lhs: AssetAttributeFunctionCall, rhs: AssetAttributeFunctionCall) -> Bool {
+        return lhs.contract == rhs.contract && lhs.functionName == rhs.functionName && lhs.inputs == rhs.inputs && lhs.output.type == rhs.output.type && lhs.argumentsDescription == rhs.argumentsDescription && lhs.server.chainID == rhs.server.chainID
+    }
+
+    init(server: RPCServer, contract: String, functionName: String, inputs: [CallForAssetAttribute.Argument], output: CallForAssetAttribute.ReturnType, arguments: [AnyObject]) {
+        self.server = server
+        self.contract = contract
+        self.functionName = functionName
+        self.inputs = inputs
+        self.output = output
+        self.arguments = arguments
+        self.argumentsDescription = arguments.description
+    }
+}

--- a/AlphaWallet/Tokens/Types/TokenBalance.swift
+++ b/AlphaWallet/Tokens/Types/TokenBalance.swift
@@ -2,14 +2,14 @@
 
 import Foundation
 import RealmSwift
-import BigInt
 
 class TokenBalance: Object {
     @objc dynamic var balance = "0"
+    @objc dynamic var json: String = "{}"
 
-    convenience init(balance: String = "0") {
+    convenience init(balance: String = "0", json: String = "{}") {
         self.init()
         self.balance = balance
+        self.json = json
     }
-
 }

--- a/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
+++ b/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
@@ -43,6 +43,18 @@ struct TokenCardRowViewModel: TokenCardRowViewModelProtocol {
         return value.formatAsShortDateString()
     }
 
+    //TODO example
+//    func subscribeDate(withBlock block: @escaping (String) -> ()) {
+//        if let subscribableAssetAttributeValue = tokenHolder.values["expired"] as? SubscribableAssetAttributeValue {
+//            subscribableAssetAttributeValue.subscribable.subscribe { value in
+//                if let value = value as? Bool {
+//                    //TODO: Remove this comment: Cast because of test and type doesn't match only. We know the type here
+//                    block("\(value)")
+//                }
+//            }
+//        }
+//    }
+
     var time: String {
         let value = tokenHolder.values["time"] as? GeneralisedTime ?? GeneralisedTime()
         return value.format("h:mm a")

--- a/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
+++ b/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
@@ -23,15 +23,32 @@ struct TokenCardRowViewModel: TokenCardRowViewModelProtocol {
         }
     }
 
+    //TODO should not check for the contract this way
+    var isMeetupContract: Bool {
+        return tokenHolder.values["building"] != nil
+    }
+
     var teams: String {
-        let countryA = tokenHolder.values["countryA"] as? String ?? ""
-        let countryB = tokenHolder.values["countryB"] as? String ?? ""
-        return R.string.localizable.aWalletTokenMatchVs(countryA, countryB)
+        if isMeetupContract && tokenHolder.values["expired"] != nil {
+            return ""
+        } else {
+            let countryA = tokenHolder.values["countryA"] as? String ?? ""
+            let countryB = tokenHolder.values["countryB"] as? String ?? ""
+            return R.string.localizable.aWalletTokenMatchVs(countryA, countryB)
+        }
     }
 
     var match: String {
-        let value = tokenHolder.values["match"] as? Int ?? 0
-        return "M\(value)"
+        if tokenHolder.values["section"] != nil {
+            if let section = tokenHolder.values["section"] as? Int {
+                return "S\(section)"
+            } else {
+                return "S0"
+            }
+        } else {
+            let value = tokenHolder.values["match"] as? Int ?? 0
+            return "M\(value)"
+        }
     }
 
     var venue: String {
@@ -43,17 +60,67 @@ struct TokenCardRowViewModel: TokenCardRowViewModelProtocol {
         return value.formatAsShortDateString()
     }
 
-    //TODO example
-//    func subscribeDate(withBlock block: @escaping (String) -> ()) {
-//        if let subscribableAssetAttributeValue = tokenHolder.values["expired"] as? SubscribableAssetAttributeValue {
-//            subscribableAssetAttributeValue.subscribable.subscribe { value in
-//                if let value = value as? Bool {
-//                    //TODO: Remove this comment: Cast because of test and type doesn't match only. We know the type here
-//                    block("\(value)")
-//                }
-//            }
-//        }
-//    }
+    func subscribeExpired(withBlock block: @escaping (String) -> ()) {
+        guard isMeetupContract else { return }
+        if let subscribableAssetAttributeValue = tokenHolder.values["expired"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let expired = value as? Bool {
+                    if expired {
+                        block("Expired")
+                    } else {
+                        block("Not expired")
+                    }
+                }
+            }
+        }
+    }
+
+    func subscribeBuilding(withBlock block: @escaping (String) -> ()) {
+        if let subscribableAssetAttributeValue = tokenHolder.values["building"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    block(value)
+                }
+            }
+        }
+    }
+
+    func subscribeStreetStateCountry(withBlock block: @escaping (String) -> ()) {
+        func updateStreetStateCountry(street: String?, state: String?, country: String?) {
+            let values = [street, state, country].compactMap { $0 }
+            let string = values.joined(separator: ", ")
+            block(string)
+        }
+        if let subscribableAssetAttributeValue = tokenHolder.values["street"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    updateStreetStateCountry(
+                            street: value,
+                            state: (self.tokenHolder.values["state"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                            country: self.tokenHolder.values["country"] as? String
+                    )
+                }
+            }
+        }
+        if let subscribableAssetAttributeValue = tokenHolder.values["state"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    updateStreetStateCountry(
+                            street: (self.tokenHolder.values["street"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                            state: value,
+                            country: self.tokenHolder.values["country"] as? String
+                    )
+                }
+            }
+        }
+        if let country = tokenHolder.values["country"] as? String {
+            updateStreetStateCountry(
+                    street: (self.tokenHolder.values["street"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                    state: (self.tokenHolder.values["state"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                    country: country
+            )
+        }
+    }
 
     var time: String {
         let value = tokenHolder.values["time"] as? GeneralisedTime ?? GeneralisedTime()

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -171,13 +171,6 @@ class TokenCardRowView: UIView {
 		venueLabel.text = viewModel.venue
 
 		dateLabel.text = viewModel.date
-        //TODO: this is how to use it
-//		if let vm = viewModel as? TokenCardRowViewModel {
-//			vm.subscribeDate { [weak self] date in
-//				guard let strongSelf = self else { return }
-//				strongSelf.dateLabel.text = date
-//			}
-//		}
 
 		timeLabel.text = viewModel.time
 
@@ -190,6 +183,23 @@ class TokenCardRowView: UIView {
 		matchLabel.text = viewModel.match
 
 		onlyShowTitle = viewModel.onlyShowTitle
+
+		if let vm = viewModel as? TokenCardRowViewModel {
+			vm.subscribeBuilding { [weak self] building in
+				guard let strongSelf = self else { return }
+				strongSelf.categoryLabel.text = building
+			}
+
+			vm.subscribeExpired { [weak self] expired in
+				guard let strongSelf = self else { return }
+				strongSelf.teamsLabel.text = expired
+			}
+
+			vm.subscribeStreetStateCountry{ [weak self] streetStateCountry in
+				guard let strongSelf = self else { return }
+				strongSelf.venueLabel.text = streetStateCountry
+			}
+		}
 
 		adjustmentsToHandleWhenCategoryLabelTextIsTooLong()
 	}

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -171,6 +171,13 @@ class TokenCardRowView: UIView {
 		venueLabel.text = viewModel.venue
 
 		dateLabel.text = viewModel.date
+        //TODO: this is how to use it
+//		if let vm = viewModel as? TokenCardRowViewModel {
+//			vm.subscribeDate { [weak self] date in
+//				guard let strongSelf = self else { return }
+//				strongSelf.dateLabel.text = date
+//			}
+//		}
 
 		timeLabel.text = viewModel.time
 

--- a/AlphaWalletTests/AssetDefinition/XMLHandlerTest.swift
+++ b/AlphaWalletTests/AssetDefinition/XMLHandlerTest.swift
@@ -18,7 +18,8 @@ class XMLHandlerTest: XCTestCase {
         let token = XMLHandler(contract: "0x").getToken(
                 name: "",
                 fromTokenId: BigUInt(tokenHex, radix: 16)!,
-                index: UInt16(1)
+                index: UInt16(1),
+                config: .make()
         )
         XCTAssertNotNil(token)
     }


### PR DESCRIPTION
@James-Sangalli: This PR includes the commit in PR #882 in order to support namespaces, so #882 
should be merged first and this PR rebased (or updated) before merging.

@colourful-land you might be interested in: (A), (C) and (D).

This PR adds support for the standard spawnable meetup contract:

1. Calls smart contract functions to retrieve asset attribute values
2. Display most fields in the spawnable meetup contract

To add these quickly, there are a few limitations that should be fixed or improved in the near future:

1. The function-call-based asset attributes are only refreshed when the app is launched or becomes active
2. The token bundles displayed on the current screen don't automatically refresh when the function-call-based asset attributes changes. It does reflect the updated values if you go back and display the screen again. (doesn't affect the spawnable meetup contract because bundling is disabled)
3. Function calls aren't throttled
4. It doesn't reload values immediately when the asset definition changes
5. Bundling is disabled for the meetup contract

I noticed a few things:

A. The signature includes this: `<ds:KeyName>Shankai</ds:KeyName>` so the token card displays `Shankai` as the issuer
B. The static attributes stored in the token IDs in the contract are all 0-values except `section`
C. I've changed `category` and `section` to syntax="1.3.6.1.4.1.1466.115.121.1.27" to get them to be parsed correctly based on the value extracted from the token IDs. @James-Sangalli This might not be correct because we might have intended for the token IDs to have encode the category and section as ascii instead. Especially because the bitmask looks quite long for both category and section
D. The asset definition in the old repo (I couldn't access the new repo) is outdated. I've tested by modifying the function-based attributes to (note that the function name of the deployed code is `getBuilding`, not `getBuildingName`):

```
    <attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> 
      <origin contract="holding-contract"> 
        <function>isExpired(<value ref="tokenID">uint256</value>)</function> 
      </origin> 
    </attribute-type> 
    <attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15"> 
      <origin contract="holding-contract"> 
        <function>getStreet(<value ref="tokenID">uint256</value>)</function> 
      </origin> 
    </attribute-type> 
    <attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.15"> 
      <origin contract="holding-contract"> 
        <function>getBuilding(<value ref="tokenID">uint256</value>)</function> 
      </origin> 
    </attribute-type> 
    <attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.15"> 
      <origin contract="holding-contract"> 
        <function>getState(<value ref="tokenID">uint256</value>)</function> 
      </origin> 
    </attribute-type> 
```

Output like this:

![simulator screen shot - iphone x - 2018-11-09 at 06 48 18](https://user-images.githubusercontent.com/56189/48232101-7ab06380-e3eb-11e8-9c41-d9cb76de7a6f.png)