### PR TITLE
Add support to display etherscan-like page for wallet address and fetch/display transaction list for POA Network

### DIFF
--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -105,7 +105,7 @@ struct Config {
             case .kovan: return "https://api-kovan.etherscan.io"
             case .ropsten: return "https://api-ropsten.etherscan.io"
             case .rinkeby: return "https://api-rinkeby.etherscan.io"
-            case .poa: return "https://poa.trustwalletapp.com"
+            case .poa: return "https://blockscout.com/poa/core/api"
             case .xDai: return "https://blockscout.com/poa/dai/api"
             case .sokol: return "https://trust-sokol.herokuapp.com"
             case .custom:

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -51,6 +51,9 @@ public struct Constants {
     //xDai APIs
     public static let xDaiAPI = "https://blockscout.com/poa/dai/"
 
+    //POA Network
+    public static let poaNetworkCoreAPI = "https://blockscout.com/poa/core/address/"
+
     //xDai contract page
     public static let xDaiContractPage = "https://blockscout.com/poa/dai/address/"
 

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -55,7 +55,7 @@ enum RPCServer: Hashable {
         case .ropsten: return Constants.ropstenEtherscanAPI
         case .rinkeby: return Constants.rinkebyEtherscanAPI
         case .kovan: return Constants.kovanEtherscanAPI
-        case .poa: return Constants.mainnetEtherscanAPI
+        case .poa: return Constants.poaNetworkCoreAPI
         case .sokol: return Constants.mainnetEtherscanAPI
         case .classic: return Constants.mainnetEtherscanAPI
         case .callisto: return Constants.mainnetEtherscanAPI
@@ -71,7 +71,8 @@ enum RPCServer: Hashable {
         case .rinkeby: return Constants.rinkebyEtherscanContractDetailsWebPageURL
         case .kovan: return Constants.kovanEtherscanContractDetailsWebPageURL
         case .xDai: return Constants.xDaiContractPage
-        case .poa, .sokol, .classic, .callisto, .custom: return Constants.mainnetEtherscanContractDetailsWebPageURL
+        case .poa: return Constants.poaNetworkCoreAPI
+        case .sokol, .classic, .callisto, .custom: return Constants.mainnetEtherscanContractDetailsWebPageURL
         }
     }
 


### PR DESCRIPTION
Test address: 0x52fE2ba14dB890b5cf98FBB0Eac74AF7A38Aca5F.

We can probably use Blockscout for POA Sokol, Ethereum Classic too