### PR TITLE
Display ERC20 transfers (send only) in redesigned send/receive view

### DIFF
--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -20,7 +20,7 @@ class MigrationInitializer: Initializer {
     }
 
     func perform() {
-        config.schemaVersion = 51
+        config.schemaVersion = 52
         config.migrationBlock = { migration, oldSchemaVersion in
             if oldSchemaVersion < 33 {
                 migration.enumerateObjects(ofType: TokenObject.className()) { oldObject, newObject in
@@ -71,6 +71,9 @@ class MigrationInitializer: Initializer {
                     newObject["order"] = bookmarkOrder
                     bookmarkOrder += 1
                 }
+            }
+            if oldSchemaVersion < 52 {
+                migration.deleteData(forType: Transaction.className())
             }
         }
     }

--- a/AlphaWallet/EtherClient/TrustClient/Models/OperationType.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/OperationType.swift
@@ -3,7 +3,10 @@
 import Foundation
 
 enum OperationType: String {
-    case tokenTransfer = "token_transfer"
+    case nativeCurrencyTokenTransfer
+    case erc20TokenTransfer
+    case erc721TokenTransfer
+    case erc875TokenTransfer
     case unknown
 
     init(string: String) {

--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 import TrustKeystore
+import BigInt
+import PromiseKit
 
 struct RawTransaction: Decodable {
     let hash: String
@@ -37,10 +39,9 @@ struct RawTransaction: Decodable {
 }
 
 extension Transaction {
-    static func from(transaction: RawTransaction) -> Transaction? {
-        guard
-            let from = Address(string: transaction.from) else {
-                return .none
+    static func from(transaction: RawTransaction, tokensStorage: TokensDataStore) -> Promise<Transaction?> {
+        guard let from = Address(string: transaction.from) else {
+            return Promise.value(nil)
         }
         let state: TransactionState = {
             if transaction.error?.isEmpty == false {
@@ -49,19 +50,80 @@ extension Transaction {
             return .completed
         }()
         let to = Address(string: transaction.to)?.description ?? transaction.to
-        return Transaction(
-            id: transaction.hash,
-            blockNumber: Int(transaction.blockNumber)!,
-            from: from.description,
-            to: to,
-            value: transaction.value,
-            gas: transaction.gas,
-            gasPrice: transaction.gasPrice,
-            gasUsed: transaction.gasUsed,
-            nonce: transaction.nonce,
-            date: NSDate(timeIntervalSince1970: TimeInterval(transaction.timeStamp) ?? 0) as Date,
-            localizedOperations: LocalizedOperationObject.from(operations: transaction.operationsLocalized),
-            state: state
-        )
+        return firstly {
+            createOperationForTokenTransfer(forTransaction: transaction, tokensStorage: tokensStorage)
+        }.then { operations -> Promise<Transaction?> in
+            let result = Transaction(
+                    id: transaction.hash,
+                    blockNumber: Int(transaction.blockNumber)!,
+                    from: from.description,
+                    to: to,
+                    value: transaction.value,
+                    gas: transaction.gas,
+                    gasPrice: transaction.gasPrice,
+                    gasUsed: transaction.gasUsed,
+                    nonce: transaction.nonce,
+                    date: NSDate(timeIntervalSince1970: TimeInterval(transaction.timeStamp) ?? 0) as Date,
+                    localizedOperations: operations,
+                    state: state)
+            return .value(result)
+        }
+    }
+
+    static private func createOperationForTokenTransfer(forTransaction transaction: RawTransaction, tokensStorage: TokensDataStore) -> Promise<[LocalizedOperationObject]> {
+        guard transaction.input != "0x" else {
+            return Promise.value([])
+        }
+        guard transaction.input.count == 138 else {
+            return Promise.value([])
+        }
+
+        let functionHash = String(transaction.input[transaction.input.index(transaction.input.startIndex, offsetBy: 0)..<transaction.input.index(transaction.input.startIndex, offsetBy: 10)])
+        //transfer(address _to, uint256 _value)
+        let functionHasForERC20Transfer = "0xa9059cbb"
+        switch functionHash {
+        case functionHasForERC20Transfer:
+            let amount1 = transaction.input[transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 64)..<transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 64 + 64)]
+            let amount = BigInt(amount1, radix: 16)
+            //Extract the address and strip the first 12 (x2 = 24) characters of 0s
+            let to = "0x\(transaction.input[transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 24)..<transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 64)])"
+            if let amount = amount, let to = Address(string: to)?.eip55String {
+                let contract = transaction.to
+                if let token = tokensStorage.token(forContract: contract) {
+                    let operationType = mapTokenTypeToTransferOperationType(token.type)
+                    let result = LocalizedOperationObject(from: transaction.from, to: to, contract: contract, type: operationType.rawValue, value: String(amount), symbol: token.symbol, name: token.name, decimals: token.decimals)
+                    return .value([result])
+                } else {
+                    let getContractName = tokensStorage.getContractName(for: contract)
+                    let getContractSymbol = tokensStorage.getContractSymbol(for: contract)
+                    let getDecimals = tokensStorage.getDecimals(for: contract)
+                    let getTokenType = tokensStorage.getTokenType(for: contract)
+                    return firstly {
+                        when(fulfilled: getContractName, getContractSymbol, getDecimals, getTokenType )
+                    }.then { name, symbol, decimals, tokenType -> Promise<[LocalizedOperationObject]> in
+                        let operationType = mapTokenTypeToTransferOperationType(tokenType)
+                        let result = LocalizedOperationObject(from: transaction.from, to: to, contract: contract, type: operationType.rawValue, value: String(amount), symbol: symbol, name: name, decimals: Int(decimals))
+                        return .value([result])
+                    }
+                }
+            } else {
+                return Promise.value([])
+            }
+        default:
+            return Promise.value([])
+        }
+    }
+
+    static private func mapTokenTypeToTransferOperationType(_ tokenType: TokenType) -> OperationType {
+        switch tokenType {
+        case .nativeCryptocurrency, .xDai:
+            return .nativeCurrencyTokenTransfer
+        case .erc20:
+            return .erc20TokenTransfer
+        case .erc721:
+            return .erc721TokenTransfer
+        case .erc875:
+            return .erc875TokenTransfer
+        }
     }
 }

--- a/AlphaWallet/Models/PendingTransaction.swift
+++ b/AlphaWallet/Models/PendingTransaction.swift
@@ -61,6 +61,7 @@ extension Transaction {
             gasUsed: "",
             nonce: transaction.nonce,
             date: Date(),
+            //TODO we should know what type of transaction (transfer) here and create accordingly if it's ERC20, ERC721, ERC875
             localizedOperations: [],
             state: .pending
         )

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -174,6 +174,7 @@ class TokensDataStore {
             completion(result)
         }
     }
+
     func getDecimals(for addressString: String,
                      completion: @escaping (ResultResult<UInt8, AnyError>.t) -> Void) {
         let address = Address(string: addressString)
@@ -181,6 +182,57 @@ class TokensDataStore {
             completion(result)
         }
     }
+
+    func getContractName(for addressString: String) -> Promise<String> {
+        let address = Address(string: addressString)
+        return Promise { seal in
+            getNameCoordinator.getName(for: address!) { (result) in
+                switch result {
+                case .success(let name):
+                    seal.fulfill(name)
+                case .failure(let error):
+                    seal.reject(error)
+                }
+            }
+        }
+    }
+
+    func getContractSymbol(for addressString: String) -> Promise<String> {
+        let address = Address(string: addressString)
+        return Promise { seal in
+            getSymbolCoordinator.getSymbol(for: address!) { result in
+                switch result {
+                case .success(let name):
+                    seal.fulfill(name)
+                case .failure(let error):
+                    seal.reject(error)
+                }
+            }
+        }
+    }
+
+    func getDecimals(for addressString: String) -> Promise<UInt8> {
+        let address = Address(string: addressString)
+        return Promise { seal in
+            getDecimalsCoordinator.getDecimals(for: address!) { result in
+                switch result {
+                case .success(let name):
+                    seal.fulfill(name)
+                case .failure(let error):
+                    seal.reject(error)
+                }
+            }
+        }
+    }
+
+    func getTokenType(for addressString: String) -> Promise<TokenType> {
+        return Promise { seal in
+            getTokenType(for: addressString) { tokenType in
+                seal.fulfill(tokenType)
+            }
+        }
+    }
+
 
     func getERC875Balance(for addressString: String,
                           completion: @escaping (ResultResult<[String], AnyError>.t) -> Void) {
@@ -255,6 +307,10 @@ class TokensDataStore {
                 completion(.erc20)
             }
         }
+    }
+
+    func token(forContract contract: String) -> TokenObject? {
+        return realm.objects(TokenObject.self).first { $0.contract.sameContract(as: contract) }
     }
 
     func refreshBalance() {

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerTransactionCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerTransactionCellViewModel.swift
@@ -28,8 +28,14 @@ struct TokenViewControllerTransactionCellViewModel {
 
     var value: NSAttributedString {
         let value = transactionViewModel.shortValue
+        let amount: String
+        if let operation = transaction.operation, (operation.operationType == .erc721TokenTransfer || operation.operationType == .erc875TokenTransfer) {
+            amount = transactionViewModel.amountWithSign(for: value.amount)
+        } else {
+            amount = transactionViewModel.amountWithSign(for: value.amount) + " " + value.symbol
+        }
         return NSAttributedString(
-                string: transactionViewModel.amountWithSign(for: value.amount) + " " + value.symbol,
+                string: amount,
                 attributes: [
                     .font: Fonts.semibold(size: 16)!,
                     .foregroundColor: transactionViewModel.amountTextColor,

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -19,8 +19,23 @@ struct TokenViewControllerViewModel {
 
         switch transferType {
         case .nativeCryptocurrency, .xDai:
-            self.recentTransactions = Array(transactionsStore.objects.lazy.filter({ $0.state == .completed || $0.state == .pending }).filter({ $0.value != "" && $0.value != "0" }).prefix(3))
-        case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
+            self.recentTransactions = Array(transactionsStore.objects.lazy
+                    .filter({ $0.state == .completed || $0.state == .pending })
+                    .filter({ $0.operation == nil })
+                    .filter({ $0.value != "" && $0.value != "0" })
+                    .prefix(3))
+        case .ERC20Token(let token):
+            self.recentTransactions = Array(transactionsStore.objects.lazy
+                    .filter({ $0.state == .completed || $0.state == .pending })
+                    .filter({
+                        if let operation = $0.operation {
+                            return operation.operationType == .erc20TokenTransfer
+                        } else {
+                            return false
+                        }})
+                    .filter({ $0.operation?.contract?.sameContract(as: token.contract) ?? false })
+                    .prefix(3))
+        case .ERC875Token, .ERC875TokenOrder, .ERC721Token, .dapp:
             self.recentTransactions = []
         }
     }

--- a/AlphaWallet/Transactions/Coordinators/TransactionCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionCoordinator.swift
@@ -21,7 +21,8 @@ class TransactionCoordinator: Coordinator {
         let coordinator = TransactionDataCoordinator(
             session: session,
             storage: storage,
-            keystore: keystore
+            keystore: keystore,
+            tokensStorage: tokensStorage
         )
         return coordinator
     }()

--- a/AlphaWallet/Transactions/ViewModels/TransactionCellViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionCellViewModel.swift
@@ -36,7 +36,7 @@ struct TransactionCellViewModel {
     private var operationTitle: String? {
         guard let operation = transaction.operation else { return .none }
         switch operation.operationType {
-        case .tokenTransfer:
+        case .nativeCurrencyTokenTransfer, .erc20TokenTransfer, .erc721TokenTransfer, .erc875TokenTransfer:
             return R.string.localizable.transactionCellTokenTransferTitle(operation.symbol ?? "")
         case .unknown:
             return .none
@@ -101,13 +101,18 @@ struct TransactionCellViewModel {
 
     var amountAttributedString: NSAttributedString {
         let value = transactionViewModel.shortValue
-
+        let amount: String
+        if let operation = transaction.operation, (operation.operationType == .erc721TokenTransfer || operation.operationType == .erc875TokenTransfer) {
+            amount = transactionViewModel.amountWithSign(for: value.amount)
+        } else {
+            amount = transactionViewModel.amountWithSign(for: value.amount) + " " + value.symbol
+        }
         return NSAttributedString(
-            string: transactionViewModel.amountWithSign(for: value.amount) + " " + value.symbol,
-            attributes: [
-                .font: Fonts.light(size: 25)!,
-                .foregroundColor: transactionViewModel.amountTextColor,
-            ]
+                string: amount,
+                attributes: [
+                    .font: Fonts.light(size: 25)!,
+                    .foregroundColor: transactionViewModel.amountTextColor,
+                ]
         )
     }
 

--- a/AlphaWallet/Transactions/ViewModels/TransactionViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionViewModel.swift
@@ -84,14 +84,22 @@ struct TransactionViewModel {
 
     private func transactionValue(for formatter: EtherNumberFormatter) -> TransactionValue {
         if let operation = transaction.operation, let symbol = operation.symbol {
+            if operation.operationType == .erc721TokenTransfer || operation.operationType == .erc875TokenTransfer {
+                return TransactionValue(
+                        amount: operation.value,
+                        symbol: symbol
+                )
+            } else {
+                return TransactionValue(
+                        amount: formatter.string(from: BigInt(operation.value) ?? BigInt(), decimals: operation.decimals),
+                        symbol: symbol
+                )
+            }
+        } else {
             return TransactionValue(
-                amount: formatter.string(from: BigInt(operation.value) ?? BigInt(), decimals: operation.decimals),
-                symbol: symbol
+                    amount: formatter.string(from: BigInt(transaction.value) ?? BigInt()),
+                    symbol: config.server.symbol
             )
         }
-        return TransactionValue(
-            amount: formatter.string(from: BigInt(transaction.value) ?? BigInt()),
-            symbol: config.server.symbol
-        )
     }
 }

--- a/AlphaWallet/Transfer/Types/SentTransaction.swift
+++ b/AlphaWallet/Transfer/Types/SentTransaction.swift
@@ -21,6 +21,7 @@ extension SentTransaction {
             gasUsed: "",
             nonce: String(transaction.original.nonce),
             date: Date(),
+            //TODO we should know what type of transaction (transfer) here and create accordingly if it's ERC20, ERC721, ERC875
             localizedOperations: [],
             state: .pending
         )


### PR DESCRIPTION
For #1049.

This involves storing the transaction (transfer) types for transactions in the database. So there is also a slight change to ERC721 transactions to show something like "-1088247" instead of "-1,088,247 CKITTY" to avoid look like we transferred 1 million tokens in the Transactions tab.

Possible future enhancement for tokens we are aware of like CryptoKitties might be to display the image of the token (kitty). Or interpreting ERC875 too (I just did the minimum to get ERC20 to show up, so they are currently still showing as 0 ETH transfers).

|   |   |
| -- | --|
| ![simulator screen shot - iphone x - 2019-01-28 at 17 26 08](https://user-images.githubusercontent.com/56189/51826466-1d5cec00-2322-11e9-9425-8b3df026ba86.png) | ![simulator screen shot - iphone x - 2019-01-28 at 17 26 22](https://user-images.githubusercontent.com/56189/51826586-5dbc6a00-2322-11e9-82df-f5adef06b5e2.png) |


