### PR TITLE
Cache ENS resolution result

### DIFF
--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -3,6 +3,7 @@
 import Foundation
 import ObjectiveC
 import TrustKeystore
+import web3swift
 
 struct Config {
     struct Keys {
@@ -115,6 +116,15 @@ struct Config {
             }
         }()
         return URL(string: urlString)!
+    }
+
+    var ensRegistrarContract: EthereumAddress {
+        switch server {
+        case .main: return Constants.ENSRegistrarAddress
+        case .ropsten: return Constants.ENSRegistrarRopsten
+        case .rinkeby: return Constants.ENSRegistrarRinkeby
+        default: return Constants.ENSRegistrarAddress
+        }
     }
 
     let priceInfoEndpoints = URL(string: "https://api.coinmarketcap.com")!

--- a/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
@@ -66,14 +66,14 @@ class GetENSOwnerCoordinator {
 
         let web3 = web3swift.web3(provider: webProvider)
         let function = GetENSOwnerEncode()
-        let contractAddress = getENSAddress(networkId: config.chainID)
-        guard let contractInstance = web3swift.web3.web3contract(web3: web3, abiString: "[\(function.abi)]", at: contractAddress, options: web3.options) else {
+        let ensRegistrarContract = config.ensRegistrarContract
+        guard let contractInstance = web3swift.web3.web3contract(web3: web3, abiString: "[\(function.abi)]", at: ensRegistrarContract, options: web3.options) else {
             completion(.failure(AnyError(Web3Error(description: "Error creating web3swift contract instance to call \(function.name)()"))))
             return
         }
 
         guard let promise = contractInstance.method(function.name, parameters: [node] as [AnyObject], options: nil) else {
-            completion(.failure(AnyError(Web3Error(description: "Error calling \(function.name)() on \(contractAddress.address)"))))
+            completion(.failure(AnyError(Web3Error(description: "Error calling \(function.name)() on \(ensRegistrarContract.address)"))))
             return
         }
 
@@ -89,10 +89,10 @@ class GetENSOwnerCoordinator {
                     completion(.success(owner))
                 }
             } else {
-                completion(.failure(AnyError(Web3Error(description: "Error extracting result from \(contractAddress.address).\(function.name)()"))))
+                completion(.failure(AnyError(Web3Error(description: "Error extracting result from \(ensRegistrarContract.address).\(function.name)()"))))
             }
         }.catch { error in
-            completion(.failure(AnyError(Web3Error(description: "Error extracting result from \(contractAddress.address).\(function.name)(): \(error)"))))
+            completion(.failure(AnyError(Web3Error(description: "Error extracting result from \(ensRegistrarContract.address).\(function.name)(): \(error)"))))
         }
     }
 
@@ -109,15 +109,6 @@ class GetENSOwnerCoordinator {
             self.getENSOwner(for: input) { result in
                 completion(result)
             }
-        }
-    }
-
-    private func getENSAddress(networkId: Int) -> EthereumAddress {
-        switch networkId {
-        case 1: return Constants.ENSRegistrarAddress
-        case 3: return Constants.ENSRegistrarRopsten
-        case 4: return Constants.ENSRegistrarRinkeby
-        default: return Constants.ENSRegistrarAddress
         }
     }
 

