### PR TITLE
set limit to geth default

### DIFF
--- a/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
@@ -6,5 +6,5 @@ import BigInt
 public struct GasLimitConfiguration {
     static let `default` = BigInt(90_000)
     static let min = BigInt(21_000)
-    static let max = BigInt(300_000)
+    static let max = BigInt(4_712_388) //geth default limit
 }

--- a/AlphaWalletTests/Transfer/Types/GasLimitConfigurationTests.swift
+++ b/AlphaWalletTests/Transfer/Types/GasLimitConfigurationTests.swift
@@ -9,6 +9,6 @@ class GasLimitConfigurationTests: XCTestCase {
     func testDefault() {
         XCTAssertEqual(BigInt(90000), GasLimitConfiguration.default)
         XCTAssertEqual(BigInt(21000), GasLimitConfiguration.min)
-        XCTAssertEqual(BigInt(300000), GasLimitConfiguration.max)
+        XCTAssertEqual(BigInt(4712388), GasLimitConfiguration.max)
     }
 }


### PR DESCRIPTION
Sets the limit to the geth limit rather than an arbitrary number.

As for #912, I believe this is actually the dapp not the app, our app gets the gas price from the dapp itself when using the browser. Not sure how @JamesSmartCell does it in android. 