### PR TITLE
Fix: tapping the Send button for ether and token card when on a watch-account doesn't show error message correctly

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -361,7 +361,11 @@ class InCoordinator: Coordinator {
             coordinator.start()
             addCoordinator(coordinator)
         case (_, _):
-            navigationController.displayError(error: InCoordinatorError.onlyWatchAccount)
+            if let topVC = navigationController.presentedViewController {
+                topVC.displayError(error: InCoordinatorError.onlyWatchAccount)
+            } else {
+                navigationController.displayError(error: InCoordinatorError.onlyWatchAccount)
+            }
         }
     }
 


### PR DESCRIPTION
The send button in this screen:

![simulator screen shot - iphone x - 2019-01-21 at 11 22 50](https://user-images.githubusercontent.com/56189/51451198-2290c880-1d6f-11e9-8b08-108303d02702.png)