### PR TITLE
Fix: Ether appreciated value and USD value appears too slowly in asset card in Wallet tab

### DIFF
--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -630,6 +630,7 @@ class TokensDataStore {
 
     private func scheduledTimerForPricesUpdate() {
         guard !config.isAutoFetchingDisabled else { return }
+        updatePrices()
         pricesTimer = Timer.scheduledTimer(timeInterval: intervalToRefreshPrices, target: BlockOperation { [weak self] in
             self?.updatePrices()
         }, selector: #selector(Operation.main), userInfo: nil, repeats: true)


### PR DESCRIPTION
For #1069 