### PR TITLE
add functions to allow for spawnable token transactions

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -397,6 +397,7 @@ class InCoordinator: Coordinator {
         let v = UInt8(signature.substring(from: 128), radix: 16)!
         let r = "0x" + signature.substring(with: Range(uncheckedBounds: (0, 64)))
         let s = "0x" + signature.substring(with: Range(uncheckedBounds: (64, 128)))
+        guard let wallet = keystore.recentlyUsedWallet else { return }
 
         ClaimOrderCoordinator(web3: web3).claimOrder(
                 signedOrder: signedOrder,
@@ -404,8 +405,10 @@ class InCoordinator: Coordinator {
                 v: v,
                 r: r,
                 s: s,
-                contractAddress: signedOrder.order.contractAddress) { result in
-            let strongSelf = self //else { return }
+                contractAddress: signedOrder.order.contractAddress,
+                recipient: wallet.address.eip55String
+        ) { result in
+            let strongSelf = self
             switch result {
             case .success(let payload):
                 let address: Address = strongSelf.initialWallet.address

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -147,10 +147,16 @@ class UniversalLinkCoordinator: Coordinator {
                     return
                 }
                 //filter null tokens
-                let filteredTokens = strongSelf.checkERC875TokensAreAvailable(
+                var filteredTokens = strongSelf.checkERC875TokensAreAvailable(
                         indices: signedOrder.order.indices,
                         balance: balance
                 )
+
+                //if the token is spawnable then let it continue
+                if signedOrder.order.spawnable, let tokens = signedOrder.order.tokenIds {
+                    filteredTokens.append(tokens[0].description)
+                }
+
                 if filteredTokens.isEmpty {
                     strongSelf.showImportError(errorMessage: R.string.localizable.aClaimTokenInvalidLinkTryAgain())
                     return

--- a/AlphaWallet/Market/MarketQueueHandler.swift
+++ b/AlphaWallet/Market/MarketQueueHandler.swift
@@ -59,7 +59,8 @@ public class MarketQueueHandler {
                 contractAddress: contractAddress,
                 start: BigUInt(orderObj["start"].string!)!,
                 count: orderObj["count"].intValue,
-                tokenIds: [BigUInt]()
+                tokenIds: [BigUInt](),
+                spawnable: false
         )
         let signedOrder = SignedOrder(
                 order: order,

--- a/AlphaWallet/Market/OrderHandler.swift
+++ b/AlphaWallet/Market/OrderHandler.swift
@@ -12,6 +12,7 @@ public struct Order {
     var start: BigUInt
     var count: Int
     var tokenIds: [BigUInt]?
+    var spawnable: Bool
 }
 
 public struct SignedOrder {

--- a/AlphaWallet/Market/UniversalLinkHandler.swift
+++ b/AlphaWallet/Market/UniversalLinkHandler.swift
@@ -105,7 +105,8 @@ public class UniversalLinkHandler {
                 contractAddress: contractAddress,
                 start: BigUInt("0")!,
                 count: tokenIndices.count,
-                tokenIds: []
+                tokenIds: [],
+                spawnable: false
         )
         let message = getMessageFromOrder(order: order)
         return SignedOrder(order: order, message: message, signature: "0x" + r + s + v)
@@ -126,7 +127,8 @@ public class UniversalLinkHandler {
             contractAddress: contractAddress,
             start: BigUInt(0),
             count: tokenIds.count,
-            tokenIds: tokenIds
+            tokenIds: tokenIds,
+            spawnable: true
         )
         let message = getMessageFromOrder(order: order)
         return SignedOrder(order: order, message: message, signature: "0x" + r + s + v)

--- a/AlphaWallet/RPC/Commands/web3wift-web3js/ClaimERC875Order.swift
+++ b/AlphaWallet/RPC/Commands/web3wift-web3js/ClaimERC875Order.swift
@@ -43,14 +43,15 @@ struct ClaimERC875Order: Web3Request {
 
 struct ClaimERC875Spawnable: Web3Request {
     typealias Response = String
-    let tokenIds: [BigUInt]
+    let tokenIds: [String]
     let v: UInt8
     let r: String
     let s: String
     let expiry: BigUInt
+    let recipient: String
 
     var type: Web3RequestType {
-        let abi = "{\"constant\":false,\"inputs\":[{\"name\":\"expiry\",\"type\":\"uint256\"},{\"name\":\"tokenIds\",\"type\":\"uint256[]\"},{\"name\":\"v\",\"type\":\"uint8\"},{\"name\":\"r\",\"type\":\"uint256\"},{\"name\":\"s\",\"type\":\"uint256\"}],\"name\":\"passToSpawnable\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"}, [\"\(expiry)\", \(tokenIds), \(v), \"\(r)\", \"\(s)\"]"
+        let abi = "{ \"constant\": false, \"inputs\": [ { \"name\": \"expiry\", \"type\": \"uint256\" }, { \"name\": \"tickets\", \"type\": \"uint256[]\" }, { \"name\": \"v\", \"type\": \"uint8\" }, { \"name\": \"r\", \"type\": \"bytes32\" }, { \"name\": \"s\", \"type\": \"bytes32\" }, { \"name\": \"recipient\", \"type\": \"address\" } ], \"name\": \"spawnPassTo\", \"outputs\": [], \"payable\": false, \"stateMutability\": \"nonpayable\", \"type\": \"function\" }, [\"\(expiry)\", \(tokenIds), \(v), \"\(r)\", \"\(s)\", \"\(recipient)\"]"
         let run = "web3.eth.abi.encodeFunctionCall(" + abi + ")"
         return .script(command: run)
     }

--- a/AlphaWallet/Tokens/Coordinators/ClaimOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimOrderCoordinator.swift
@@ -26,11 +26,12 @@ class ClaimOrderCoordinator {
                     r: String,
                     s: String,
                     contractAddress: String,
+                    recipient: String,
                     completion: @escaping (Result<String, AnyError>) -> Void
         ) {
 
         if let tokenIds = signedOrder.order.tokenIds, !tokenIds.isEmpty {
-            claimSpawnableOrder(expiry: expiry, tokenIds: tokenIds, v: v, r: r, s: s) { result in
+            claimSpawnableOrder(expiry: expiry, tokenIds: tokenIds, v: v, r: r, s: s, recipient: recipient) { result in
                 completion(result)
             }
         } else {
@@ -66,8 +67,15 @@ class ClaimOrderCoordinator {
                              v: UInt8,
                              r: String,
                              s: String,
+                             recipient: String,
                              completion: @escaping (Result<String, AnyError>) -> Void) {
-        let request = ClaimERC875Spawnable(tokenIds: tokenIds, v: v, r: r, s: s, expiry: expiry)
+        var tokenStrings = [String]()
+        //conversion from BigUInt fails in abi encoding
+        for i in 0..<tokenIds.count {
+            let tokenHex = MarketQueueHandler.bytesToHexa(tokenIds[i].serialize().array)
+            tokenStrings.append(tokenHex)
+        }
+        let request = ClaimERC875Spawnable(tokenIds: tokenStrings, v: v, r: r, s: s, expiry: expiry, recipient: recipient)
         web3.request(request: request) { result in
             switch result {
             case .success(let res):

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -284,7 +284,8 @@ class TokensCardCoordinator: NSObject, Coordinator {
             contractAddress: tokenHolder.contractAddress,
             start: BigUInt("0")!,
             count: tokenHolder.indices.count,
-            tokenIds: [BigUInt]()
+            tokenIds: [BigUInt](),
+            spawnable: false
         )
         let orders = [order]
         let address = keystore.recentlyUsedWallet?.address
@@ -308,7 +309,8 @@ class TokensCardCoordinator: NSObject, Coordinator {
                 contractAddress: tokenHolder.contractAddress,
                 start: BigUInt("0")!,
                 count: tokenHolder.indices.count,
-                tokenIds: [BigUInt]()
+                tokenIds: [BigUInt](),
+                spawnable: false
         )
         let orders = [order]
         let address = keystore.recentlyUsedWallet?.address

--- a/AlphaWallet/Transactions/Coordinators/TrustProvider.swift
+++ b/AlphaWallet/Transactions/Coordinators/TrustProvider.swift
@@ -5,14 +5,8 @@ import Foundation
 import Moya
 
 struct TrustProviderFactory {
-    static let policies: [String: ServerTrustPolicy] = [
+    static let policies: [String: ServerAlphaWalletPolicy] = [
         :
-//        Disabled until: https://github.com/TrustWallet/trust-wallet-ios/pull/129#issuecomment-353718512
-//        "trustwalletapp.com": .pinPublicKeys(
-//            publicKeys: ServerTrustPolicy.publicKeys(in: Bundle.main),
-//            validateCertificateChain: true,
-//            validateHost: true
-//        ),
     ]
 
     static func makeProvider() -> MoyaProvider<TrustService> {


### PR DESCRIPTION
Before this PR we could not accept spawnable links from Peter's tool because it checked for a balance which does not exist for spawnable tokens. The function calls to the contract were also out of date and incompatible. 

Note: we seem to have an issue with exceeding gas limits for magic links. I noticed this when importing both a spawnable and non spawnable token link...