### PR TITLE
Add danger rule to check for leading spaces in otherwise empty lines of code

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -7,6 +7,7 @@ if (danger.github) {
     warnClosureStronglyCapturesSelf()
     failUsingNSLocalizedStringWithoutR()
     failIfRemoveAnyRealmSchemaMigrationBlock()
+    checkForSpacesInOtherwiseEmptyLines()
 }
 
 function warnHTMLLocalizationMissing() {
@@ -52,6 +53,17 @@ function failIfRemoveAnyRealmSchemaMigrationBlock() {
         })
     })
 }
+
+function checkForSpacesInOtherwiseEmptyLines() {
+    modifiedSwiftFiles().forEach(each => {
+        danger.git.diffForFile(each).then(diff => {
+            if (diff.added.includes("    \n")) {
+                fail(each + ": leading spaces for otherwise empty lines should be removed.")
+            }
+        })
+    })
+}
+
 
 function modifiedSwiftFiles() {
     return danger.git.modified_files.filter(f => f.includes(".swift"))


### PR DESCRIPTION
This PR helps with code health. No functional change.

Checks for something like this (where the `xxxx` represents the spurious spaces added by text editor to otherwise empty lines we are checking for:

```
    func oldCode() {
    }
xxxx
    func newCode() {
    }
```