### PR TITLE
Fix: import screen for spawnable token not displaying attribute values

### DIFF
--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenCardRowViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenCardRowViewModel.swift
@@ -44,4 +44,85 @@ struct ImportMagicTokenCardRowViewModel: TokenCardRowViewModelProtocol {
     var onlyShowTitle: Bool {
         return importMagicTokenViewControllerViewModel.onlyShowTitle
     }
+
+    //TODO should not check for the contract this way
+    var isMeetupContract: Bool {
+        return importMagicTokenViewControllerViewModel.tokenHolder?.values["building"] != nil
+    }
+
+    func subscribeExpired(withBlock block: @escaping (String) -> ()) {
+        guard isMeetupContract else { return }
+        if let subscribableAssetAttributeValue = importMagicTokenViewControllerViewModel.tokenHolder?.values["expired"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let expired = value as? Bool {
+                    if expired {
+                        block("Expired")
+                    } else {
+                        block("Not expired")
+                    }
+                }
+            }
+        }
+    }
+
+    func subscribeLocality(withBlock block: @escaping (String) -> ()) {
+        guard isMeetupContract else { return }
+        if let subscribableAssetAttributeValue = importMagicTokenViewControllerViewModel.tokenHolder?.values["locality"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    block(value)
+                }
+            }
+        }
+    }
+
+    func subscribeBuilding(withBlock block: @escaping (String) -> ()) {
+        if let subscribableAssetAttributeValue = importMagicTokenViewControllerViewModel.tokenHolder?.values["building"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                if let value = value as? String {
+                    block(value)
+                }
+            }
+        }
+    }
+
+    func subscribeStreetStateCountry(withBlock block: @escaping (String) -> ()) {
+        func updateStreetStateCountry(street: String?, state: String?, country: String?) {
+            let values = [street, state, country].compactMap { $0 }
+            let string = values.joined(separator: ", ")
+            block(string)
+        }
+        if let subscribableAssetAttributeValue = importMagicTokenViewControllerViewModel.tokenHolder?.values["street"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                guard let tokenHolder = self.importMagicTokenViewControllerViewModel.tokenHolder else { return }
+                if let value = value as? String {
+                    updateStreetStateCountry(
+                            street: value,
+                            state: (tokenHolder.values["state"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                            country: tokenHolder.values["country"] as? String
+                    )
+                }
+            }
+        }
+        if let subscribableAssetAttributeValue = importMagicTokenViewControllerViewModel.tokenHolder?.values["state"] as? SubscribableAssetAttributeValue {
+            subscribableAssetAttributeValue.subscribable.subscribe { value in
+                guard let tokenHolder = self.importMagicTokenViewControllerViewModel.tokenHolder else { return }
+                if let value = value as? String {
+                    updateStreetStateCountry(
+                            street: (tokenHolder.values["street"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                            state: value,
+                            country: tokenHolder.values["country"] as? String
+                    )
+                }
+            }
+        }
+        if let country = importMagicTokenViewControllerViewModel.tokenHolder?.values["country"] as? String {
+            guard let tokenHolder = self.importMagicTokenViewControllerViewModel.tokenHolder else { return }
+            updateStreetStateCountry(
+                    street: (tokenHolder.values["street"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                    state: (tokenHolder.values["state"] as? SubscribableAssetAttributeValue)?.subscribable.value as? String,
+                    country: country
+            )
+        }
+    }
 }

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -184,7 +184,28 @@ class TokenCardRowView: UIView {
 
 		onlyShowTitle = viewModel.onlyShowTitle
 
+        //TODO this if-else-if is so easy to miss implementing either the if(s) because we aren't taking advantage of type-checking
 		if let vm = viewModel as? TokenCardRowViewModel {
+			vm.subscribeBuilding { [weak self] building in
+				guard let strongSelf = self else { return }
+				strongSelf.categoryLabel.text = building
+			}
+
+			vm.subscribeLocality { [weak self] locality in
+				guard let strongSelf = self else { return }
+				strongSelf.cityLabel.text = ", \(locality)"
+			}
+
+			vm.subscribeExpired { [weak self] expired in
+				guard let strongSelf = self else { return }
+				strongSelf.teamsLabel.text = expired
+			}
+
+			vm.subscribeStreetStateCountry{ [weak self] streetStateCountry in
+				guard let strongSelf = self else { return }
+				strongSelf.venueLabel.text = streetStateCountry
+			}
+		} else if let vm = viewModel as? ImportMagicTokenCardRowViewModel {
 			vm.subscribeBuilding { [weak self] building in
 				guard let strongSelf = self else { return }
 				strongSelf.categoryLabel.text = building


### PR DESCRIPTION
For #896 

(Note to self: The problem is that while the token card view is shared across many screens in the app, the version in the import screen is slightly different (because it doesn't always have a TokenHolder). So it's easy to change one and forget to change the other. And this has happened to me at least once previously.

Have to come back and figure out how to make this take advantage of strong-typing to catch it.)