### PR TITLE
Fix: Redeem token screen layout broken

### DIFF
--- a/AlphaWallet/Redeem/ViewControllers/TokenCardRedemptionViewController.swift
+++ b/AlphaWallet/Redeem/ViewControllers/TokenCardRedemptionViewController.swift
@@ -80,6 +80,9 @@ class TokenCardRedemptionViewController: UIViewController, TokenVerifiableStatus
             imageHolder.trailingAnchor.constraint(equalTo: tokenRowView.background.trailingAnchor),
 			imageHolder.widthAnchor.constraint(equalTo: imageHolder.heightAnchor),
 
+            tokenRowView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tokenRowView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.topAnchor),


### PR DESCRIPTION
Fixes this: 

![simulator screen shot - iphone x - 2019-01-29 at 23 08 22](https://user-images.githubusercontent.com/56189/51917627-e8809000-241a-11e9-8699-adcd8d5d5f76.png)

(another candidate for snapshot test).