### PR TITLE
rename references from eth to xdai for sending

### DIFF
--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -46,7 +46,7 @@ class MigrationInitializer: Initializer {
                     guard let oldObject = oldObject else { return }
                     guard let newObject = newObject else { return }
                     if let contract = oldObject["contract"] as? String, contract == Constants.nullAddress {
-                        newObject["rawType"] = TokenType.ether.rawValue
+                        newObject["rawType"] = TokenType.nativeCryptocurrency.rawValue
                     }
                 }
             }

--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -4,7 +4,8 @@ import Foundation
 import Moya
 
 enum AlphaWalletService {
-    case prices
+    case priceOfEth
+    case priceOfDai
     case getTransactions(address: String, startBlock: Int, endBlock: Int, sortOrder: SortOrder)
     case getTransaction(ID: String)
     case register(device: PushDevice)
@@ -22,7 +23,7 @@ extension AlphaWalletService: TargetType {
         switch self {
         case .getTransactions:
             return Config().transactionInfoEndpoints
-        case .prices:
+        case .priceOfEth, .priceOfDai:
             return Config().priceInfoEndpoints
         case .getTransaction, .register, .unregister, .marketplace:
             //TODO this wouldn't be needed after we remove these unused cases
@@ -40,8 +41,10 @@ extension AlphaWalletService: TargetType {
             return "/push/register"
         case .unregister:
             return "/push/unregister"
-        case .prices:
+        case .priceOfEth:
             return "/v1/ticker/ethereum/"
+        case .priceOfDai:
+            return "/v1/ticker/dai/"
         case .marketplace:
             return "/marketplace"
         }
@@ -53,7 +56,8 @@ extension AlphaWalletService: TargetType {
         case .getTransaction: return .get
         case .register: return .post
         case .unregister: return .delete
-        case .prices: return .get
+        case .priceOfEth: return .get
+        case .priceOfDai: return .get
         case .marketplace: return .get
         }
     }
@@ -75,7 +79,7 @@ extension AlphaWalletService: TargetType {
             return .requestJSONEncodable(device)
         case .unregister(let device):
             return .requestJSONEncodable(device)
-        case .prices:
+        case .priceOfEth, .priceOfDai:
             return .requestPlain
         case .marketplace(let chainID):
             return .requestParameters(parameters: ["chainID": chainID], encoding: URLEncoding())

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -61,7 +61,7 @@ class InCoordinator: Coordinator {
     var keystore: Keystore
     lazy var ethPrice: Subscribable<Double> = {
         var value = Subscribable<Double>(nil)
-        fetchEthPrice()
+        fetchCryptoPrice()
         return value
     }()
     var ethBalance = Subscribable<BigInt>(nil)
@@ -106,7 +106,7 @@ class InCoordinator: Coordinator {
         return tokensStorage
     }
 
-    private func fetchEthPrice() {
+    private func fetchCryptoPrice() {
         let migration = MigrationInitializer(account: keystore.recentlyUsedWallet!, chainID: config.chainID)
         migration.perform()
         let realm = self.realm(for: migration.config)

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -28,7 +28,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32</string>
+	<string>1.40</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -41,7 +41,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>241</string>
+	<string>252</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -324,3 +324,4 @@
 "dappBrowser.myDapps.edit.url.label" = "Address";
 "dappBrowser.clearMyDapps" = "Remove Dapp?";
 "recent.transactions" = "Recent Transactions";
+"blockchain.XDAI" = "xDAI Chain";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -324,3 +324,4 @@
 "dappBrowser.myDapps.edit.url.label" = "Address";
 "dappBrowser.clearMyDapps" = "Remove Dapp?";
 "recent.transactions" = "Recent Transactions";
+"blockchain.XDAI" = "xDAI Chain";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -324,3 +324,4 @@
 "dappBrowser.myDapps.edit.url.label" = "Address";
 "dappBrowser.clearMyDapps" = "Remove Dapp?";
 "recent.transactions" = "Recent Transactions";
+"blockchain.XDAI" = "xDAI Chain";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -324,3 +324,4 @@
 "dappBrowser.myDapps.edit.url.label" = "Address";
 "dappBrowser.clearMyDapps" = "Remove Dapp?";
 "recent.transactions" = "Recent Transactions";
+"blockchain.XDAI" = "xDAI Chain";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -324,3 +324,4 @@
 "dappBrowser.myDapps.edit.url.label" = "Address";
 "dappBrowser.clearMyDapps" = "Remove Dapp?";
 "recent.transactions" = "Recent Transactions";
+"blockchain.XDAI" = "xDAI Chain";

--- a/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
@@ -92,21 +92,12 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
         ethCostLabelLabel.translatesAutoresizingMaskIntoConstraints = false
         dollarCostLabelLabel.translatesAutoresizingMaskIntoConstraints = false
         dollarCostLabel.translatesAutoresizingMaskIntoConstraints = false
-
         pricePerTokenField.translatesAutoresizingMaskIntoConstraints = false
-        if config.chainID == 100 {
-            self.pricePerTokenField.cryptoToDollarRate = 1
-        } else {
-            ethPrice.subscribe { [weak self] value in
-                if let value = value {
-                    self?.pricePerTokenField.cryptoToDollarRate = value
-                }
-            }
-        }
+
+        setPricesForCoinType(config: config)
+
         pricePerTokenField.delegate = self
-
         ethCostLabel.translatesAutoresizingMaskIntoConstraints = false
-
         quantityStepper.translatesAutoresizingMaskIntoConstraints = false
         quantityStepper.minimumValue = 1
         quantityStepper.value = 1
@@ -258,6 +249,20 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
 
     @objc func quantityChanged() {
         updateTotalCostsLabels()
+    }
+
+    private func setPricesForCoinType(config: Config) {
+        switch config.server {
+        case .xDai:
+            //TODO fetch price
+            self.pricePerTokenField.cryptoToDollarRate = 1
+        case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:
+            ethPrice.subscribe { [weak self] value in
+                if let value = value {
+                    self?.pricePerTokenField.cryptoToDollarRate = value
+                }
+            }
+        }
     }
 
     private func updateTotalCostsLabels() {

--- a/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
@@ -54,13 +54,13 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
             config: Config,
             storage: TokensDataStore,
             paymentFlow: PaymentFlow,
-            ethPrice: Subscribable<Double>,
+            cryptoPrice: Subscribable<Double>,
             viewModel: EnterSellTokensCardPriceQuantityViewControllerViewModel
     ) {
         self.config = config
         self.storage = storage
         self.paymentFlow = paymentFlow
-        self.ethPrice = ethPrice
+        self.ethPrice = cryptoPrice
         self.viewModel = viewModel
 
         let tokenType = OpenSeaNonFungibleTokenHandling(token: viewModel.token)
@@ -93,9 +93,11 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
         dollarCostLabelLabel.translatesAutoresizingMaskIntoConstraints = false
         dollarCostLabel.translatesAutoresizingMaskIntoConstraints = false
         pricePerTokenField.translatesAutoresizingMaskIntoConstraints = false
-
-        setPricesForCoinType(config: config)
-
+        cryptoPrice.subscribe { [weak self] value in
+            if let value = value {
+                self?.pricePerTokenField.cryptoToDollarRate = value
+            }
+        }
         pricePerTokenField.delegate = self
         ethCostLabel.translatesAutoresizingMaskIntoConstraints = false
         quantityStepper.translatesAutoresizingMaskIntoConstraints = false
@@ -249,20 +251,6 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
 
     @objc func quantityChanged() {
         updateTotalCostsLabels()
-    }
-
-    private func setPricesForCoinType(config: Config) {
-        switch config.server {
-        case .xDai:
-            //TODO fetch price
-            self.pricePerTokenField.cryptoToDollarRate = 1
-        case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:
-            ethPrice.subscribe { [weak self] value in
-                if let value = value {
-                    self?.pricePerTokenField.cryptoToDollarRate = value
-                }
-            }
-        }
     }
 
     private func updateTotalCostsLabels() {

--- a/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
@@ -94,9 +94,13 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
         dollarCostLabel.translatesAutoresizingMaskIntoConstraints = false
 
         pricePerTokenField.translatesAutoresizingMaskIntoConstraints = false
-        ethPrice.subscribe { [weak self] value in
-            if let value = value {
-                self?.pricePerTokenField.ethToDollarRate = value
+        if config.chainID == 100 {
+            self.pricePerTokenField.cryptoToDollarRate = 1
+        } else {
+            ethPrice.subscribe { [weak self] value in
+                if let value = value {
+                    self?.pricePerTokenField.cryptoToDollarRate = value
+                }
             }
         }
         pricePerTokenField.delegate = self

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -413,9 +413,9 @@ extension TokensCoordinator: TokensViewControllerDelegate {
     func didSelect(token: TokenObject, in viewController: UIViewController) {
         switch token.type {
         case .nativeCryptocurrency:
-                    delegate?.didPress(for: .send(type: .nativeCryptocurrency(config: session.config, destination: .none)), in: self)
+            show(fungibleToken: token, transferType: .nativeCryptocurrency(config: session.config, destination: .none))
         case .xDai:
-            delegate?.didPress(for: .send(type: .xDai(config: session.config, destination: .none)), in: self)
+            show(fungibleToken: token, transferType: .xDai(config: session.config, destination: .none))
         case .erc20:
             show(fungibleToken: token, transferType: .ERC20Token(token))
         case .erc721:

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -340,7 +340,7 @@ class TokensCoordinator: Coordinator {
                         callCompletionFailed()
                     }
                 }
-            case .ether:
+            case .ether, .xDai:
                 break
             }
         }
@@ -377,7 +377,7 @@ class TokensCoordinator: Coordinator {
 
     private func makeCoordinatorReadOnlyIfNotSupportedByOpenSeaERC721(coordinator: TokensCardCoordinator, token: TokenObject) {
         switch token.type {
-        case .ether, .erc20, .erc875:
+        case .ether, .erc20, .erc875, .xDai:
             break
         case .erc721:
             switch OpenSeaNonFungibleTokenHandling(token: token) {
@@ -414,6 +414,12 @@ extension TokensCoordinator: TokensViewControllerDelegate {
         switch token.type {
         case .ether:
             show(fungibleToken: token, transferType: .ether(config: session.config, destination: .none))
+        case .ether, .xDai:
+            if token.name == "xDai" {
+                delegate?.didPress(for: .send(type: .xDai(config: session.config, destination: .none)), in: self)
+            } else {
+                delegate?.didPress(for: .send(type: .ether(config: session.config, destination: .none)), in: self)
+            }
         case .erc20:
             show(fungibleToken: token, transferType: .ERC20Token(token))
         case .erc721:

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -26,7 +26,7 @@ class TokensCoordinator: Coordinator {
     private let session: WalletSession
     private let keystore: Keystore
     private let storage: TokensDataStore
-    private let ethPrice: Subscribable<Double>
+    private let cryptoPrice: Subscribable<Double>
     private let assetDefinitionStore: AssetDefinitionStore
 
     private lazy var tokensViewController: TokensViewController = {
@@ -60,7 +60,7 @@ class TokensCoordinator: Coordinator {
         self.session = session
         self.keystore = keystore
         self.storage = tokensStorage
-        self.ethPrice = ethPrice
+        self.cryptoPrice = ethPrice
         self.assetDefinitionStore = assetDefinitionStore
     }
 
@@ -356,7 +356,7 @@ class TokensCoordinator: Coordinator {
                 session: session,
                 keystore: keystore,
                 tokensStorage: storage,
-                ethPrice: ethPrice,
+                ethPrice: cryptoPrice,
                 token: token,
                 assetDefinitionStore: assetDefinitionStore
         )

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -340,7 +340,7 @@ class TokensCoordinator: Coordinator {
                         callCompletionFailed()
                     }
                 }
-            case .ether, .xDai:
+            case .nativeCryptocurrency, .xDai:
                 break
             }
         }
@@ -377,7 +377,7 @@ class TokensCoordinator: Coordinator {
 
     private func makeCoordinatorReadOnlyIfNotSupportedByOpenSeaERC721(coordinator: TokensCardCoordinator, token: TokenObject) {
         switch token.type {
-        case .ether, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
             break
         case .erc721:
             switch OpenSeaNonFungibleTokenHandling(token: token) {
@@ -412,14 +412,10 @@ class TokensCoordinator: Coordinator {
 extension TokensCoordinator: TokensViewControllerDelegate {
     func didSelect(token: TokenObject, in viewController: UIViewController) {
         switch token.type {
-        case .ether:
-            show(fungibleToken: token, transferType: .ether(config: session.config, destination: .none))
-        case .ether, .xDai:
-            if token.name == "xDai" {
-                delegate?.didPress(for: .send(type: .xDai(config: session.config, destination: .none)), in: self)
-            } else {
-                delegate?.didPress(for: .send(type: .ether(config: session.config, destination: .none)), in: self)
-            }
+        case .nativeCryptocurrency:
+                    delegate?.didPress(for: .send(type: .nativeCryptocurrency(config: session.config, destination: .none)), in: self)
+        case .xDai:
+            delegate?.didPress(for: .send(type: .xDai(config: session.config, destination: .none)), in: self)
         case .erc20:
             show(fungibleToken: token, transferType: .ERC20Token(token))
         case .erc721:

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -19,7 +19,7 @@ class TokenAdaptor {
 
     public func getTokenHolders() -> [TokenHolder] {
         switch token.type {
-        case .ether, .erc20, .erc875:
+        case .ether, .erc20, .xDai, .erc875:
             return getNotSupportedByOpenSeaTokenHolders()
         case .erc721:
             let tokenType = OpenSeaNonFungibleTokenHandling(token: token)
@@ -65,7 +65,7 @@ class TokenAdaptor {
 
     func bundle(tokens: [Token]) -> [TokenHolder] {
         switch token.type {
-        case .ether, .erc20, .erc875:
+        case .ether, .xDai, .erc20, .erc875:
             //TODO handle bundling properly for meetup contracts
             if !tokens.isEmpty && tokens[0].values["building"] != nil {
                 return tokens.map { getTokenHolder(for: [$0]) }

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -19,7 +19,7 @@ class TokenAdaptor {
 
     public func getTokenHolders() -> [TokenHolder] {
         switch token.type {
-        case .ether, .erc20, .xDai, .erc875:
+        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
             return getNotSupportedByOpenSeaTokenHolders()
         case .erc721:
             let tokenType = OpenSeaNonFungibleTokenHandling(token: token)
@@ -65,7 +65,7 @@ class TokenAdaptor {
 
     func bundle(tokens: [Token]) -> [TokenHolder] {
         switch token.type {
-        case .ether, .xDai, .erc20, .erc875:
+        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
             //TODO handle bundling properly for meetup contracts
             if !tokens.isEmpty && tokens[0].values["building"] != nil {
                 return tokens.map { getTokenHolder(for: [$0]) }

--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -22,7 +22,11 @@ class TokenObject: Object {
 
     var type: TokenType {
         get {
-            return TokenType(rawValue: rawType)!
+            if name == "xDai" {
+                return .xDai
+            } else {
+                return TokenType(rawValue: rawType)!
+            }
         }
         set {
             rawType = newValue.rawValue
@@ -85,7 +89,7 @@ class TokenObject: Object {
         switch type {
         case .erc721:
             return true
-        case .ether, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
             return false
         }
     }

--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -85,7 +85,7 @@ class TokenObject: Object {
         switch type {
         case .erc721:
             return true
-        case .ether, .erc20, .erc875:
+        case .ether, .erc20, .erc875, .xDai:
             return false
         }
     }

--- a/AlphaWallet/Tokens/Types/TokenType.swift
+++ b/AlphaWallet/Tokens/Types/TokenType.swift
@@ -4,6 +4,7 @@ import Foundation
 
 enum TokenType: String {
     case ether = "ether"
+    case xDai = "xDai"
     case erc20 = "ERC20"
     case erc875 = "ERC875"
     case erc721 = "ERC721"

--- a/AlphaWallet/Tokens/Types/TokenType.swift
+++ b/AlphaWallet/Tokens/Types/TokenType.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 enum TokenType: String {
-    case ether = "ether"
+    case nativeCryptocurrency = "ether"
     case xDai = "xDai"
     case erc20 = "ERC20"
     case erc875 = "ERC875"

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -434,12 +434,8 @@ class TokensDataStore {
     }
 
     func updatePrices() {
-//        let tokens = objects.map { TokenPrice(contract: $0.contract, symbol: $0.symbol) }
-//        let tokensPrice = TokensPrice(
-//            currency: config.currency.rawValue,
-//            tokens: tokens
-//        )
-        provider.request(.prices) { [weak self] result in
+        let priceToUpdate = getPriceToUpdate()
+        provider.request(priceToUpdate) { [weak self] result in
             guard let strongSelf = self else { return }
             guard case .success(let response) = result else { return }
             do {
@@ -451,6 +447,15 @@ class TokensDataStore {
                 }
                 strongSelf.updateDelegate()
             } catch { }
+        }
+    }
+
+    private func getPriceToUpdate() -> AlphaWalletService {
+        switch self.config.server {
+        case .xDai:
+            return .priceOfDai
+        default:
+            return .priceOfEth
         }
     }
 

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -98,7 +98,7 @@ class TokensDataStore {
             decimals: config.server.decimals,
             value: "0",
             isCustom: false,
-            type: .ether
+            type: .nativeCryptocurrency
         )
     }
 
@@ -111,7 +111,7 @@ class TokensDataStore {
                 decimals: config.server.decimals,
                 value: "0",
                 isCustom: false,
-                type: .ether
+                type: .nativeCryptocurrency
         )
     }
 
@@ -282,7 +282,7 @@ class TokensDataStore {
         }
         for tokenObject in tokens {
             switch tokenObject.type {
-            case .ether, .xDai:
+            case .nativeCryptocurrency, .xDai:
                 incrementCountAndUpdateDelegate()
             case .erc20:
                 guard let contract = Address(string: tokenObject.contract) else {
@@ -359,7 +359,7 @@ class TokensDataStore {
 
                 if let tokenObject = tokens.first(where: { $0.contract.sameContract(as: contract) }) {
                     switch tokenObject.type {
-                    case .ether, .xDai, .erc721, .erc875:
+                    case .nativeCryptocurrency, .erc721, .erc875, .xDai:
                         break
                     case .erc20:
                         strongSelf.update(token: tokenObject, action: .type(.erc721))

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -282,7 +282,7 @@ class TokensDataStore {
         }
         for tokenObject in tokens {
             switch tokenObject.type {
-            case .ether:
+            case .ether, .xDai:
                 incrementCountAndUpdateDelegate()
             case .erc20:
                 guard let contract = Address(string: tokenObject.contract) else {
@@ -359,7 +359,7 @@ class TokensDataStore {
 
                 if let tokenObject = tokens.first(where: { $0.contract.sameContract(as: contract) }) {
                     switch tokenObject.type {
-                    case .ether, .erc721, .erc875:
+                    case .ether, .xDai, .erc721, .erc875:
                         break
                     case .erc20:
                         strongSelf.update(token: tokenObject, action: .type(.erc721))

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -208,7 +208,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
     public func updateForm(forTokenType tokenType: TokenType) {
         self.tokenType = tokenType
         switch tokenType {
-        case .ether, .erc20:
+        case .ether, .erc20, .xDai:
             decimalsTextField.isHidden = false
             balanceTextField.isHidden = true
             decimalsTextField.label.isHidden = false
@@ -237,7 +237,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
         guard let tokenType = tokenType else { return false }
 
         switch tokenType {
-        case .ether, .erc20:
+        case .ether, .erc20, .xDai:
             guard !decimalsTextField.value.trimmed.isEmpty else {
                 displayError(title: R.string.localizable.decimals(), error: ValidationError(msg: R.string.localizable.warningFieldRequired()))
                 return false

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -208,7 +208,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
     public func updateForm(forTokenType tokenType: TokenType) {
         self.tokenType = tokenType
         switch tokenType {
-        case .ether, .erc20, .xDai:
+        case .nativeCryptocurrency, .erc20, .xDai:
             decimalsTextField.isHidden = false
             balanceTextField.isHidden = true
             decimalsTextField.label.isHidden = false
@@ -237,7 +237,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
         guard let tokenType = tokenType else { return false }
 
         switch tokenType {
-        case .ether, .erc20, .xDai:
+        case .nativeCryptocurrency, .erc20, .xDai:
             guard !decimalsTextField.value.trimmed.isEmpty else {
                 displayError(title: R.string.localizable.decimals(), error: ValidationError(msg: R.string.localizable.warningFieldRequired()))
                 return false

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -105,7 +105,7 @@ class TokenViewController: UIViewController {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .nativeCryptocurrency:
+        case .nativeCryptocurrency, .xDai:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort
@@ -132,7 +132,7 @@ class TokenViewController: UIViewController {
             if let viewModel = self.viewModel {
                 configure(viewModel: viewModel)
             }
-        default:
+        case .ERC875Token(_), .ERC875TokenOrder(_), .ERC721Token(_), .dapp(_, _):
             break
         }
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -79,7 +79,7 @@ class TokenViewController: UIViewController {
         headerViewModel.showAlternativeAmount = viewModel.showAlternativeAmount
 
         switch transferType {
-        case .ether, .xDai:
+        case .nativeCryptocurrency, .xDai:
             header.verificationStatus = .verified(session.account.address.eip55String)
         case .ERC20Token, .ERC875TokenOrder, .ERC875Token, .ERC721Token, .dapp:
             header.verificationStatus = .unverified
@@ -105,7 +105,7 @@ class TokenViewController: UIViewController {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .ether, .xDai:
+        case .nativeCryptocurrency:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -105,7 +105,7 @@ class TokenViewController: UIViewController {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .ether:
+        case .ether, .xDai:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -79,7 +79,7 @@ class TokenViewController: UIViewController {
         headerViewModel.showAlternativeAmount = viewModel.showAlternativeAmount
 
         switch transferType {
-        case .ether:
+        case .ether, .xDai:
             header.verificationStatus = .verified(session.account.address.eip55String)
         case .ERC20Token, .ERC875TokenOrder, .ERC875Token, .ERC721Token, .dapp:
             header.verificationStatus = .unverified

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -173,9 +173,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         transferButton.titleLabel?.font = viewModel.buttonFont
 
         switch tokenObject.type {
-        case .ether:
-            break
-        case .erc20:
+        case .ether, .xDai, .erc20:
             break
         case .erc875:
             redeemButton.isHidden = false

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -173,7 +173,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         transferButton.titleLabel?.font = viewModel.buttonFont
 
         switch tokenObject.type {
-        case .ether, .xDai, .erc20:
+        case .nativeCryptocurrency, .erc20, .xDai:
             break
         case .erc875:
             redeemButton.isHidden = false

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -270,22 +270,23 @@ extension TokensViewController: UITableViewDelegate {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
 
         switch token.type {
-        case .ether:
+        case .ether, .xDai:
             let cellViewModel = EthTokenViewCellViewModel(
                     token: token,
                     ticker: viewModel.ticker(for: token),
                     currencyAmount: session.balanceCoordinator.viewModel.currencyAmount,
-                    currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol
+                    currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol,
+                    chainId: session.config.chainID
             )
             return cellViewModel.cellHeight
         case .erc20:
             let cellViewModel = TokenViewCellViewModel(token: token)
             return cellViewModel.cellHeight
         case .erc721:
-            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token)
+            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, chainId: session.config.chainID)
             return cellViewModel.cellHeight
         case .erc875:
-            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token)
+            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, chainId: session.config.chainID)
             return cellViewModel.cellHeight
         }
     }
@@ -319,14 +320,15 @@ extension TokensViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
         switch token.type {
-        case .ether:
+        case .ether, .xDai:
             let cell = tableView.dequeueReusableCell(withIdentifier: EthTokenViewCell.identifier, for: indexPath) as! EthTokenViewCell
             cell.configure(
                     viewModel: .init(
                             token: token,
                             ticker: viewModel.ticker(for: token),
                             currencyAmount: session.balanceCoordinator.viewModel.currencyAmount,
-                            currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol
+                            currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol,
+                            chainId: session.config.chainID
                     )
             )
             return cell
@@ -336,11 +338,11 @@ extension TokensViewController: UITableViewDataSource {
             return cell
         case .erc721:
             let cell = tableView.dequeueReusableCell(withIdentifier: NonFungibleTokenViewCell.identifier, for: indexPath) as! NonFungibleTokenViewCell
-            cell.configure(viewModel: .init(token: token))
+            cell.configure(viewModel: .init(token: token, chainId: session.config.chainID))
             return cell
         case .erc875:
             let cell = tableView.dequeueReusableCell(withIdentifier: NonFungibleTokenViewCell.identifier, for: indexPath) as! NonFungibleTokenViewCell
-            cell.configure(viewModel: .init(token: token))
+            cell.configure(viewModel: .init(token: token, chainId: session.config.chainID))
             return cell
         }
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -276,17 +276,17 @@ extension TokensViewController: UITableViewDelegate {
                     ticker: viewModel.ticker(for: token),
                     currencyAmount: session.balanceCoordinator.viewModel.currencyAmount,
                     currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol,
-                    chainId: session.config.chainID
+                    server: session.config.server
             )
             return cellViewModel.cellHeight
         case .erc20:
             let cellViewModel = TokenViewCellViewModel(token: token)
             return cellViewModel.cellHeight
         case .erc721:
-            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, chainId: session.config.chainID)
+            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, server: session.config.server)
             return cellViewModel.cellHeight
         case .erc875:
-            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, chainId: session.config.chainID)
+            let cellViewModel = NonFungibleTokenViewCellViewModel(token: token, server: session.config.server)
             return cellViewModel.cellHeight
         }
     }
@@ -328,7 +328,7 @@ extension TokensViewController: UITableViewDataSource {
                             ticker: viewModel.ticker(for: token),
                             currencyAmount: session.balanceCoordinator.viewModel.currencyAmount,
                             currencyAmountWithoutSymbol: session.balanceCoordinator.viewModel.currencyAmountWithoutSymbol,
-                            chainId: session.config.chainID
+                            server: session.config.server
                     )
             )
             return cell
@@ -338,11 +338,11 @@ extension TokensViewController: UITableViewDataSource {
             return cell
         case .erc721:
             let cell = tableView.dequeueReusableCell(withIdentifier: NonFungibleTokenViewCell.identifier, for: indexPath) as! NonFungibleTokenViewCell
-            cell.configure(viewModel: .init(token: token, chainId: session.config.chainID))
+            cell.configure(viewModel: .init(token: token, server: session.config.server))
             return cell
         case .erc875:
             let cell = tableView.dequeueReusableCell(withIdentifier: NonFungibleTokenViewCell.identifier, for: indexPath) as! NonFungibleTokenViewCell
-            cell.configure(viewModel: .init(token: token, chainId: session.config.chainID))
+            cell.configure(viewModel: .init(token: token, server: session.config.server))
             return cell
         }
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -270,7 +270,7 @@ extension TokensViewController: UITableViewDelegate {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
 
         switch token.type {
-        case .ether, .xDai:
+        case .nativeCryptocurrency, .xDai:
             let cellViewModel = EthTokenViewCellViewModel(
                     token: token,
                     ticker: viewModel.ticker(for: token),
@@ -320,7 +320,7 @@ extension TokensViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
         switch token.type {
-        case .ether, .xDai:
+        case .nativeCryptocurrency, .xDai:
             let cell = tableView.dequeueReusableCell(withIdentifier: EthTokenViewCell.identifier, for: indexPath) as! EthTokenViewCell
             cell.configure(
                     viewModel: .init(

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -10,20 +10,20 @@ struct EthTokenViewCellViewModel {
     private let currencyAmount: String?
     private let currencyAmountWithoutSymbol: Double?
     private let ticker: CoinTicker?
-    private let chainId: Int
+    private let server: RPCServer
 
     init(
         token: TokenObject,
         ticker: CoinTicker?,
         currencyAmount: String?,
         currencyAmountWithoutSymbol: Double?,
-        chainId: Int
+        server: RPCServer
     ) {
         self.token = token
         self.ticker = ticker
         self.currencyAmount = currencyAmount
         self.currencyAmountWithoutSymbol = currencyAmountWithoutSymbol
-        self.chainId = chainId
+        self.server = server
     }
 
     var title: String {
@@ -39,10 +39,10 @@ struct EthTokenViewCellViewModel {
     }
 
     var blockChainName: String {
-        if chainId == 100 {
-            //xdai network, can create switch statement in future if supporting many chains
+        switch server {
+        case .xDai:
             return R.string.localizable.blockchainXDAI()
-        } else {
+        case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:
             return R.string.localizable.blockchainEthereum()
         }
     }

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -10,17 +10,20 @@ struct EthTokenViewCellViewModel {
     private let currencyAmount: String?
     private let currencyAmountWithoutSymbol: Double?
     private let ticker: CoinTicker?
+    private let chainId: Int
 
     init(
         token: TokenObject,
         ticker: CoinTicker?,
         currencyAmount: String?,
-        currencyAmountWithoutSymbol: Double?
+        currencyAmountWithoutSymbol: Double?,
+        chainId: Int
     ) {
         self.token = token
         self.ticker = ticker
         self.currencyAmount = currencyAmount
         self.currencyAmountWithoutSymbol = currencyAmountWithoutSymbol
+        self.chainId = chainId
     }
 
     var title: String {
@@ -36,7 +39,12 @@ struct EthTokenViewCellViewModel {
     }
 
     var blockChainName: String {
-        return R.string.localizable.blockchainEthereum()
+        if chainId == 100 {
+            //xdai network, can create switch statement in future if supporting many chains
+            return R.string.localizable.blockchainXDAI()
+        } else {
+            return R.string.localizable.blockchainEthereum()
+        }
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
@@ -6,11 +6,11 @@ import BigInt
 
 struct NonFungibleTokenViewCellViewModel {
     private let token: TokenObject
-    private let chainId: Int
+    private let server: RPCServer
 
-    init(token: TokenObject, chainId: Int) {
+    init(token: TokenObject, server: RPCServer) {
         self.token = token
-        self.chainId = chainId
+        self.server = server
     }
 
     var title: String {
@@ -41,10 +41,10 @@ struct NonFungibleTokenViewCellViewModel {
     }
 
     var blockChainName: String {
-        if chainId == 100 {
-            //xdai network, can create switch statement in future if supporting many chains
+        switch server {
+        case .xDai:
             return R.string.localizable.blockchainXDAI()
-        } else {
+        case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:
             return R.string.localizable.blockchainEthereum()
         }
     }

--- a/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
@@ -6,9 +6,11 @@ import BigInt
 
 struct NonFungibleTokenViewCellViewModel {
     private let token: TokenObject
+    private let chainId: Int
 
-    init(token: TokenObject) {
+    init(token: TokenObject, chainId: Int) {
         self.token = token
+        self.chainId = chainId
     }
 
     var title: String {
@@ -39,7 +41,12 @@ struct NonFungibleTokenViewCellViewModel {
     }
 
     var blockChainName: String {
-        return R.string.localizable.blockchainEthereum()
+        if chainId == 100 {
+            //xdai network, can create switch statement in future if supporting many chains
+            return R.string.localizable.blockchainXDAI()
+        } else {
+            return R.string.localizable.blockchainEthereum()
+        }
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -18,7 +18,7 @@ struct TokenViewControllerViewModel {
         self.transactionsStore = transactionsStore
 
         switch transferType {
-        case .ether, .xDai:
+        case .nativeCryptocurrency, .xDai:
             self.recentTransactions = Array(transactionsStore.objects.lazy.filter({ $0.state == .completed || $0.state == .pending }).filter({ $0.value != "" && $0.value != "0" }).prefix(3))
         case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
             self.recentTransactions = []

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -18,7 +18,7 @@ struct TokenViewControllerViewModel {
         self.transactionsStore = transactionsStore
 
         switch transferType {
-        case .ether:
+        case .ether, .xDai:
             self.recentTransactions = Array(transactionsStore.objects.lazy.filter({ $0.state == .completed || $0.state == .pending }).filter({ $0.value != "" && $0.value != "0" }).prefix(3))
         case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
             self.recentTransactions = []

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -32,9 +32,9 @@ class TokensViewModel {
         case .all:
             return tokens
         case .currencyOnly:
-            return tokens.filter { $0.type == .ether || $0.type == .erc20 }
+            return tokens.filter { $0.type == .nativeCryptocurrency || $0.type == .erc20 }
         case .assetsOnly:
-            return tokens.filter { $0.type != .ether && $0.type != .erc20 }
+            return tokens.filter { $0.type != .nativeCryptocurrency && $0.type != .erc20 }
         case .collectiblesOnly:
             return tokens.filter { $0.type == .erc721 && !$0.balance.isEmpty }
         case .keyword(let keyword):

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -484,7 +484,7 @@ extension TokensCardCoordinator: TransferTokensCardViewControllerDelegate {
             viewController.navigationController?.pushViewController(vc, animated: true)
         case .erc875:
             showEnterQuantityViewController(token: token, for: tokenHolder, in: viewController)
-        case .ether, .xDai, .erc20: break
+        case .nativeCryptocurrency, .erc20, .xDai: break
         }
     }
 

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -207,7 +207,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
 
     private func makeEnterSellTokensCardPriceQuantityViewController(token: TokenObject, for tokenHolder: TokenHolder, paymentFlow: PaymentFlow) -> EnterSellTokensCardPriceQuantityViewController {
         let viewModel = EnterSellTokensCardPriceQuantityViewControllerViewModel(token: token, tokenHolder: tokenHolder)
-        let controller = EnterSellTokensCardPriceQuantityViewController(config: session.config, storage: tokensStorage, paymentFlow: paymentFlow, ethPrice: ethPrice, viewModel: viewModel)
+        let controller = EnterSellTokensCardPriceQuantityViewController(config: session.config, storage: tokensStorage, paymentFlow: paymentFlow, cryptoPrice: ethPrice, viewModel: viewModel)
         controller.configure()
         controller.delegate = self
         return controller

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -484,8 +484,7 @@ extension TokensCardCoordinator: TransferTokensCardViewControllerDelegate {
             viewController.navigationController?.pushViewController(vc, animated: true)
         case .erc875:
             showEnterQuantityViewController(token: token, for: tokenHolder, in: viewController)
-        case .erc20: break
-        case .ether: break
+        case .ether, .xDai, .erc20: break
         }
     }
 

--- a/AlphaWallet/Transactions/ViewModels/BalanceViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/BalanceViewModel.swift
@@ -36,8 +36,9 @@ struct BalanceViewModel: BalanceBaseViewModel {
 
     var currencyAmountWithoutSymbol: Double? {
         guard let rate = rate else { return nil }
+        let symbol = mapSymbolToVersionInRates(config.server.symbol)
         guard
-                let currentRate = (rate.rates.filter { $0.code == config.server.symbol }.first),
+                let currentRate = (rate.rates.filter { $0.code == symbol }.first),
                 currentRate.price > 0,
                 amount > 0
                 else { return nil }
@@ -54,5 +55,10 @@ struct BalanceViewModel: BalanceBaseViewModel {
 
     var symbol: String {
         return config.server.symbol
+    }
+
+    private func mapSymbolToVersionInRates(_ symbol: String) -> String {
+        let mapping = ["xDai": "DAI"]
+        return mapping[symbol] ?? symbol
     }
 }

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -59,7 +59,7 @@ class TransactionConfigurator {
     func estimateGasLimit() {
         let to: Address? = {
             switch transaction.transferType {
-            case .ether, .dapp, .xDai: return transaction.to
+            case .nativeCryptocurrency, .dapp, .xDai: return transaction.to
             case .ERC20Token(let token):
                 return Address(string: token.contract)
             case .ERC875Token(let token):
@@ -99,7 +99,7 @@ class TransactionConfigurator {
 
     func load(completion: @escaping (Result<Void, AnyError>) -> Void) {
         switch transaction.transferType {
-        case .ether, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp, .xDai:
             guard requestEstimateGas else {
                 return completion(.success(()))
             }
@@ -205,7 +205,7 @@ class TransactionConfigurator {
     func formUnsignedTransaction() -> UnsignedTransaction {
         let value: BigInt = {
             switch transaction.transferType {
-            case .ether, .dapp, .xDai: return transaction.value
+            case .nativeCryptocurrency, .dapp, .xDai: return transaction.value
             case .ERC20Token: return 0
             case .ERC875Token: return 0
             case .ERC875TokenOrder: return transaction.value
@@ -214,7 +214,7 @@ class TransactionConfigurator {
         }()
         let address: Address? = {
             switch transaction.transferType {
-            case .ether, .dapp, .xDai: return transaction.to
+            case .nativeCryptocurrency, .dapp, .xDai: return transaction.to
             case .ERC20Token(let token): return token.address
             case .ERC875Token(let token): return token.address
             case .ERC875TokenOrder(let token): return token.address

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -59,7 +59,7 @@ class TransactionConfigurator {
     func estimateGasLimit() {
         let to: Address? = {
             switch transaction.transferType {
-            case .ether, .dapp: return transaction.to
+            case .ether, .dapp, .xDai: return transaction.to
             case .ERC20Token(let token):
                 return Address(string: token.contract)
             case .ERC875Token(let token):
@@ -99,7 +99,7 @@ class TransactionConfigurator {
 
     func load(completion: @escaping (Result<Void, AnyError>) -> Void) {
         switch transaction.transferType {
-        case .ether, .dapp:
+        case .ether, .dapp, .xDai:
             guard requestEstimateGas else {
                 return completion(.success(()))
             }
@@ -205,7 +205,7 @@ class TransactionConfigurator {
     func formUnsignedTransaction() -> UnsignedTransaction {
         let value: BigInt = {
             switch transaction.transferType {
-            case .ether, .dapp: return transaction.value
+            case .ether, .dapp, .xDai: return transaction.value
             case .ERC20Token: return 0
             case .ERC875Token: return 0
             case .ERC875TokenOrder: return transaction.value
@@ -214,7 +214,7 @@ class TransactionConfigurator {
         }()
         let address: Address? = {
             switch transaction.transferType {
-            case .ether, .dapp: return transaction.to
+            case .ether, .dapp, .xDai: return transaction.to
             case .ERC20Token(let token): return token.address
             case .ERC875Token(let token): return token.address
             case .ERC875TokenOrder(let token): return token.address

--- a/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
@@ -37,7 +37,7 @@ class RequestCoordinator: Coordinator {
 
     func makeRequestViewController() -> RequestViewController {
         let controller = RequestViewController(viewModel: viewModel)
-        controller.navigationItem.titleView = BalanceTitleView.make(from: session, .ether(config: session.config, destination: .none))
+        controller.navigationItem.titleView = BalanceTitleView.make(from: session, .nativeCryptocurrency(config: session.config, destination: .none))
         controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         controller.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share(_:)))
         return controller

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -77,7 +77,7 @@ class SendCoordinator: Coordinator {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         }
         switch transferType {
-        case .ether(_, let destination), .xDai(_, let destination):
+        case .nativeCryptocurrency(_, let destination), .xDai(_, let destination):
             controller.targetAddressTextField.value = destination?.description ?? ""
         case .ERC20Token: break
         case .ERC875Token: break

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -70,7 +70,7 @@ class SendCoordinator: Coordinator {
             storage: storage,
             account: account,
             transferType: transferType,
-            ethPrice: ethPrice
+            cryptoPrice: ethPrice
         )
 
         if navigationController.viewControllers.isEmpty {

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -77,7 +77,7 @@ class SendCoordinator: Coordinator {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         }
         switch transferType {
-        case .ether(_, let destination):
+        case .ether(_, let destination), .xDai(_, let destination):
             controller.targetAddressTextField.value = destination?.description ?? ""
         case .ERC20Token: break
         case .ERC875Token: break

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -13,10 +13,8 @@ enum TransferType {
     init(token: TokenObject) {
         self = {
             switch token.type {
-            case .ether:
-                return .ether(config: Config(), destination: nil)
-            case .xDai:
-                return .xDai(config: Config(), destination: nil)
+            case .nativeCryptocurrency, .xDai:
+                return .nativeCryptocurrency(config: Config(), destination: nil)
             case .erc20:
                 return .ERC20Token(token)
             case .erc875:
@@ -27,7 +25,7 @@ enum TransferType {
         }()
     }
 
-    case ether(config: Config, destination: Address?)
+    case nativeCryptocurrency(config: Config, destination: Address?)
     case xDai(config: Config, destination: Address?)
     case ERC20Token(TokenObject)
     case ERC875Token(TokenObject)
@@ -39,7 +37,7 @@ enum TransferType {
 extension TransferType {
     func symbol(server: RPCServer) -> String {
         switch self {
-        case .ether, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp, .xDai:
             return server.symbol
         case .ERC20Token(let token):
             return token.symbol
@@ -54,7 +52,7 @@ extension TransferType {
 
     func contract() -> Address {
         switch self {
-        case .ether(let config, _), .xDai(let config, _):
+        case .nativeCryptocurrency(let config, _), .xDai(let config, _):
             return Address(uncheckedAgainstNullAddress: TokensDataStore.etherToken(for: config).contract)!
         case .ERC20Token(let token):
             return Address(string: token.contract)!

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -15,6 +15,8 @@ enum TransferType {
             switch token.type {
             case .ether:
                 return .ether(config: Config(), destination: nil)
+            case .xDai:
+                return .xDai(config: Config(), destination: nil)
             case .erc20:
                 return .ERC20Token(token)
             case .erc875:
@@ -26,6 +28,7 @@ enum TransferType {
     }
 
     case ether(config: Config, destination: Address?)
+    case xDai(config: Config, destination: Address?)
     case ERC20Token(TokenObject)
     case ERC875Token(TokenObject)
     case ERC875TokenOrder(TokenObject)
@@ -36,7 +39,7 @@ enum TransferType {
 extension TransferType {
     func symbol(server: RPCServer) -> String {
         switch self {
-        case .ether, .dapp:
+        case .ether, .dapp, .xDai:
             return server.symbol
         case .ERC20Token(let token):
             return token.symbol
@@ -51,7 +54,7 @@ extension TransferType {
 
     func contract() -> Address {
         switch self {
-        case .ether(let config, _):
+        case .ether(let config, _), .xDai(let config, _):
             return Address(uncheckedAgainstNullAddress: TokensDataStore.etherToken(for: config).contract)!
         case .ERC20Token(let token):
             return Address(string: token.contract)!

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -260,7 +260,7 @@ class SendViewController: UIViewController, CanScanQRCode {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .ether:
+        case .ether, .xDai:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -44,7 +44,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         switch transferType {
         case .ERC20Token(let token):
             return token.contract
-        case .ether:
+        case .ether, .xDai:
             return account.address.eip55String
         case .dapp:
             return "0x"
@@ -90,9 +90,12 @@ class SendViewController: UIViewController, CanScanQRCode {
         case .ether:
             ethPrice.subscribe { [weak self] value in
                 if let value = value {
-                    self?.amountTextField.ethToDollarRate = value
+                    self?.amountTextField.cryptoToDollarRate = value
                 }
             }
+        case .xDai:
+            //TODO maybe get this price realtime, however it is supposed to stayed pegged to USD at 1:1
+            self.amountTextField.cryptoToDollarRate = 1
         default:
             amountTextField.alternativeAmountLabel.isHidden = true
             amountTextField.isFiatButtonHidden = true
@@ -211,7 +214,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         let amountString = amountTextField.ethCost
         let parsedValue: BigInt? = {
             switch transferType {
-            case .ether, .dapp:
+            case .ether, .dapp, .xDai:
                 return EtherNumberFormatter.full.number(from: amountString, units: .ether)
             case .ERC20Token(let token):
                 return EtherNumberFormatter.full.number(from: amountString, decimals: token.decimals)

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -87,13 +87,13 @@ class SendViewController: UIViewController, CanScanQRCode {
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
         switch transferType {
-        case .nativeCryptocurrency:
+        case .nativeCryptocurrency, .xDai:
             cryptoPrice.subscribe { [weak self] value in
                 if let value = value {
                     self?.amountTextField.cryptoToDollarRate = value
                 }
             }
-        default:
+        case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
             amountTextField.alternativeAmountLabel.isHidden = true
             amountTextField.isFiatButtonHidden = true
         }
@@ -260,7 +260,7 @@ class SendViewController: UIViewController, CanScanQRCode {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .nativeCryptocurrency:
+        case .nativeCryptocurrency, .xDai:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort
@@ -287,7 +287,7 @@ class SendViewController: UIViewController, CanScanQRCode {
             if let viewModel = self.viewModel {
                 configure(viewModel: viewModel)
             }
-        default:
+        case .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
             break
         }
     }

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -64,13 +64,13 @@ class SendViewController: UIViewController, CanScanQRCode {
             storage: TokensDataStore,
             account: Account,
             transferType: TransferType = .ether(config: Config(), destination: .none),
-            ethPrice: Subscribable<Double>
+            cryptoPrice: Subscribable<Double>
     ) {
         self.session = session
         self.account = account
         self.transferType = transferType
         self.storage = storage
-        self.ethPrice = ethPrice
+        self.ethPrice = cryptoPrice
         self.config = Config()
 
         super.init(nibName: nil, bundle: nil)
@@ -87,15 +87,12 @@ class SendViewController: UIViewController, CanScanQRCode {
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
         switch transferType {
-        case .ether:
-            ethPrice.subscribe { [weak self] value in
+        case .ether, .xDai:
+            cryptoPrice.subscribe { [weak self] value in
                 if let value = value {
                     self?.amountTextField.cryptoToDollarRate = value
                 }
             }
-        case .xDai:
-            //TODO maybe get this price realtime, however it is supposed to stayed pegged to USD at 1:1
-            self.amountTextField.cryptoToDollarRate = 1
         default:
             amountTextField.alternativeAmountLabel.isHidden = true
             amountTextField.isFiatButtonHidden = true

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -44,7 +44,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         switch transferType {
         case .ERC20Token(let token):
             return token.contract
-        case .ether, .xDai:
+        case .nativeCryptocurrency, .xDai:
             return account.address.eip55String
         case .dapp:
             return "0x"
@@ -63,7 +63,7 @@ class SendViewController: UIViewController, CanScanQRCode {
             session: WalletSession,
             storage: TokensDataStore,
             account: Account,
-            transferType: TransferType = .ether(config: Config(), destination: .none),
+            transferType: TransferType = .nativeCryptocurrency(config: Config(), destination: .none),
             cryptoPrice: Subscribable<Double>
     ) {
         self.session = session
@@ -87,7 +87,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
         switch transferType {
-        case .ether, .xDai:
+        case .nativeCryptocurrency:
             cryptoPrice.subscribe { [weak self] value in
                 if let value = value {
                     self?.amountTextField.cryptoToDollarRate = value
@@ -211,7 +211,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         let amountString = amountTextField.ethCost
         let parsedValue: BigInt? = {
             switch transferType {
-            case .ether, .dapp, .xDai:
+            case .nativeCryptocurrency, .dapp, .xDai:
                 return EtherNumberFormatter.full.number(from: amountString, units: .ether)
             case .ERC20Token(let token):
                 return EtherNumberFormatter.full.number(from: amountString, decimals: token.decimals)
@@ -227,7 +227,7 @@ class SendViewController: UIViewController, CanScanQRCode {
             return displayError(error: SendInputErrors.wrongInput)
         }
 
-        if case .ether = transferType, let balance = session.balance, balance.value < value {
+        if case .nativeCryptocurrency = transferType, let balance = session.balance, balance.value < value {
             return displayError(title: R.string.localizable.aSendBalanceInsufficient(), error: Errors.invalidAmount)
         }
 
@@ -260,7 +260,7 @@ class SendViewController: UIViewController, CanScanQRCode {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .ether, .xDai:
+        case .nativeCryptocurrency:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -28,7 +28,7 @@ struct ConfigureTransactionViewModel {
 
     var isDataInputHidden: Bool {
         switch transferType {
-        case .ether, .dapp, .xDai: return false
+        case .nativeCryptocurrency, .dapp, .xDai: return false
         case .ERC20Token: return true
         case .ERC875Token: return true
         case .ERC875TokenOrder: return true

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -28,7 +28,7 @@ struct ConfigureTransactionViewModel {
 
     var isDataInputHidden: Bool {
         switch transferType {
-        case .ether, .dapp: return false
+        case .ether, .dapp, .xDai: return false
         case .ERC20Token: return true
         case .ERC875Token: return true
         case .ERC875TokenOrder: return true

--- a/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
@@ -102,7 +102,7 @@ struct ConfirmPaymentDetailsViewModel {
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value, decimals: token.decimals)
             )
-        case .ether, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp, .xDai:
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value)
             )

--- a/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
@@ -102,7 +102,7 @@ struct ConfirmPaymentDetailsViewModel {
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value, decimals: token.decimals)
             )
-        case .ether, .dapp:
+        case .ether, .dapp, .xDai:
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value)
             )

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -8,17 +8,17 @@ struct SendHeaderViewViewModel {
     var currencyAmount: String?
     var currencyAmountWithoutSymbol: Double?
     var showAlternativeAmount = false
-    var chainId = Config().chainID
+    var server = Config().server
 
     var issuer: String {
         return ""
     }
 
     var blockChainName: String {
-        if chainId == 100 {
-            //xdai network, can create switch statement in future if supporting many chains
+        switch server {
+        case .xDai:
             return R.string.localizable.blockchainXDAI()
-        } else {
+        case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:
             return R.string.localizable.blockchainEthereum()
         }
     }

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -8,13 +8,19 @@ struct SendHeaderViewViewModel {
     var currencyAmount: String?
     var currencyAmountWithoutSymbol: Double?
     var showAlternativeAmount = false
+    var chainId = Config().chainID
 
     var issuer: String {
         return ""
     }
 
     var blockChainName: String {
-        return R.string.localizable.blockchainEthereum()
+        if chainId == 100 {
+            //xdai network, can create switch statement in future if supporting many chains
+            return R.string.localizable.blockchainXDAI()
+        } else {
+            return R.string.localizable.blockchainEthereum()
+        }
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -25,7 +25,7 @@ struct SendViewModel {
 
     var token: TokenObject? {
         switch transferType {
-        case .ether(destination: _), .xDai(destination: _):
+        case .nativeCryptocurrency(destination: _), .xDai:
             return nil
         case .ERC20Token(let token):
             return token

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -25,7 +25,7 @@ struct SendViewModel {
 
     var token: TokenObject? {
         switch transferType {
-        case .ether(destination: _):
+        case .ether(destination: _), .xDai(destination: _):
             return nil
         case .ERC20Token(let token):
             return token

--- a/AlphaWallet/UI/BalanceTitleView.swift
+++ b/AlphaWallet/UI/BalanceTitleView.swift
@@ -97,7 +97,7 @@ extension BalanceTitleView {
         let view = BalanceTitleView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         switch transferType {
-        case .ether, .dapp:
+        case .ether, .dapp, .xDai:
             session.balanceViewModel.subscribe { [weak view] viewModel in
                 guard let viewModel = viewModel else { return }
                 view?.viewModel = viewModel

--- a/AlphaWallet/UI/BalanceTitleView.swift
+++ b/AlphaWallet/UI/BalanceTitleView.swift
@@ -97,7 +97,7 @@ extension BalanceTitleView {
         let view = BalanceTitleView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         switch transferType {
-        case .ether, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp, .xDai:
             session.balanceViewModel.subscribe { [weak view] viewModel in
                 guard let viewModel = viewModel else { return }
                 view?.viewModel = viewModel

--- a/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
@@ -69,7 +69,7 @@ class InCoordinatorTests: XCTestCase {
         )
         coordinator.showTabBar(for: .make())
 
-        coordinator.showPaymentFlow(for: .send(type: .ether(config: .make(), destination: .none)))
+        coordinator.showPaymentFlow(for: .send(type: .nativeCryptocurrency(config: .make(), destination: .none)))
 
         let controller = (coordinator.navigationController.presentedViewController as? UINavigationController)?.viewControllers[0]
 

--- a/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
@@ -8,7 +8,7 @@ class SendCoordinatorTests: XCTestCase {
     
     func testRootViewController() {
         let coordinator = SendCoordinator(
-            transferType: .ether(config: Config(), destination: .none),
+            transferType: .nativeCryptocurrency(config: Config(), destination: .none),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),
@@ -25,7 +25,7 @@ class SendCoordinatorTests: XCTestCase {
     func testDestination() {
         let address: Address = .make()
         let coordinator = SendCoordinator(
-            transferType: .ether(config: Config(), destination: address),
+            transferType: .nativeCryptocurrency(config: Config(), destination: address),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),

--- a/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
+++ b/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
@@ -7,7 +7,7 @@ import BigInt
 
 extension UnconfirmedTransaction {
     static func make(
-        transferType: TransferType = .ether(config: Config(), destination: .none),
+        transferType: TransferType = .nativeCryptocurrency(config: Config(), destination: .none),
         value: BigInt = BigInt(1),
         to: Address = .make(),
         data: Data = Data(),

--- a/AlphaWalletTests/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewControllerTests.swift
+++ b/AlphaWalletTests/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewControllerTests.swift
@@ -19,7 +19,7 @@ class EnterSellTokensCardPriceQuantityViewControllerTests: FBSnapshotTestCase {
                 config: Config(),
                 storage: FakeTokensDataStore(),
                 paymentFlow: .send(type: .ERC875Token(tokenObject)),
-                ethPrice: .init(nil),
+                cryptoPrice: .init(nil),
                 viewModel: .init(token: tokenObject, tokenHolder: tokenHolder)
         )
         controller.configure()

--- a/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
+++ b/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
@@ -10,7 +10,7 @@ class PaymentCoordinatorTests: XCTestCase {
         let address: Address = .make()
         let coordinator = PaymentCoordinator(
             navigationController: FakeNavigationController(),
-            flow: .send(type: .ether(config: Config(), destination: address)),
+            flow: .send(type: .nativeCryptocurrency(config: Config(), destination: address)),
             session: .make(),
             keystore: FakeKeystore(),
             storage: FakeTokensDataStore(),


### PR DESCRIPTION
for #997 

Note: TokenObject is added into the database as Ethereum, therefore I had to patch the switch on token type to ensure that xdai was used when appropriate. 