### PR TITLE
set gas price to network value if non zero else default to 1 gwei

### DIFF
--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -24,7 +24,11 @@ class TransactionConfigurator {
     private let account: Account
 
     private lazy var calculatedGasPrice: BigInt = {
-        return transaction.gasPrice ?? configuration.gasPrice
+        if let gasPrice = transaction.gasPrice, gasPrice > 0 {
+            return gasPrice
+        } else {
+            return configuration.gasPrice
+        }
     }()
 
     private var requestEstimateGas: Bool {


### PR DESCRIPTION
For #1020 

@hboon will use the network set value (from the node) provided it is not zero, else it will default to 1 Gwei as set by configuration.gasPrice