### PR TITLE
Fix broken tests on Travis (and switching to using a fork of TrezorCrypto pod for more control)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,6 +24,7 @@ target 'AlphaWallet' do
   pod 'SwiftyXMLParser', :git => 'https://github.com/yahoojapan/SwiftyXMLParser.git'
   pod 'Kingfisher', '~> 4.0'
   pod 'TrustWeb3Provider', :git=>'https://github.com/alpha-wallet/dapp-web3-provider', :branch => 'nervos-dist'
+  pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/alpha-wallet/trust-keystore.git', :commit => '9abdc1a63f1baf17facb26a3e049b5e335a95816'
   pod 'SwiftyJSON'
   pod 'web3swift', :git => 'https://github.com/alpha-wallet/web3swift.git', :commit => '2b3c5ee878212ce70768568def7e727f0f1ebf86'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -63,7 +63,7 @@ PODS:
   - SwiftyJSON (4.0.0)
   - SwiftyXMLParser (4.1.0)
   - SWXMLHash (4.7.1)
-  - TrezorCrypto (0.0.8)
+  - TrezorCrypto (0.0.9)
   - TrustKeystore (0.1.3):
     - CryptoSwift (~> 0.10.0)
     - secp256k1_ios (~> 0.1.0)
@@ -105,6 +105,7 @@ DEPENDENCIES:
   - SwiftLint
   - SwiftyJSON
   - SwiftyXMLParser (from `https://github.com/yahoojapan/SwiftyXMLParser.git`)
+  - TrezorCrypto (from `https://github.com/AlphaWallet/trezor-crypto-ios.git`, commit `50c16ba5527e269bbc838e80aee5bac0fe304cc7`)
   - TrustKeystore (from `https://github.com/alpha-wallet/trust-keystore.git`, commit `9abdc1a63f1baf17facb26a3e049b5e335a95816`)
   - TrustWeb3Provider (from `https://github.com/alpha-wallet/dapp-web3-provider`, branch `nervos-dist`)
   - web3swift (from `https://github.com/alpha-wallet/web3swift.git`, commit `2b3c5ee878212ce70768568def7e727f0f1ebf86`)
@@ -142,7 +143,6 @@ SPEC REPOS:
     - SwiftLint
     - SwiftyJSON
     - SWXMLHash
-    - TrezorCrypto
 
 EXTERNAL SOURCES:
   Macaw:
@@ -153,6 +153,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/yannickl/QRCodeReaderViewController.git
   SwiftyXMLParser:
     :git: https://github.com/yahoojapan/SwiftyXMLParser.git
+  TrezorCrypto:
+    :commit: 50c16ba5527e269bbc838e80aee5bac0fe304cc7
+    :git: https://github.com/AlphaWallet/trezor-crypto-ios.git
   TrustKeystore:
     :commit: 9abdc1a63f1baf17facb26a3e049b5e335a95816
     :git: https://github.com/alpha-wallet/trust-keystore.git
@@ -173,6 +176,9 @@ CHECKOUT OPTIONS:
   SwiftyXMLParser:
     :commit: 1ddcad0a09efb85f2325d994c2169cd9ba116ae3
     :git: https://github.com/yahoojapan/SwiftyXMLParser.git
+  TrezorCrypto:
+    :commit: 50c16ba5527e269bbc838e80aee5bac0fe304cc7
+    :git: https://github.com/AlphaWallet/trezor-crypto-ios.git
   TrustKeystore:
     :commit: 9abdc1a63f1baf17facb26a3e049b5e335a95816
     :git: https://github.com/alpha-wallet/trust-keystore.git
@@ -218,11 +224,11 @@ SPEC CHECKSUMS:
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
   SwiftyXMLParser: b5a79fb8a730903703d0a92d30752a0b05158967
   SWXMLHash: 661b67bc94a01fe71a6ad4ca690cf2cafa5d1d6f
-  TrezorCrypto: 938c4b715fff7824a9c891a105e65ee0e4e81662
+  TrezorCrypto: bfeea47a052dca2c77d4a39e1e183865e52de14d
   TrustKeystore: 26efa8079f6451d02ce64b906d3ff240fd71d7ca
   TrustWeb3Provider: 50fa391bdf170feb43dd4419992931510a5751d8
   web3swift: ec721fe509a4b3ca7abdf027d186d07fce65be8f
 
-PODFILE CHECKSUM: 5f466c536c14e9c8f9d033b78ce18bfa41c167b1
+PODFILE CHECKSUM: 42d64abd066342d6529b93feae6fe5984ceace25
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
The author deleted the version (0.0.8) of the pod we are using (really uncommmon and shouldn't be done unless something horrible happened. But every old version was removed..). This situation is bad because we were forced to update the version of the pod we use. It also broke Travis, which couldn't find the pod.

This PR:

1. Forks the repo and use it instead
2. Increases the version from 0.0.8 to 0.0.9 anyway. Had wanted to stick with 0.0.8 with the fork, but can't find the commit (I suppose the pod author must have forced push at some point so pod v0.0.8 and pod v0.0.8 in the repo wasn't exactly the same). We can still use 0.0.8 in the fork, but since both 0.0.8 (in the repo) and 0.0.9 wasn't tested against previously, might as well up version from 0.0.8 -> 0.0.9

With the added maintenance of the fork (we might choose to just pull from upstream and make no changes, then minimal work), at least this wouldn't happen again.