### PR TITLE
Fix: background color of table view in wallet tab when pulled down

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -409,8 +409,15 @@ extension TokensViewController {
         tableView.tableHeaderView = searchController.searchBar
     }
 
+    private func fixTableViewBackgroundColor() {
+        let v = UIView()
+        v.backgroundColor = Colors.appBackground
+        tableView.backgroundView = v
+    }
+
     private func setupFilteringWithKeyword() {
         wireUpSearchController()
+        fixTableViewBackgroundColor()
         doNotDimTableViewToReuseTableForFilteringResult()
         removeSearchBarBorderForiOS10()
         makeSwitchToAnotherTabWorkWhileFiltering()


### PR DESCRIPTION
This PR fixes a bug caused by adding a search bar to the wallet tab: the background color at the top was wrong.