--- a/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
@@ -21,7 +21,15 @@ extension String {
 }
 
 class GetENSOwnerCoordinator {
+    private struct ENSLookupKey: Hashable {
+        let name: String
+        let server: RPCServer
+    }
 
+    private static var resultsCache = [ENSLookupKey:EthereumAddress]()
+    private static let DELAY_AFTER_STOP_TYPING_TO_START_RESOLVING_ENS_NAME = TimeInterval(0.5)
+
+    private var toStartResolvingEnsNameTimer: Timer?
     private let config: Config
 
     init(config: Config) {
@@ -46,6 +54,10 @@ class GetENSOwnerCoordinator {
         }
 
         let node = input.lowercased().nameHash
+        if let cachedResult = cachedResult(forNode: node) {
+            completion(.success(cachedResult))
+            return
+        }
 
         guard let webProvider = Web3HttpProvider(config.rpcURL, network: config.server.web3Network) else {
             completion(.failure(AnyError(Web3Error(description: "Error creating web provider for: \(config.rpcURL) + \(config.server.web3Network)"))))
@@ -72,6 +84,8 @@ class GetENSOwnerCoordinator {
                 if owner.address == Constants.nullAddress {
                     completion(.failure(AnyError(Web3Error(description: "Null address returned"))))
                 } else {
+                    //Retain self because it's useful to cache the results even if we don't immediately need it now
+                    self.cache(forNode: node, result: owner)
                     completion(.success(owner))
                 }
             } else {
@@ -79,6 +93,22 @@ class GetENSOwnerCoordinator {
             }
         }.catch { error in
             completion(.failure(AnyError(Web3Error(description: "Error extracting result from \(contractAddress.address).\(function.name)(): \(error)"))))
+        }
+    }
+
+    func queueGetENSOwner(for input: String, completion: @escaping (Result<EthereumAddress, AnyError>) -> Void) {
+        let node = input.lowercased().nameHash
+        if let cachedResult = cachedResult(forNode: node) {
+            completion(.success(cachedResult))
+            return
+        }
+
+        toStartResolvingEnsNameTimer?.invalidate()
+        toStartResolvingEnsNameTimer = Timer.scheduledTimer(withTimeInterval: GetENSOwnerCoordinator.DELAY_AFTER_STOP_TYPING_TO_START_RESOLVING_ENS_NAME, repeats: false) { _ in
+            //Retain self because it's useful to cache the results even if we don't immediately need it now
+            self.getENSOwner(for: input) { result in
+                completion(result)
+            }
         }
     }
 
@@ -90,5 +120,12 @@ class GetENSOwnerCoordinator {
         default: return Constants.ENSRegistrarAddress
         }
     }
-    
+
+    private func cachedResult(forNode node: String) -> EthereumAddress? {
+        return GetENSOwnerCoordinator.resultsCache[ENSLookupKey(name: node, server: config.server)]
+    }
+
+    private func cache(forNode node: String, result: EthereumAddress) {
+        GetENSOwnerCoordinator.resultsCache[ENSLookupKey(name: node, server: config.server)] = result
+    }
 }

