### PR TITLE
Print the correct database file path for debugging

### DIFF
--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        print(Realm.Configuration().fileURL!)
         window = UIWindow(frame: UIScreen.main.bounds)
         do {
             let keystore = try EtherKeystore()

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -130,6 +130,8 @@ class InCoordinator: Coordinator {
 
         let migration = MigrationInitializer(account: account, chainID: config.chainID)
         migration.perform()
+        //Debugging
+        print(migration.config.fileURL!)
 
         //TODO this is bad because it is optional and effectively a global
         if let tokensDataStore = createTokensDatastore() {


### PR DESCRIPTION
This PR fixes the Realm database file path logged to the console for debugging purposes.

It will also log it correctly again when the user switches wallet/server.