### PR TITLE
Adjust action button titles in choose token transfer mode screen to fit long titles

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/ChooseTokenCardTransferModeViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ChooseTokenCardTransferModeViewControllerViewModel.swift
@@ -18,9 +18,9 @@ struct ChooseTokenCardTransferModeViewControllerViewModel {
 
     var buttonFont: UIFont {
         if ScreenChecker().isNarrowScreen() {
-            return Fonts.regular(size: 13)!
+            return Fonts.regular(size: 12)!
         } else {
-            return Fonts.regular(size: 16)!
+            return Fonts.regular(size: 15)!
         }
     }
 }


### PR DESCRIPTION
Was:

![simulator screen shot - iphone x - 2019-01-28 at 13 11 17](https://user-images.githubusercontent.com/56189/51920790-06e98a00-2421-11e9-9808-fef001b821e0.png)
