### PR TITLE
Don't (offer to) autocorrect or autocapitalize in address textfields.

### DIFF
--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -111,6 +111,8 @@ class AddressTextField: UIControl {
         textField.layer.borderColor = Colors.appBackground.cgColor
         textField.layer.borderWidth = 1
         textField.placeholder = "Ethereum address or ENS name"
+        textField.autocapitalizationType = .none
+        textField.autocorrectionType = .no
     }
 
     private func makeTargetAddressRightView() -> UIView {


### PR DESCRIPTION
Especially since we allow entering of ENS names now.