### PR TITLE
Update XML parsing to handle latest asset definition schema

### DIFF
--- a/AlphaWallet/AssetDefinition/XMLHandler.swift
+++ b/AlphaWallet/AssetDefinition/XMLHandler.swift
@@ -89,7 +89,7 @@ private class PrivateXMLHandler {
         let lang = getLang()
         var fields = [String: AssetAttribute]()
         for e in xml["\(rootNamespacePrefix)token"]["\(rootNamespacePrefix)attribute-types"]["\(rootNamespacePrefix)attribute-type"] {
-            if let id = e.attributes["id"], case let .singleElement(element) = e, XML.Accessor(element)["\(rootNamespacePrefix)origin"].attributes["as"] != nil {
+            if let id = e.attributes["id"], case let .singleElement(element) = e, XML.Accessor(element)["\(rootNamespacePrefix)origin"].attributes["bitmask"] != nil {
                 fields[id] = AssetAttribute(attribute: element, rootNamespacePrefix: rootNamespacePrefix, lang: lang)
             } else if let id = e.attributes["id"], case let .singleElement(element) = e, XML.Accessor(element)["\(rootNamespacePrefix)origin"].attributes["contract"] == "holding-contract" {
                 fields[id] = AssetAttribute(attribute: element, rootNamespacePrefix: rootNamespacePrefix)

--- a/AlphaWallet/RPC/Commands/web3swift-pod/CallForAssetAttribute.swift
+++ b/AlphaWallet/RPC/Commands/web3swift-pod/CallForAssetAttribute.swift
@@ -4,10 +4,24 @@ import Foundation
 
 struct CallForAssetAttribute {
     enum SolidityType: String {
+        //TODO do we need to support the "odd" ones like uint24 in all steps of 8?
+        //TODO support address, enums, etc?
         case bool
         case int
-        case string
+        case int8
+        case int16
+        case int32
+        case int64
+        case int128
+        case int256
+        case uint
+        case uint8
+        case uint16
+        case uint32
+        case uint64
+        case uint128
         case uint256
+        case string
     }
 
     struct Argument: Equatable {

--- a/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
@@ -101,7 +101,7 @@ class CallForAssetAttributeCoordinator {
                         let result = value as? String ?? ""
                         seal.fulfill(result)
                         self.updateDataStore(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName, value: result)
-                    case .int, .uint256:
+                    case .int, .int8, .int16, .int32, .int64, .int128, .int256, .uint, .uint8, .uint16, .uint32, .uint64, .uint128, .uint256:
                         let result = value as? Int ?? 0
                         seal.fulfill(result)
                         self.updateDataStore(forContract: functionCall.contract, tokenId: tokenId, attributeName: attributeName, value: result)

--- a/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
+++ b/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
@@ -75,6 +75,17 @@ struct TokenCardRowViewModel: TokenCardRowViewModelProtocol {
         }
     }
 
+    func subscribeLocality(withBlock block: @escaping (String) -> ()) {
+        guard isMeetupContract else { return }
+        if let subscribableAssetAttributeValue = tokenHolder.values["locality"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    block(value)
+                }
+            }
+        }
+    }
+
     func subscribeBuilding(withBlock block: @escaping (String) -> ()) {
         if let subscribableAssetAttributeValue = tokenHolder.values["building"] as? SubscribableAssetAttributeValue {
             subscribableAssetAttributeValue.subscribable.subscribe { value in

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -190,6 +190,11 @@ class TokenCardRowView: UIView {
 				strongSelf.categoryLabel.text = building
 			}
 
+			vm.subscribeLocality { [weak self] locality in
+				guard let strongSelf = self else { return }
+				strongSelf.cityLabel.text = ", \(locality)"
+			}
+
 			vm.subscribeExpired { [weak self] expired in
 				guard let strongSelf = self else { return }
 				strongSelf.teamsLabel.text = expired


### PR DESCRIPTION
This PR updates XML parsing the handle the asset definitions in https://github.com/AlphaWallet/contracts/pull/86/commits/c6a1ad04ff286b532220866be9eb4035fb99043b

I tested this by downloading the 3 XMLs into the `assetDefinitionsOverrides/` directory and then renaming them to the appropriate contracts.

Might be good to update the contract (I tested against `0x16e58F9a98bc46a572CFb9ce28DDEeaf76AF645a`) based on the spawnable meetup contract XML to have a couple more tokens with various fields encoded in the token ID to see if that works.

Might have to wait till https://github.com/AlphaWallet/contracts/pull/86/commits/c6a1ad04ff286b532220866be9eb4035fb99043b is finalised to merge. cc @colourful-land 