--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -11,7 +11,6 @@ protocol AddressTextFieldDelegate: class {
 }
 
 class AddressTextField: UIControl {
-    private static let MINIMUM_ENS_NAME_LENGTH = 6 //We assume .co is possible in the future, so: a.b.co
     private var isConfigured = false
     private let textField = UITextField()
     let label = UILabel()
@@ -185,14 +184,6 @@ class AddressTextField: UIControl {
     private func clearAddressFromResolvingEnsName() {
         ensAddressLabel.text = nil
     }
-
-    private func isPossible(ensName: String) -> Bool {
-        if ensName.count >= AddressTextField.MINIMUM_ENS_NAME_LENGTH && ensName.contains(".") {
-            return true
-        } else {
-            return false
-        }
-    }
 }
 
 extension AddressTextField: UITextFieldDelegate {
@@ -206,7 +197,7 @@ extension AddressTextField: UITextFieldDelegate {
         guard delegate != nil else { return true }
         let newValue = (self.textField.text as NSString?)?.replacingCharacters(in: range, with: string)
         if let newValue = newValue, !CryptoAddressValidator.isValidAddress(newValue) {
-            if isPossible(ensName: newValue) {
+            if newValue.isPossibleEnsName {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     //Retain self because it's still useful to resolve and cache even if not used immediately
                     self.queueResolution(ofValue: newValue)
@@ -225,5 +216,12 @@ extension AddressTextField: UITextFieldDelegate {
                 strongSelf.delegate?.didChange(to: string, in: strongSelf)
             }
         }
+    }
+}
+
+extension String {
+    fileprivate var isPossibleEnsName: Bool {
+        let minimumEnsNameLength = 6 //We assume .co is possible in the future, so: a.b.co
+        return count >= minimumEnsNameLength && contains(".")
     }
 }

--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -12,10 +12,8 @@ protocol AddressTextFieldDelegate: class {
 
 class AddressTextField: UIControl {
     private static let MINIMUM_ENS_NAME_LENGTH = 6 //We assume .co is possible in the future, so: a.b.co
-    private static let DELAY_AFTER_STOP_TYPING_TO_START_RESOLVING_ENS_NAME = TimeInterval(0.5)
     private var isConfigured = false
     private let textField = UITextField()
-    private var toStartResolvingEnsNameTimer: Timer?
     let label = UILabel()
     let ensAddressLabel = UILabel()
 
@@ -168,21 +166,18 @@ class AddressTextField: UIControl {
         delegate?.openQRCodeReader(for: self)
     }
 
-    private func setToStartResolvingEnsNameTimer() {
-        toStartResolvingEnsNameTimer?.invalidate()
-        //TODO should only resolve one at a time
-        toStartResolvingEnsNameTimer = Timer.scheduledTimer(withTimeInterval: AddressTextField.DELAY_AFTER_STOP_TYPING_TO_START_RESOLVING_ENS_NAME, repeats: false) { _ in
-            if let value = self.textField.text?.trimmed {
-                //TODO extract duplicate calls to GetENSOwnerCoordinator in this class
-                GetENSOwnerCoordinator(config: Config()).getENSOwner(for: value) { result in
-                    if let address = result.value {
-                        guard CryptoAddressValidator.isValidAddress(address.address) else {
-                            //TODO good to show an error message in the UI/label that it is not a valid ENS name
-                            return
-                        }
-                        self.ensAddressLabel.text = address.address
-                    }
+    private func queueResolution(ofValue value: String) {
+        let value = value.trimmed
+        let oldTextValue = textField.text?.trimmed
+        GetENSOwnerCoordinator(config: Config()).queueGetENSOwner(for: value) { [weak self] result in
+            guard let strongSelf = self else { return }
+            if let address = result.value {
+                guard CryptoAddressValidator.isValidAddress(address.address) else {
+                    //TODO good to show an error message in the UI/label that it is not a valid ENS name
+                    return
                 }
+                guard oldTextValue == strongSelf.textField.text?.trimmed else { return }
+                strongSelf.ensAddressLabel.text = address.address
             }
         }
     }
@@ -191,8 +186,8 @@ class AddressTextField: UIControl {
         ensAddressLabel.text = nil
     }
 
-    private func isPossible(ensName: String?) -> Bool {
-        if let ensName = ensName, ensName.count >= AddressTextField.MINIMUM_ENS_NAME_LENGTH && ensName.contains(".") {
+    private func isPossible(ensName: String) -> Bool {
+        if ensName.count >= AddressTextField.MINIMUM_ENS_NAME_LENGTH && ensName.contains(".") {
             return true
         } else {
             return false
@@ -210,10 +205,12 @@ extension AddressTextField: UITextFieldDelegate {
         clearAddressFromResolvingEnsName()
         guard delegate != nil else { return true }
         let newValue = (self.textField.text as NSString?)?.replacingCharacters(in: range, with: string)
-        if let newValue = newValue, CryptoAddressValidator.isValidAddress(newValue) {
-        } else {
+        if let newValue = newValue, !CryptoAddressValidator.isValidAddress(newValue) {
             if isPossible(ensName: newValue) {
-                setToStartResolvingEnsNameTimer()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    //Retain self because it's still useful to resolve and cache even if not used immediately
+                    self.queueResolution(ofValue: newValue)
+                }
             }
         }
         informDelegateDidChange(to: newValue ?? "")


### PR DESCRIPTION
For #911. This PR will 

* Cache the ENS resolution result (in-memory, which will mostly take care of when the ENS name expires)
* Use the resolved result immediately without a delay when they user types, if it has been cached earlier
* Some refactoring