### PR TITLE
Fix: blockchain name label is clipped in the send/receive screen for Ether

### DIFF
--- a/AlphaWallet/Transfer/Views/SendHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/SendHeaderView.swift
@@ -31,6 +31,7 @@ class SendHeaderView: UIView {
         valueNameLabel.textAlignment = .center
 
         let bottomRowStack = [blockchainLabel, issuerLabel].asStackView(spacing: 15)
+        blockchainLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         let footerValuesStack = [valuePercentageChangeValueLabel, valueChangeLabel, valueLabel].asStackView(distribution: .equalCentering, spacing: 15)
 


### PR DESCRIPTION
For #1031 