### PR TITLE
Remove unnecessary implementations of Equatable and Hashable

### DIFF
--- a/AlphaWallet/EtherClient/Wallet.swift
+++ b/AlphaWallet/EtherClient/Wallet.swift
@@ -3,26 +3,12 @@
 import Foundation
 import TrustKeystore
 
-enum WalletType {
+enum WalletType: Equatable {
     case real(Account)
     case watch(Address)
 }
 
-extension WalletType: Equatable {
-    static func == (lhs: WalletType, rhs: WalletType) -> Bool {
-        switch (lhs, rhs) {
-        case (let .real(lhs), let .real(rhs)):
-            return lhs == rhs
-        case (let .watch(lhs), let .watch(rhs)):
-            return lhs == rhs
-        case (.real, .watch),
-             (.watch, .real):
-            return false
-        }
-    }
-}
-
-struct Wallet {
+struct Wallet: Equatable  {
     let type: WalletType
 
     var address: Address {
@@ -32,11 +18,5 @@ struct Wallet {
         case .watch(let address):
             return address
         }
-    }
-}
-
-extension Wallet: Equatable {
-    static func == (lhs: Wallet, rhs: Wallet) -> Bool {
-        return lhs.type == rhs.type
     }
 }

--- a/AlphaWallet/Foundation/QRURLParser.swift
+++ b/AlphaWallet/Foundation/QRURLParser.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-struct ParserResult {
+struct ParserResult: Equatable {
     let protocolName: String
     let address: String
     let params: [String: String]
@@ -55,11 +55,5 @@ struct QRURLParser {
             i += 1
         }
         return params
-    }
-}
-
-extension ParserResult: Equatable {
-    static func == (lhs: ParserResult, rhs: ParserResult) -> Bool {
-        return lhs.protocolName == rhs.protocolName && lhs.address == rhs.address && lhs.params == rhs.params
     }
 }

--- a/AlphaWallet/Settings/Types/CustomRPC.swift
+++ b/AlphaWallet/Settings/Types/CustomRPC.swift
@@ -2,19 +2,9 @@
 
 import Foundation
 
-struct CustomRPC {
+struct CustomRPC: Hashable {
     let chainID: Int
     let name: String
     let symbol: String
     let endpoint: String
-}
-
-extension CustomRPC: Equatable {
-    static func == (lhs: CustomRPC, rhs: CustomRPC) -> Bool {
-        return
-            lhs.chainID == rhs.chainID &&
-            lhs.name == rhs.name &&
-            lhs.symbol == rhs.symbol &&
-            lhs.endpoint == rhs.symbol
-    }
 }

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -5,7 +5,7 @@ import web3swift
 import BigInt
 import TrustKeystore
 
-enum RPCServer {
+enum RPCServer: Hashable {
     case main
     case kovan
     case ropsten
@@ -164,16 +164,5 @@ enum RPCServer {
             default: return .main
             }
         }()
-    }
-}
-
-extension RPCServer: Equatable {
-    static func == (lhs: RPCServer, rhs: RPCServer) -> Bool {
-        switch (lhs, rhs) {
-        case (let .custom(lhs), let .custom(rhs)):
-            return lhs == rhs
-        case (let lhs, let rhs):
-            return lhs.chainID == rhs.chainID
-        }
     }
 }


### PR DESCRIPTION
They are auto-synthensized in Swift 4.1

https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md