### PR TITLE
Update web3 provider so that isAlphaWallet flag is set to true

### DIFF
--- a/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
+++ b/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
@@ -78,8 +78,6 @@ extension WKWebViewConfiguration {
         web3.eth.getCoinbase = function(cb) {
             return cb(null, addressHex)
         }
-        web3.currentProvider.isAlphaWallet = false
-
         """
         let userScript = WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         webViewConfig.userContentController.add(messageHandler, name: Method.signTransaction.rawValue)

--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ target 'AlphaWallet' do
   pod 'CryptoSwift'
   pod 'SwiftyXMLParser', :git => 'https://github.com/yahoojapan/SwiftyXMLParser.git'
   pod 'Kingfisher', '~> 4.0'
-  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => '63c55489c49c63ed4543b7a21563ef77eeb3c7e0'
+  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => 'f25206c50009d1eb922c3cc8c0ba91594155e8b6'
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/alpha-wallet/trust-keystore.git', :commit => '9abdc1a63f1baf17facb26a3e049b5e335a95816'
   pod 'SwiftyJSON'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -80,7 +80,7 @@ PODS:
     - secp256k1_ios (~> 0.1.3)
 
 DEPENDENCIES:
-  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `63c55489c49c63ed4543b7a21563ef77eeb3c7e0`)
+  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `f25206c50009d1eb922c3cc8c0ba91594155e8b6`)
   - APIKit
   - AWSSNS
   - BigInt (~> 3.0)
@@ -146,7 +146,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
-    :commit: 63c55489c49c63ed4543b7a21563ef77eeb3c7e0
+    :commit: f25206c50009d1eb922c3cc8c0ba91594155e8b6
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Macaw:
     :commit: c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8
@@ -168,7 +168,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AlphaWalletWeb3Provider:
-    :commit: 63c55489c49c63ed4543b7a21563ef77eeb3c7e0
+    :commit: f25206c50009d1eb922c3cc8c0ba91594155e8b6
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Macaw:
     :commit: c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8
@@ -229,6 +229,6 @@ SPEC CHECKSUMS:
   TrustKeystore: 26efa8079f6451d02ce64b906d3ff240fd71d7ca
   web3swift: ec721fe509a4b3ca7abdf027d186d07fce65be8f
 
-PODFILE CHECKSUM: b1a0899658002a573c641f65e1d16556e8daa59f
+PODFILE CHECKSUM: 60bd42079815449bfc0a86db9f656b1f7ec2e1cb
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
For https://github.com/AlphaWallet/alpha-wallet-android/pull/451#discussion_r237672053

After this PR is applied, dapps can check `web3.currentProvider.isAlphaWallet` like described in https://github.com/AlphaWallet/AlphaWallet-web3-provider/blob/master/README.md (hopefully to display the name `AlphaWallet` as well as our logo)