### PR TITLE
Refactor: Pass Config instance around rather than create locally

### DIFF
--- a/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
+++ b/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
@@ -31,7 +31,7 @@ class AccountsCoordinator: Coordinator {
     weak var delegate: AccountsCoordinatorDelegate?
 
     init(
-        config: Config = Config(),
+        config: Config,
         navigationController: UINavigationController,
         keystore: Keystore,
         balanceCoordinator: GetBalanceCoordinator
@@ -72,7 +72,7 @@ class AccountsCoordinator: Coordinator {
 	}
 
     func importOrCreateWallet(entryPoint: WalletEntryPoint) {
-        let coordinator = WalletCoordinator(keystore: keystore)
+        let coordinator = WalletCoordinator(config: config, keystore: keystore)
         if case .createInstantWallet = entryPoint {
             coordinator.navigationController = navigationController
         }

--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -6,7 +6,8 @@ import UIKit
 import BigInt
 
 class AppCoordinator: NSObject, Coordinator {
-    private let config: Config
+    //TODO remove once we support multi-chain
+    private var config: Config
     private lazy var welcomeViewController: WelcomeViewController = {
         let controller = WelcomeViewController()
         controller.delegate = self
@@ -48,7 +49,7 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     init(
-        config: Config = Config(),
+        config: Config = Config(chainID: Config.getChainId()),
         window: UIWindow,
         keystore: Keystore,
         navigationController: UINavigationController = NavigationController()
@@ -98,6 +99,7 @@ class AppCoordinator: NSObject, Coordinator {
                 wallet: wallet,
                 keystore: keystore,
                 assetDefinitionStore: assetDefinitionStore,
+                config: config,
                 appTracker: appTracker
         )
         coordinator.delegate = self
@@ -150,6 +152,7 @@ class AppCoordinator: NSObject, Coordinator {
 
     func showInitialWalletCoordinator(entryPoint: WalletEntryPoint) {
         let coordinator = InitialWalletCreationCoordinator(
+                config: config,
                 navigationController: navigationController,
                 keystore: keystore,
                 entryPoint: entryPoint
@@ -160,7 +163,7 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     private func createInitialWallet() {
-        WalletCoordinator(keystore: keystore).createInitialWallet()
+        WalletCoordinator(config: config, keystore: keystore).createInitialWallet()
     }
 
     @discardableResult func handleUniversalLink(url: URL) -> Bool {
@@ -186,7 +189,7 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     func handleUniversalLinkInPasteboard() {
-        let universalLinkPasteboardCoordinator = UniversalLinkInPasteboardCoordinator()
+        let universalLinkPasteboardCoordinator = UniversalLinkInPasteboardCoordinator(config: config)
         universalLinkPasteboardCoordinator.delegate = self
         universalLinkPasteboardCoordinator.start()
     }
@@ -249,6 +252,11 @@ extension AppCoordinator: InCoordinatorDelegate {
 
     func assetDefinitionsOverrideViewController(for coordinator: InCoordinator) -> UIViewController? {
         return assetDefinitionStoreCoordinator?.createOverridesViewController()
+    }
+
+    func mayHaveChangeChain(in coordinator: InCoordinator) {
+        config = Config(chainID: Config.getChainId())
+        inCoordinator?.config = config
     }
 }
 

--- a/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
+++ b/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
@@ -7,7 +7,7 @@ class CurrencyFormatter {
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
-        formatter.currencyCode = Config().currency.rawValue
+        formatter.currencyCode = Config.getCurrency().rawValue
         formatter.numberStyle = .currency
         return formatter
     }

--- a/AlphaWallet/EtherClient/ChainState.swift
+++ b/AlphaWallet/EtherClient/ChainState.swift
@@ -28,9 +28,7 @@ class ChainState {
 
     var updateLatestBlock: Timer?
 
-    init(
-        config: Config = Config()
-    ) {
+    init(config: Config) {
         self.config = config
         self.defaults = config.defaults
         if config.isAutoFetchingDisabled {
@@ -50,7 +48,7 @@ class ChainState {
     }
 
     @objc func fetch() {
-        let request = EtherServiceRequest(batch: BatchFactory().create(BlockNumberRequest()))
+        let request = EtherServiceRequest(config: config, batch: BatchFactory().create(BlockNumberRequest()))
         Session.send(request) { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {

--- a/AlphaWallet/EtherClient/EtherServiceRequest.swift
+++ b/AlphaWallet/EtherClient/EtherServiceRequest.swift
@@ -5,12 +5,12 @@ import APIKit
 import JSONRPCKit
 
 struct EtherServiceRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
+    let config: Config
     let batch: Batch
 
     typealias Response = Batch.Responses
 
     var baseURL: URL {
-        let config = Config()
         return config.rpcURL
     }
 

--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -29,8 +29,8 @@ class OpenSea {
     }
 
     ///Uses a promise to make sure we don't fetch from OpenSea multiple times concurrently
-    func makeFetchPromise(owner: String) -> PromiseResult {
-        switch Config().server {
+    func makeFetchPromise(config: Config, owner: String) -> PromiseResult {
+        switch config.server {
         case .main:
             break
         case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .custom, .xDai:

--- a/AlphaWallet/Export/Coordinators/PromptBackupCoordinator.swift
+++ b/AlphaWallet/Export/Coordinators/PromptBackupCoordinator.swift
@@ -10,12 +10,14 @@ protocol PromptBackupCoordinatorDelegate: class {
 ///We allow user to switch wallets, so it's important to know which wallet we are prompting for. It might not be the current wallet
 class PromptBackupCoordinator: Coordinator {
     private var walletAddress: String
+    private let config: Config
 
     var coordinators: [Coordinator] = []
     weak var delegate: PromptBackupCoordinatorDelegate?
 
-    init(walletAddress: String) {
+    init(walletAddress: String, config: Config) {
         self.walletAddress = walletAddress
+        self.config = config
     }
 
     func start() {
@@ -24,7 +26,7 @@ class PromptBackupCoordinator: Coordinator {
             finish()
             return
         }
-        let coordinator = WalletCoordinator(keystore: keystore)
+        let coordinator = WalletCoordinator(config: config, keystore: keystore)
         coordinator.delegate = self
         let proceed = coordinator.start(.backupWallet(address: walletAddress))
         guard proceed else {

--- a/AlphaWallet/Export/ViewControllers/BackUpViewController.swift
+++ b/AlphaWallet/Export/ViewControllers/BackUpViewController.swift
@@ -9,12 +9,14 @@ protocol BackupViewControllerDelegate: class {
 }
 
 class BackupViewController: UIViewController {
+    private let config: Config
     private let account: Account
-    private let viewModel = BackupViewModel()
+    lazy private var viewModel = BackupViewModel(config: config)
 
     weak var delegate: BackupViewControllerDelegate?
 
-    init(account: Account) {
+    init(config: Config, account: Account) {
+        self.config = config
         self.account = account
 
         super.init(nibName: nil, bundle: nil)

--- a/AlphaWallet/Export/ViewModels/BackupViewModel.swift
+++ b/AlphaWallet/Export/ViewModels/BackupViewModel.swift
@@ -3,12 +3,9 @@
 import Foundation
 
 struct BackupViewModel {
-
     private let config: Config
 
-    init(
-        config: Config = Config()
-    ) {
+    init(config: Config) {
         self.config = config
     }
 

--- a/AlphaWallet/Extensions/Date.swift
+++ b/AlphaWallet/Extensions/Date.swift
@@ -27,16 +27,15 @@ public extension Date {
     }
 
     public static func formatter(with format: String, withTimeZone timeZone: TimeZone? = nil) -> DateFormatter {
-        let config = Config()
-        if config.locale != formatsMapLocale {
-            formatsMapLocale = config.locale
+        if Config.getLocale() != formatsMapLocale {
+            formatsMapLocale = Config.getLocale()
             formatsMap = Dictionary()
         }
 
         var foundFormatter = formatsMap[format]
         if foundFormatter == nil {
             foundFormatter = DateFormatter()
-            if let locale = config.locale {
+            if let locale = Config.getLocale() {
                 foundFormatter?.locale = Locale(identifier: locale)
             }
             foundFormatter?.setLocalizedDateFormatFromTemplate(format)

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -11,6 +11,8 @@ protocol InCoordinatorDelegate: class {
     func didUpdateAccounts(in coordinator: InCoordinator)
     func didShowWallet(in coordinator: InCoordinator)
     func assetDefinitionsOverrideViewController(for coordinator: InCoordinator) -> UIViewController?
+    //TODO remove when we support multi-chain
+    func mayHaveChangeChain(in coordinator: InCoordinator)
 }
 
 enum Tabs {
@@ -32,7 +34,8 @@ enum Tabs {
 
 class InCoordinator: Coordinator {
     private let initialWallet: Wallet
-    private let config: Config
+    //TODO make private or remove once we support multi-chain
+    var config: Config
     private let assetDefinitionStore: AssetDefinitionStore
     private let appTracker: AppTracker
     private var tokensStorageForCryptoPriceFetching: TokensDataStore?
@@ -76,7 +79,7 @@ class InCoordinator: Coordinator {
             wallet: Wallet,
             keystore: Keystore,
             assetDefinitionStore: AssetDefinitionStore,
-            config: Config = Config(),
+            config: Config,
             appTracker: AppTracker = AppTracker()
     ) {
         self.navigationController = navigationController
@@ -271,7 +274,7 @@ class InCoordinator: Coordinator {
     }
 
     private func promptBackupWallet(withAddress address: String) {
-        let coordinator = PromptBackupCoordinator(walletAddress: address)
+        let coordinator = PromptBackupCoordinator(walletAddress: address, config: config)
         addCoordinator(coordinator)
         coordinator.delegate = self
         coordinator.start()
@@ -311,6 +314,7 @@ class InCoordinator: Coordinator {
         removeAllCoordinators()
         OpenSea.sharedInstance.reset()
         callForAssetAttributeCoordinator = nil
+        delegate?.mayHaveChangeChain(in: self)
         restartCryptoPriceFetching()
         showTabBar(for: account)
         fetchXMLAssetDefinitions()

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -205,7 +205,7 @@ class UniversalLinkCoordinator: Coordinator {
         if isLegacyLink {
             prefix = Constants.legacyMagicLinkPrefix
         }
-        guard let signedOrder = UniversalLinkHandler().parseUniversalLink(url: url.absoluteString, prefix: prefix) else {
+        guard let signedOrder = UniversalLinkHandler(config: config).parseUniversalLink(url: url.absoluteString, prefix: prefix) else {
             showImportError(errorMessage: R.string.localizable.aClaimTokenInvalidLinkTryAgain())
             return false
         }
@@ -409,8 +409,6 @@ class UniversalLinkCoordinator: Coordinator {
     private func makeTokenHolderImpl(name: String, bytes32Tokens: [String], contractAddress: String) {
         var tokens = [Token]()
         let xmlHandler = XMLHandler(contract: contractAddress)
-        //TODO should pass Config instance into this func instead
-        let config = Config()
         for i in 0..<bytes32Tokens.count {
             let token = bytes32Tokens[i]
             if let tokenId = BigUInt(token.drop0x, radix: 16) {
@@ -467,7 +465,7 @@ class UniversalLinkCoordinator: Coordinator {
 
     private func promptBackupWallet() {
         guard let keystore = try? EtherKeystore(), let address = keystore.recentlyUsedWallet?.address.eip55String else { return }
-		let coordinator = PromptBackupCoordinator(walletAddress: address)
+		let coordinator = PromptBackupCoordinator(walletAddress: address, config: config)
 		addCoordinator(coordinator)
 		coordinator.delegate = self
 		coordinator.start()

--- a/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
@@ -8,15 +8,21 @@ protocol UniversalLinkInPasteboardCoordinatorDelegate: class {
 }
 
 class UniversalLinkInPasteboardCoordinator: Coordinator {
+    private let config: Config
+
     var coordinators: [Coordinator] = []
     weak var delegate: UniversalLinkInPasteboardCoordinatorDelegate?
+
+    init(config: Config) {
+        self.config = config
+    }
     
     func start() {
         guard let contents = UIPasteboard.general.string?.trimmed else { return }
         guard let url = URL(string: contents) else { return }
         let isLegacy = contents.hasPrefix(Constants.legacyMagicLinkPrefix)
-        guard contents.hasPrefix(UniversalLinkHandler().urlPrefix) || isLegacy else {
-            let actualNetwork = Config().server.magicLinkNetwork(url: url.description)
+        guard contents.hasPrefix(UniversalLinkHandler(config: config).urlPrefix) || isLegacy else {
+            let actualNetwork = config.server.magicLinkNetwork(url: url.description)
             delegate?.showImportError(errorMessage: R.string.localizable.aClaimTokenWrongNetworkLink(actualNetwork), cost: nil)
             return
         }

--- a/AlphaWallet/Market/UniversalLinkHandler.swift
+++ b/AlphaWallet/Market/UniversalLinkHandler.swift
@@ -45,16 +45,19 @@ extension Array {
 }
 
 public class UniversalLinkHandler {
+    private let config: Config
 
     public let urlPrefix: String
 
-    init() {
-        urlPrefix = Config().magicLinkPrefix.description
+    init(config: Config) {
+        self.config = config
+
+        urlPrefix = config.magicLinkPrefix.description
     }
 
     //message is with 32 bytes each of price and expiry and is shortened for link
     func createUniversalLink(signedOrder: SignedOrder) -> String {
-        let prefix = Config().magicLinkPrefix.description
+        let prefix = config.magicLinkPrefix.description
         let message = formatMessageForLink(signedOrder: signedOrder)
         let signature = signedOrder.signature
         let link = (message + signature).hexa2Bytes

--- a/AlphaWallet/Redeem/ViewModels/RedeemTokenCardViewModel.swift
+++ b/AlphaWallet/Redeem/ViewModels/RedeemTokenCardViewModel.swift
@@ -13,9 +13,9 @@ struct RedeemTokenCardViewModel {
     let token: TokenObject
     let tokenHolders: [TokenHolder]
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self.token = token
-        self.tokenHolders = TokenAdaptor(token: token).getTokenHolders()
+        self.tokenHolders = TokenAdaptor(config: config, token: token).getTokenHolders()
 
         selectSoleTokenHolder()
     }

--- a/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
@@ -46,7 +46,7 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
     var contract: String {
         return viewModel.token.contract
     }
-    let pricePerTokenField = AmountTextField()
+    lazy var pricePerTokenField = AmountTextField(config: config)
     let paymentFlow: PaymentFlow
     weak var delegate: EnterSellTokensCardPriceQuantityViewControllerDelegate?
 

--- a/AlphaWallet/Sell/ViewControllers/SetSellTokensCardExpiryDateViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/SetSellTokensCardExpiryDateViewController.swift
@@ -122,7 +122,7 @@ class SetSellTokensCardExpiryDateViewController: UIViewController, TokenVerifiab
         datePicker.minimumDate = Date()
         datePicker.addTarget(self, action: #selector(datePickerValueChanged), for: .valueChanged)
         datePicker.isHidden = true
-        if let locale = config.locale {
+        if let locale = Config.getLocale() {
             datePicker.locale = Locale(identifier: locale)
         }
 
@@ -130,7 +130,7 @@ class SetSellTokensCardExpiryDateViewController: UIViewController, TokenVerifiab
         timePicker.minimumDate = Date.yesterday
         timePicker.addTarget(self, action: #selector(timePickerValueChanged), for: .valueChanged)
         timePicker.isHidden = true
-        if let locale = config.locale {
+        if let locale = Config.getLocale() {
             timePicker.locale = Locale(identifier: locale)
         }
 

--- a/AlphaWallet/Sell/ViewModels/SellTokensCardViewModel.swift
+++ b/AlphaWallet/Sell/ViewModels/SellTokensCardViewModel.swift
@@ -7,9 +7,9 @@ struct SellTokensCardViewModel {
     let token: TokenObject
     let tokenHolders: [TokenHolder]
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self.token = token
-        self.tokenHolders = TokenAdaptor(token: token).getTokenHolders()
+        self.tokenHolders = TokenAdaptor(config: config, token: token).getTokenHolders()
 
         selectSoleTokenHolder()
     }

--- a/AlphaWallet/Settings/Coordinators/LocalesCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/LocalesCoordinator.swift
@@ -21,7 +21,7 @@ class LocalesCoordinator: Coordinator {
             .japanese
         ]
         let controller = LocalesViewController()
-        controller.configure(viewModel: LocalesViewModel(locales: locales, selectedLocale: AppLocale(id: config.locale)))
+        controller.configure(viewModel: LocalesViewModel(locales: locales, selectedLocale: AppLocale(id: Config.getLocale())))
         controller.delegate = self
         return controller
     }()
@@ -37,7 +37,7 @@ class LocalesCoordinator: Coordinator {
 
 extension LocalesCoordinator: LocalesViewControllerDelegate {
     func didSelect(locale: AppLocale, in viewController: LocalesViewController) {
-        config.locale = locale.id
+        Config.setLocale(locale)
         delegate?.didSelect(locale: locale, in: self)
     }
 }

--- a/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
@@ -42,7 +42,7 @@ class ServersCoordinator: Coordinator {
 
 extension ServersCoordinator: ServersViewControllerDelegate {
     func didSelectServer(server: RPCServer, in viewController: ServersViewController) {
-        config.chainID = server.chainID
+        Config.setChainId(server.chainID)
         delegate?.didSelectServer(server: server, in: self)
     }
 }

--- a/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
@@ -55,6 +55,7 @@ class SettingsCoordinator: Coordinator {
 
 	@objc func showAccounts() {
 		let coordinator = AccountsCoordinator(
+				config: session.config,
 				navigationController: NavigationController(),
 				keystore: keystore,
 				balanceCoordinator: balanceCoordinator

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -6,6 +6,66 @@ import TrustKeystore
 import web3swift
 
 struct Config {
+    //TODO `currency` was originally a instance-side property, but was refactored out. Maybe better if it it's moved elsewhere
+    static func getCurrency() -> Currency {
+        let defaults = UserDefaults.standard
+
+        //If it is saved currency
+        if let currency = defaults.string(forKey: Keys.currencyID) {
+            return Currency(rawValue: currency)!
+        }
+        //If ther is not saved currency try to use user local currency if it is supported.
+        let availableCurrency = Currency.allValues.first { currency in
+            return currency.rawValue == Locale.current.currencySymbol
+        }
+        if let isAvailableCurrency = availableCurrency {
+            return isAvailableCurrency
+        }
+        //If non of the previous is not working return USD.
+        return Currency.USD
+    }
+
+    static func setCurrency(_ currency: Currency) {
+        let defaults = UserDefaults.standard
+        defaults.set(currency.rawValue, forKey: Keys.currencyID)
+    }
+
+    //TODO `locale` was originally a instance-side property, but was refactored out. Maybe better if it it's moved elsewhere
+    static func getLocale() -> String? {
+        let defaults = UserDefaults.standard
+        return defaults.string(forKey: Keys.locale)
+    }
+
+    static func setLocale(_ locale: AppLocale) {
+        setLocale(locale.id)
+    }
+
+    static func setLocale(_ locale: String?) {
+        let defaults = UserDefaults.standard
+        let preferenceKeyForOverridingInAppLanguage = "AppleLanguages"
+        if let locale = locale {
+            defaults.set(locale, forKey: Keys.locale)
+            defaults.set([locale], forKey: preferenceKeyForOverridingInAppLanguage)
+        } else {
+            defaults.removeObject(forKey: Keys.locale)
+            defaults.removeObject(forKey: preferenceKeyForOverridingInAppLanguage)
+        }
+        defaults.synchronize()
+        LiveLocaleSwitcherBundle.switchLocale(to: locale)
+    }
+
+    //TODO remove when we support multi-chain
+    //TODO we should also look for where Config instances are created
+    static func setChainId(_ chainId: Int, defaults: UserDefaults = UserDefaults.standard) {
+        defaults.set(chainId, forKey: Keys.chainID)
+    }
+
+    static func getChainId(defaults: UserDefaults = UserDefaults.standard) -> Int {
+        let id = defaults.integer(forKey: Keys.chainID)
+        guard id > 0 else { return RPCServer.main.chainID }
+        return id
+    }
+
     struct Keys {
         static let chainID = "chainID"
         static let isCryptoPrimaryCurrency = "isCryptoPrimaryCurrency"
@@ -18,55 +78,12 @@ struct Config {
 
     let defaults: UserDefaults
 
-    init(
-        defaults: UserDefaults = UserDefaults.standard
-    ) {
+    init(chainID: Int, defaults: UserDefaults = UserDefaults.standard) {
+        self.chainID = chainID
         self.defaults = defaults
     }
 
-    var currency: Currency {
-        get {
-            //If it is saved currency
-            if let currency = defaults.string(forKey: Keys.currencyID) {
-                return Currency(rawValue: currency)!
-            }
-            //If ther is not saved currency try to use user local currency if it is supported.
-            let availableCurrency = Currency.allValues.first { currency in
-                return currency.rawValue == Locale.current.currencySymbol
-            }
-            if let isAvailableCurrency = availableCurrency {
-                return isAvailableCurrency
-            }
-            //If non of the previous is not working return USD.
-            return Currency.USD
-        }
-        set { defaults.set(newValue.rawValue, forKey: Keys.currencyID) }
-    }
-
-    var chainID: Int {
-        get {
-            let id = defaults.integer(forKey: Keys.chainID)
-            guard id > 0 else { return RPCServer.main.chainID }
-            return id
-        }
-        set { defaults.set(newValue, forKey: Keys.chainID) }
-    }
-
-    var locale: String? {
-        get { return defaults.string(forKey: Keys.locale) }
-        set {
-            let preferenceKeyForOverridingInAppLanguage = "AppleLanguages"
-            if let locale = newValue {
-                defaults.set(newValue, forKey: Keys.locale)
-                defaults.set([locale], forKey: preferenceKeyForOverridingInAppLanguage)
-            } else {
-                defaults.removeObject(forKey: Keys.locale)
-                defaults.removeObject(forKey: preferenceKeyForOverridingInAppLanguage)
-            }
-            defaults.synchronize()
-            LiveLocaleSwitcherBundle.switchLocale(to: newValue)
-        }
-    }
+    let chainID: Int
 
     var server: RPCServer {
         return RPCServer(chainID: chainID)

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -68,11 +68,6 @@ struct Config {
         }
     }
 
-    var isCryptoPrimaryCurrency: Bool {
-        get { return defaults.bool(forKey: Keys.isCryptoPrimaryCurrency) }
-        set { defaults.set(newValue, forKey: Keys.isCryptoPrimaryCurrency) }
-    }
-
     var server: RPCServer {
         return RPCServer(chainID: chainID)
     }

--- a/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
@@ -72,7 +72,7 @@ class SettingsViewController: FormViewController {
             guard let strongSelf = self else { return }
             cell.imageView?.image = R.image.settings_language()?.withRenderingMode(.alwaysTemplate)
             cell.textLabel?.text = strongSelf.viewModel.localeTitle
-            cell.detailTextLabel?.text = AppLocale(id: strongSelf.session.config.locale).displayName
+            cell.detailTextLabel?.text = AppLocale(id: Config.getLocale()).displayName
             cell.accessoryType = .disclosureIndicator
         }
 

--- a/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/CallForAssetAttributeCoordinator.swift
@@ -87,7 +87,7 @@ class CallForAssetAttributeCoordinator {
 
     private func refreshFunctionCallBasedAssetAttributes(forToken token: TokenObject) {
         contractToRefetch = token.contract
-        _ = TokenAdaptor(token: token).getTokenHolders()
+        _ = TokenAdaptor(config: config, token: token).getTokenHolders()
         contractToRefetch = nil
     }
 

--- a/AlphaWallet/Tokens/Coordinators/GetBalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetBalanceCoordinator.swift
@@ -41,7 +41,7 @@ class GetBalanceCoordinator {
         for address: Address,
         completion: @escaping (ResultResult<Balance, AnyError>.t) -> Void
     ) {
-        let request = EtherServiceRequest(batch: BatchFactory().create(BalanceRequest(address: address.description)))
+        let request = EtherServiceRequest(config: config, batch: BatchFactory().create(BalanceRequest(address: address.description)))
         Session.send(request) { result in
             switch result {
             case .success(let balance):

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -229,7 +229,7 @@ class TokensCoordinator: Coordinator {
     }
 
     func newTokenViewController() -> NewTokenViewController {
-        let controller = NewTokenViewController()
+        let controller = NewTokenViewController(config: session.config)
         controller.delegate = self
         return controller
     }

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -11,9 +11,11 @@ import RealmSwift
 import BigInt
 
 class TokenAdaptor {
+    private let config: Config
     private let token: TokenObject
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
+        self.config = config
         self.token = token
     }
 
@@ -35,8 +37,6 @@ class TokenAdaptor {
     private func getNotSupportedByOpenSeaTokenHolders() -> [TokenHolder] {
         let balance = token.balance
         var tokens = [Token]()
-        //TODO should pass Config instance into this func instead
-        let config = Config()
         for (index, item) in balance.enumerated() {
             //id is the value of the bytes32 token
             let id = item.balance

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -264,7 +264,7 @@ class TokensDataStore {
 
     private func getTokensFromOpenSea() -> OpenSea.PromiseResult {
         //TODO when we no longer create multiple instances of TokensDataStore, we don't have to use singleton for OpenSea class. This was to avoid fetching multiple times from OpenSea concurrently
-        return OpenSea.sharedInstance.makeFetchPromise(owner: account.address.eip55String)
+        return OpenSea.sharedInstance.makeFetchPromise(config: config, owner: account.address.eip55String)
     }
 
     func getTokenType(for addressString: String,
@@ -507,11 +507,11 @@ class TokensDataStore {
     }
 
     private func getPriceToUpdate() -> AlphaWalletService {
-        switch self.config.server {
+        switch config.server {
         case .xDai:
-            return .priceOfDai
+            return .priceOfDai(config: config)
         default:
-            return .priceOfEth
+            return .priceOfEth(config: config)
         }
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -20,8 +20,8 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
             updateSaveButtonBasedOnTokenTypeDetected()
         }
     }
-
-    private let addressTextField = AddressTextField()
+    private let config: Config
+    lazy private var addressTextField = AddressTextField(config: config)
     private let symbolTextField = TextField()
     private let decimalsTextField = TextField()
     private let balanceTextField = TextField()
@@ -31,6 +31,15 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
     private var scrollViewBottomAnchorConstraint: NSLayoutConstraint!
 
     weak var delegate: NewTokenViewControllerDelegate?
+
+    init(config: Config) {
+        self.config = config
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -12,7 +12,7 @@ protocol TokenViewControllerDelegate: class, CanOpenURL {
 class TokenViewController: UIViewController {
     private let roundedBackground = RoundedBackground()
     private let header = TokenViewControllerHeaderView()
-    private var headerViewModel = SendHeaderViewViewModel()
+    lazy private var headerViewModel = SendHeaderViewViewModel(config: session.config)
     private var viewModel: TokenViewControllerViewModel?
     private let session: WalletSession
     private let tokensDataStore: TokensDataStore

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -171,7 +171,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
     }
 
     @objc func transfer() {
-        let transferType = TransferType(token: viewModel.token)
+        let transferType = TransferType(config: config, token: viewModel.token)
         delegate?.didPressTransfer(for: .send(type: transferType),
                                    tokenHolders: viewModel.tokenHolders,
                                    in: self)

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -367,7 +367,7 @@ extension TokensViewController: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OpenSeaNonFungibleTokenViewCell.identifier, for: indexPath) as! OpenSeaNonFungibleTokenViewCell
-        cell.configure(viewModel: .init(token: token))
+        cell.configure(viewModel: .init(config: session.config, token: token))
         return cell
     }
 }

--- a/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenViewCellViewModel.swift
@@ -13,10 +13,10 @@ class OpenSeaNonFungibleTokenViewCellViewModel {
         return token.name
     }
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self.token = token
         //We use the contract's image and fallback to the first token ID's image if the former is not available
-        if let tokenHolder = TokenAdaptor(token: token).getTokenHolders().first {
+        if let tokenHolder = TokenAdaptor(config: config, token: token).getTokenHolders().first {
             var url = tokenHolder.values["contractImageUrl"] as? String ?? ""
             if url.isEmpty {
                 url = tokenHolder.values["imageUrl"] as? String ?? ""

--- a/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
@@ -13,9 +13,9 @@ struct TokensCardViewModel {
     let token: TokenObject
     let tokenHolders: [TokenHolder]
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self.token = token
-        self.tokenHolders = TokenAdaptor(token: token).getTokenHolders()
+        self.tokenHolders = TokenAdaptor(config: config, token: token).getTokenHolders()
     }
 
     func item(for indexPath: IndexPath) -> TokenHolder {

--- a/AlphaWallet/Transactions/Coordinators/BalanceCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/BalanceCoordinator.swift
@@ -12,6 +12,7 @@ protocol BalanceCoordinatorDelegate: class {
 
 class BalanceCoordinator {
     private let wallet: Wallet
+    private let config: Config
     private let storage: TokensDataStore
 
     var balance: Balance?
@@ -20,6 +21,7 @@ class BalanceCoordinator {
 
     var viewModel: BalanceViewModel {
         return BalanceViewModel(
+            config: config,
             balance: balance,
             rate: currencyRate
         )
@@ -31,6 +33,7 @@ class BalanceCoordinator {
             storage: TokensDataStore
     ) {
         self.wallet = wallet
+        self.config = config
         self.storage = storage
         self.storage.refreshBalance()
 

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -21,7 +21,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
     private let keystore: Keystore
     private let token: TokenObject
     private lazy var rootViewController: TokensCardViewController = {
-        let viewModel = TokensCardViewModel(token: token)
+        let viewModel = TokensCardViewModel(config: session.config, token: token)
         return makeTokensCardViewController(with: session.account, viewModel: viewModel)
     }()
 
@@ -68,7 +68,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
         assetDefinitionStore.subscribe { [weak self] contract in
             guard let strongSelf = self else { return }
             guard contract.sameContract(as: strongSelf.token.contract) else { return }
-            let viewModel = TokensCardViewModel(token: strongSelf.token)
+            let viewModel = TokensCardViewModel(config: strongSelf.session.config, token: strongSelf.token)
             strongSelf.rootViewController.configure(viewModel: viewModel)
         }
     }
@@ -183,7 +183,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
     }
 
     private func makeRedeemTokensViewController() -> RedeemTokenViewController {
-        let viewModel = RedeemTokenCardViewModel(token: token)
+        let viewModel = RedeemTokenCardViewModel(config: session.config, token: token)
         let controller = RedeemTokenViewController(config: session.config, token: token, viewModel: viewModel)
         controller.configure()
         controller.delegate = self
@@ -191,7 +191,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
     }
 
     private func makeSellTokensCardViewController(paymentFlow: PaymentFlow) -> SellTokensCardViewController {
-        let viewModel = SellTokensCardViewModel(token: token)
+        let viewModel = SellTokensCardViewModel(config: session.config, token: token)
         let controller = SellTokensCardViewController(config: session.config, paymentFlow: paymentFlow, viewModel: viewModel)
         controller.configure()
         controller.delegate = self
@@ -247,7 +247,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
     }
 
     private func makeTransferTokensCardViewController(paymentFlow: PaymentFlow) -> TransferTokensCardViewController {
-        let viewModel = TransferTokensCardViewModel(token: token)
+        let viewModel = TransferTokensCardViewModel(config: session.config, token: token)
         let controller = TransferTokensCardViewController(config: session.config, paymentFlow: paymentFlow, token: token, viewModel: viewModel)
         controller.configure()
         controller.delegate = self
@@ -293,7 +293,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
         let address = keystore.recentlyUsedWallet?.address
         let account = try! EtherKeystore().getAccount(for: address!)
         let signedOrders = try! OrderHandler().signOrders(orders: orders, account: account!)
-        return UniversalLinkHandler().createUniversalLink(signedOrder: signedOrders[0])
+        return UniversalLinkHandler(config: session.config).createUniversalLink(signedOrder: signedOrders[0])
     }
 
     //note that the price must be in szabo for a sell link, price must be rounded
@@ -319,7 +319,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
         let address = keystore.recentlyUsedWallet?.address
         let account = try! EtherKeystore().getAccount(for: address!)
         let signedOrders = try! OrderHandler().signOrders(orders: orders, account: account!)
-        return UniversalLinkHandler().createUniversalLink(signedOrder: signedOrders[0])
+        return UniversalLinkHandler(config: session.config).createUniversalLink(signedOrder: signedOrders[0])
     }
 
     private func sellViaActivitySheet(tokenHolder: TokenHolder, linkExpiryDate: Date, ethCost: Ether, paymentFlow: PaymentFlow, in viewController: UIViewController, sender: UIView) {

--- a/AlphaWallet/Transactions/Coordinators/TransactionCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionCoordinator.swift
@@ -55,7 +55,7 @@ class TransactionCoordinator: Coordinator {
     }
 
     private func makeTransactionsController(with account: Wallet) -> TransactionsViewController {
-        let viewModel = TransactionsViewModel()
+        let viewModel = TransactionsViewModel(config: session.config)
         let controller = TransactionsViewController(
             account: account,
             dataCoordinator: dataCoordinator,

--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -21,16 +21,13 @@ protocol TransactionDataCoordinatorDelegate: class {
 }
 
 class TransactionDataCoordinator {
-    struct Config {
-        static let deleteMissingInternalSeconds: Double = 60.0
-        static let deleyedTransactionInternalSeconds: Double = 60.0
-    }
+    static let deleteMissingInternalSeconds: Double = 60.0
+    static let delayedTransactionInternalSeconds: Double = 60.0
 
     private let storage: TransactionsStorage
     private let session: WalletSession
     private let keystore: Keystore
     private let tokensStorage: TokensDataStore
-    private let config = Config()
     private var viewModel: TransactionsViewModel {
         return .init(transactions: storage.objects)
     }
@@ -182,7 +179,7 @@ class TransactionDataCoordinator {
             switch result {
             case .success:
                 // NSLog("parsedTransaction \(_parsedTransaction)")
-                if transaction.date > Date().addingTimeInterval(Config.deleyedTransactionInternalSeconds) {
+                if transaction.date > Date().addingTimeInterval(TransactionDataCoordinator.delayedTransactionInternalSeconds) {
                     strongSelf.update(state: .completed, for: transaction)
                     strongSelf.update(items: [transaction])
                 }
@@ -197,7 +194,7 @@ class TransactionDataCoordinator {
                         // NSLog("code \(code), error: \(message)")
                         strongSelf.delete(transactions: [transaction])
                     case .resultObjectParseError:
-                        if transaction.date > Date().addingTimeInterval(Config.deleteMissingInternalSeconds) {
+                        if transaction.date > Date().addingTimeInterval(TransactionDataCoordinator.deleteMissingInternalSeconds) {
                             strongSelf.update(state: .failed, for: transaction)
                         }
                     default: break

--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -29,7 +29,7 @@ class TransactionDataCoordinator {
     private let keystore: Keystore
     private let tokensStorage: TokensDataStore
     private var viewModel: TransactionsViewModel {
-        return .init(transactions: storage.objects)
+        return .init(config: session.config, transactions: storage.objects)
     }
     private var timer: Timer?
     private var updateTransactionsTimer: Timer?
@@ -75,7 +75,7 @@ class TransactionDataCoordinator {
     }
 
     private func runScheduledTimers() {
-        guard !AlphaWallet.Config().isAutoFetchingDisabled else { return }
+        guard !session.config.isAutoFetchingDisabled else { return }
         guard timer == nil, updateTransactionsTimer == nil else {
             return
         }
@@ -129,6 +129,7 @@ class TransactionDataCoordinator {
     ) {
         alphaWalletProvider.request(
                 .getTransactions(
+                        config: session.config,
                         address: address.description,
                         startBlock: startBlock,
                         endBlock: endBlock,
@@ -174,7 +175,7 @@ class TransactionDataCoordinator {
 
     private func updatePendingTransaction(_ transaction: Transaction) {
         let request = GetTransactionRequest(hash: transaction.id)
-        Session.send(EtherServiceRequest(batch: BatchFactory().create(request))) { [weak self] result in
+        Session.send(EtherServiceRequest(config: session.config, batch: BatchFactory().create(request))) { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
             case .success:
@@ -246,7 +247,7 @@ class TransactionDataCoordinator {
     private func notifyUserEtherReceived(for transactionId: String, amount: String) {
         let notificationCenter = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
-        let config = AlphaWallet.Config()
+        let config = session.config
         switch config.server {
         case .main, .xDai:
             content.body = R.string.localizable.transactionsReceivedEther(amount, config.server.symbol)

--- a/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
@@ -26,7 +26,7 @@ class TransactionsViewController: UIViewController {
         account: Wallet,
         dataCoordinator: TransactionDataCoordinator,
         session: WalletSession,
-        viewModel: TransactionsViewModel = TransactionsViewModel(transactions: [])
+        viewModel: TransactionsViewModel
     ) {
         self.account = account
         self.dataCoordinator = dataCoordinator
@@ -36,7 +36,7 @@ class TransactionsViewController: UIViewController {
 
         title = R.string.localizable.transactionsTabbarItemTitle()
 
-        view.backgroundColor = viewModel.backgroundColor
+        view.backgroundColor = self.viewModel.backgroundColor
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.dataSource = self
@@ -138,7 +138,7 @@ extension TransactionsViewController: TransactionDataCoordinatorDelegate {
     func didUpdate(result: Result<[Transaction], TransactionError>) {
         switch result {
         case .success(let items):
-        let viewModel = TransactionsViewModel(transactions: items)
+        let viewModel = TransactionsViewModel(config: session.config, transactions: items)
             configure(viewModel: viewModel)
             endLoading()
         case .failure(let error):

--- a/AlphaWallet/Transactions/ViewModels/BalanceViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/BalanceViewModel.swift
@@ -4,18 +4,18 @@ import Foundation
 import UIKit
 
 struct BalanceViewModel: BalanceBaseViewModel {
+    private let config: Config
     private let balance: Balance?
     private let rate: CurrencyRate?
-    private let config: Config
 
     init(
+        config: Config,
         balance: Balance? = .none,
-        rate: CurrencyRate? = .none,
-        config: Config = Config()
+        rate: CurrencyRate? = .none
     ) {
+        self.config = config
         self.balance = balance
         self.rate = rate
-        self.config = config
     }
 
     var amount: Double {

--- a/AlphaWallet/Transactions/ViewModels/TransactionsViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionsViewModel.swift
@@ -11,8 +11,8 @@ struct TransactionsViewModel {
     private let config: Config
 
     init(
-        transactions: [Transaction] = [],
-        config: Config = Config()
+        config: Config,
+        transactions: [Transaction] = []
     ) {
         self.config = config
 

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -90,7 +90,7 @@ class TransactionConfigurator {
             value: transaction.value,
             data: configuration.data
         )
-        Session.send(EtherServiceRequest(batch: BatchFactory().create(request))) { [weak self] result in
+        Session.send(EtherServiceRequest(config: session.config, batch: BatchFactory().create(request))) { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
             case .success(let gasLimit):

--- a/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
@@ -29,7 +29,7 @@ class SendTransactionCoordinator {
         if transaction.nonce >= 0 {
             signAndSend(transaction: transaction, completion: completion)
         } else {
-            let request = EtherServiceRequest(batch: BatchFactory().create(GetTransactionCountRequest(
+            let request = EtherServiceRequest(config: session.config, batch: BatchFactory().create(GetTransactionCountRequest(
                 address: session.account.address.description,
                 state: "pending"
             )))
@@ -72,7 +72,7 @@ class SendTransactionCoordinator {
             case .sign:
                 completion(.success(.signedTransaction(data)))
             case .signThenSend:
-                let request = EtherServiceRequest(batch: BatchFactory().create(SendRawTransactionRequest(signedTransaction: data.hexEncoded)))
+                let request = EtherServiceRequest(config: session.config, batch: BatchFactory().create(SendRawTransactionRequest(signedTransaction: data.hexEncoded)))
                 Session.send(request) { result in
                     switch result {
                     case .success(let transactionID):

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -10,11 +10,11 @@ struct Transfer {
 
 enum TransferType {
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self = {
             switch token.type {
             case .nativeCryptocurrency, .xDai:
-                return .nativeCryptocurrency(config: Config(), destination: nil)
+                return .nativeCryptocurrency(config: config, destination: nil)
             case .erc20:
                 return .ERC20Token(token)
             case .erc875:

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -135,6 +135,7 @@ class ConfirmPaymentViewController: UIViewController {
     private func reloadView() {
         let viewModel = ConfirmPaymentDetailsViewModel(
             transaction: configurator.previewTransaction(),
+            config: session.config,
             currentBalance: session.balance,
             currencyRate: session.balanceCoordinator.currencyRate
         )

--- a/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
@@ -104,7 +104,7 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
         datePicker.minimumDate = Date()
         datePicker.addTarget(self, action: #selector(datePickerValueChanged), for: .valueChanged)
         datePicker.isHidden = true
-        if let locale = config.locale {
+        if let locale = Config.getLocale() {
             datePicker.locale = Locale(identifier: locale)
         }
 
@@ -112,7 +112,7 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
         timePicker.minimumDate = Date.yesterday
         timePicker.addTarget(self, action: #selector(timePickerValueChanged), for: .valueChanged)
         timePicker.isHidden = true
-        if let locale = config.locale {
+        if let locale = Config.getLocale() {
             timePicker.locale = Locale(identifier: locale)
         }
 

--- a/AlphaWallet/Transfer/ViewControllers/TransferTokensCardQuantitySelectionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransferTokensCardQuantitySelectionViewController.swift
@@ -25,7 +25,7 @@ class TransferTokensCardQuantitySelectionViewController: UIViewController, Token
     weak var delegate: TransferTokenCardQuantitySelectionViewControllerDelegate?
 
     init(
-            config: Config = Config(),
+            config: Config,
             paymentFlow: PaymentFlow,
             token: TokenObject,
             viewModel: TransferTokensCardQuantitySelectionViewModel

--- a/AlphaWallet/Transfer/ViewControllers/TransferTokensCardViaWalletAddressViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransferTokensCardViaWalletAddressViewController.swift
@@ -13,7 +13,7 @@ class TransferTokensCardViaWalletAddressViewController: UIViewController, TokenV
     private let roundedBackground = RoundedBackground()
     private let header = TokensCardViewControllerTitleHeader()
     private let tokenRowView: TokenRowView & UIView
-    private let targetAddressTextField = AddressTextField()
+    lazy private var targetAddressTextField = AddressTextField(config: config)
     private let buttonsBar = ButtonsBar(numberOfButtons: 1)
     private var viewModel: TransferTokensCardViaWalletAddressViewControllerViewModel
     private var tokenHolder: TokenHolder

--- a/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
@@ -24,7 +24,7 @@ struct ConfirmPaymentDetailsViewModel {
 
     init(
         transaction: PreviewTransaction,
-        config: Config = Config(),
+        config: Config,
         currentBalance: BalanceProtocol?,
         currencyRate: CurrencyRate?
     ) {

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -3,19 +3,27 @@
 import UIKit
 
 struct SendHeaderViewViewModel {
-    var title = ""
+    let config: Config
+    var title: String
     var ticker: CoinTicker?
     var currencyAmount: String?
     var currencyAmountWithoutSymbol: Double?
     var showAlternativeAmount = false
-    var server = Config().server
+
+    init(config: Config) {
+        self.config = config
+        title = ""
+        ticker = nil
+        currencyAmount = nil
+        currencyAmountWithoutSymbol = nil
+    }
 
     var issuer: String {
         return ""
     }
 
     var blockChainName: String {
-        switch server {
+        switch config.server {
         case .xDai:
             return R.string.localizable.blockchainXDAI()
         case .rinkeby, .ropsten, .main, .custom, .callisto, .classic, .kovan, .sokol, .poa:

--- a/AlphaWallet/Transfer/ViewModels/TransferTokensCardViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransferTokensCardViewModel.swift
@@ -7,9 +7,9 @@ struct TransferTokensCardViewModel {
     let token: TokenObject
     let tokenHolders: [TokenHolder]
 
-    init(token: TokenObject) {
+    init(config: Config, token: TokenObject) {
         self.token = token
-        self.tokenHolders = TokenAdaptor(token: token).getTokenHolders()
+        self.tokenHolders = TokenAdaptor(config: config, token: token).getTokenHolders()
 
         selectSoleTokenHolder()
     }

--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -15,6 +15,7 @@ class AddressTextField: UIControl {
     private let textField = UITextField()
     let label = UILabel()
     let ensAddressLabel = UILabel()
+    private let config: Config
 
     var value: String {
         get {
@@ -43,8 +44,9 @@ class AddressTextField: UIControl {
 
     weak var delegate: AddressTextFieldDelegate?
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(config: Config) {
+        self.config = config
+        super.init(frame: .zero)
 
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.delegate = self
@@ -146,7 +148,7 @@ class AddressTextField: UIControl {
             return
         } else {
             textField.text = value
-            GetENSOwnerCoordinator(config: Config()).getENSOwner(for: value) { result in
+            GetENSOwnerCoordinator(config: config).getENSOwner(for: value) { result in
                 guard let address = result.value else {
                     //Don't show an error when pasting what seems like a wrong ENS name for better usability
                     return
@@ -168,7 +170,7 @@ class AddressTextField: UIControl {
     private func queueResolution(ofValue value: String) {
         let value = value.trimmed
         let oldTextValue = textField.text?.trimmed
-        GetENSOwnerCoordinator(config: Config()).queueGetENSOwner(for: value) { [weak self] result in
+        GetENSOwnerCoordinator(config: config).queueGetENSOwner(for: value) { [weak self] result in
             guard let strongSelf = self else { return }
             if let address = result.value {
                 guard CryptoAddressValidator.isValidAddress(address.address) else {

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -84,8 +84,8 @@ class AmountTextField: UIControl {
         return DecimalFormatter()
     }()
 
-    init() {
-        let server = Config().server
+    init(config: Config) {
+        let server = config.server
 
         switch server {
         case .xDai:

--- a/AlphaWallet/Wallet/Coordinators/InitialWalletCreationCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/InitialWalletCreationCoordinator.swift
@@ -12,16 +12,19 @@ protocol InitialWalletCreationCoordinatorDelegate: class {
 class InitialWalletCreationCoordinator: Coordinator {
     private let keystore: Keystore
     private let entryPoint: WalletEntryPoint
+    private let config: Config
 
     let navigationController: UINavigationController
     var coordinators: [Coordinator] = []
     weak var delegate: InitialWalletCreationCoordinatorDelegate?
 
     init(
+        config: Config,
         navigationController: UINavigationController = NavigationController(),
         keystore: Keystore,
         entryPoint: WalletEntryPoint
     ) {
+        self.config = config
         self.navigationController = navigationController
         self.keystore = keystore
         self.entryPoint = entryPoint
@@ -39,14 +42,14 @@ class InitialWalletCreationCoordinator: Coordinator {
     }
 
     func showCreateWallet() {
-        let coordinator = WalletCoordinator(navigationController: navigationController, keystore: keystore)
+        let coordinator = WalletCoordinator(config: config, navigationController: navigationController, keystore: keystore)
         coordinator.delegate = self
         let _ = coordinator.start(entryPoint)
         addCoordinator(coordinator)
     }
 
     func presentImportWallet() {
-        let coordinator = WalletCoordinator(keystore: keystore)
+        let coordinator = WalletCoordinator(config: config, keystore: keystore)
         coordinator.delegate = self
         let _ = coordinator.start(entryPoint)
         navigationController.present(coordinator.navigationController, animated: true, completion: nil)

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -19,7 +19,7 @@ class WalletCoordinator: Coordinator {
     var coordinators: [Coordinator] = []
 
     init(
-        config: Config = Config(),
+        config: Config,
         navigationController: UINavigationController = NavigationController(),
         keystore: Keystore
     ) {
@@ -39,7 +39,7 @@ class WalletCoordinator: Coordinator {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
             navigationController.viewControllers = [controller]
         case .importWallet:
-            let controller = ImportWalletViewController(keystore: keystore)
+            let controller = ImportWalletViewController(config: config, keystore: keystore)
             controller.delegate = self
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
             navigationController.viewControllers = [controller]
@@ -60,7 +60,7 @@ class WalletCoordinator: Coordinator {
     }
 
     func pushImportWallet() {
-        let controller = ImportWalletViewController(keystore: keystore)
+        let controller = ImportWalletViewController(config: config, keystore: keystore)
         controller.delegate = self
         navigationController.pushViewController(controller, animated: true)
     }
@@ -90,7 +90,7 @@ class WalletCoordinator: Coordinator {
     }
 
     func pushBackup(for account: Account) {
-        let controller = BackupViewController(account: account)
+        let controller = BackupViewController(config: config, account: account)
         controller.delegate = self
         controller.navigationItem.backBarButtonItem = nil
         controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)

--- a/AlphaWallet/Wallet/ViewControllers/ImportWalletViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ImportWalletViewController.swift
@@ -15,6 +15,7 @@ class ImportWalletViewController: UIViewController, CanScanQRCode {
         }
     }
 
+    private let config: Config
     private let keystore: Keystore
     private let viewModel = ImportWalletViewModel()
     //We don't actually use the rounded corner here, but it's a useful "content" view here
@@ -24,7 +25,7 @@ class ImportWalletViewController: UIViewController, CanScanQRCode {
     private let keystoreJSONTextView = TextView()
     private let passwordTextField = TextField()
     private let privateKeyTextView = TextView()
-    private let watchAddressTextField = AddressTextField()
+    lazy private var watchAddressTextField = AddressTextField(config: config)
     private var keystoreJSONControlsStackView: UIStackView!
     private var privateKeyControlsStackView: UIStackView!
     private var watchControlsStackView: UIStackView!
@@ -32,7 +33,8 @@ class ImportWalletViewController: UIViewController, CanScanQRCode {
 
     weak var delegate: ImportWalletViewControllerDelegate?
 
-    init(keystore: Keystore) {
+    init(config: Config, keystore: Keystore) {
+        self.config = config
         self.keystore = keystore
 
         super.init(nibName: nil, bundle: nil)

--- a/AlphaWalletTests/Coordinators/InitialWalletCreationCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/InitialWalletCreationCoordinatorTests.swift
@@ -7,6 +7,7 @@ class InitialWalletCreationCoordinatorTests: XCTestCase {
 
     func testImportWallet() {
         let coordinator = InitialWalletCreationCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeKeystore(),
             entryPoint: .importWallet

--- a/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
@@ -8,7 +8,7 @@ class SendCoordinatorTests: XCTestCase {
     
     func testRootViewController() {
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(config: Config(), destination: .none),
+            transferType: .nativeCryptocurrency(config: .make(), destination: .none),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),
@@ -25,7 +25,7 @@ class SendCoordinatorTests: XCTestCase {
     func testDestination() {
         let address: Address = .make()
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(config: Config(), destination: address),
+            transferType: .nativeCryptocurrency(config: .make(), destination: address),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),

--- a/AlphaWalletTests/Coordinators/WalletCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/WalletCoordinatorTests.swift
@@ -8,6 +8,7 @@ class WalletCoordinatorTests: XCTestCase {
     
     func testWelcome() {
         let coordinator = WalletCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeKeystore()
         )
@@ -19,6 +20,7 @@ class WalletCoordinatorTests: XCTestCase {
 
     func testImportWallet() {
         let coordinator = WalletCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeKeystore()
         )
@@ -31,6 +33,7 @@ class WalletCoordinatorTests: XCTestCase {
     func testCreateInstantWallet() {
         let delegate = FakeWalletCoordinatorDelegate()
         let coordinator = WalletCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeEtherKeystore()
         )
@@ -41,6 +44,7 @@ class WalletCoordinatorTests: XCTestCase {
 
     func testPushImportWallet() {
         let coordinator = WalletCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeKeystore()
         )

--- a/AlphaWalletTests/Factories/Config.swift
+++ b/AlphaWalletTests/Factories/Config.swift
@@ -4,11 +4,8 @@ import Foundation
 @testable import AlphaWallet
 
 extension Config {
-    static func make(
-        defaults: UserDefaults = .test
-    ) -> Config {
-        return Config(
-            defaults: defaults
-        )
+    static func make(chainID: Int = RPCServer.main.chainID, defaults: UserDefaults = .test) -> Config {
+        //TODO perhaps we should be explicit about which chain the Config instance is for
+        return Config(chainID: chainID, defaults: defaults)
     }
 }

--- a/AlphaWalletTests/Factories/FakeGetBalanceCoordinator(.swift
+++ b/AlphaWalletTests/Factories/FakeGetBalanceCoordinator(.swift
@@ -5,6 +5,6 @@ import Foundation
 
 class FakeGetBalanceCoordinator: GetBalanceCoordinator {
     convenience init() {
-        self.init(config: Config())
+        self.init(config: .make())
     }
 }

--- a/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
+++ b/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
@@ -7,7 +7,7 @@ import BigInt
 
 extension UnconfirmedTransaction {
     static func make(
-        transferType: TransferType = .nativeCryptocurrency(config: Config(), destination: .none),
+        transferType: TransferType = .nativeCryptocurrency(config: .make(), destination: .none),
         value: BigInt = BigInt(1),
         to: Address = .make(),
         data: Data = Data(),

--- a/AlphaWalletTests/Market/UniversalLinkHandlerTests.swift
+++ b/AlphaWalletTests/Market/UniversalLinkHandlerTests.swift
@@ -11,15 +11,16 @@ import TrustKeystore
 class UniversalLinkHandlerTests: XCTestCase {
     
     func testUniversalLinkParser() {
-        guard Config().server == .main else {
+        let config = Config.make()
+        guard config.server == .main else {
             XCTFail("This test expects itself to be run on Mainnet.")
             return
         }
 
         let testUrl = "https://aw.app/AQAAAAAAAACjNHyO0TRETCUWmHLJCmNg1Cs2kQFxEtQiQ269SZP2r2Y6CETiCqCE3HGQa63LYjsaCOccJi0mj9bpsmnZCwFkjVcNaaJ6Ed8lVU83UiGILQZ4CcFhHA=="
-        if let signedOrder = UniversalLinkHandler().parseUniversalLink(url: testUrl, prefix: Constants.mainnetMagicLinkPrefix) {
+        if let signedOrder = UniversalLinkHandler(config: config).parseUniversalLink(url: testUrl, prefix: Constants.mainnetMagicLinkPrefix) {
             XCTAssertGreaterThanOrEqual(signedOrder.signature.count, 130)
-            let url = UniversalLinkHandler().createUniversalLink(signedOrder: signedOrder)
+            let url = UniversalLinkHandler(config: config).createUniversalLink(signedOrder: signedOrder)
             print(url)
             XCTAssertEqual(testUrl, url)
         }

--- a/AlphaWalletTests/Redeem/CreateRedeemTests.swift
+++ b/AlphaWalletTests/Redeem/CreateRedeemTests.swift
@@ -16,7 +16,7 @@ class CreateRedeemTests: XCTestCase {
         indices.append(1)
         indices.append(2)
         let account = keyStore.createAccount(password: "test")
-        let message = CreateRedeem(config: Config(), token: TokenObject()).redeemMessage(tokenIndices: indices).0
+        let message = CreateRedeem(config: .make(), token: TokenObject()).redeemMessage(tokenIndices: indices).0
         print(message)
         let data = message.data(using: String.Encoding.utf8)
 

--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -23,12 +23,6 @@ class ConfigTests: XCTestCase {
         XCTAssertEqual(.kovan, config.server)
     }
 
-    func testTestDefaultisCryptoPrimaryCurrency() {
-        var config: Config = .make()
-
-        XCTAssertEqual(false, config.isCryptoPrimaryCurrency)
-    }
-
     func testSwitchLocale() {
         var config: Config = .make()
 

--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -12,12 +12,14 @@ class ConfigTests: XCTestCase {
         XCTAssertEqual(.main, config.server)
     }
 
+    //TODO remove when we support multi-chain
     func testChangeChainID() {
-        var config: Config = .make()
+        XCTAssertEqual(1, Config.make().chainID)
 
-        XCTAssertEqual(1, config.chainID)
+        let testDefaults = UserDefaults.test
+        Config.setChainId(RPCServer.ropsten.chainID, defaults: testDefaults)
 
-        config.chainID = 42
+        let config = Config(chainID: RPCServer.kovan.chainID)
 
         XCTAssertEqual(42, config.chainID)
         XCTAssertEqual(.kovan, config.server)
@@ -26,7 +28,7 @@ class ConfigTests: XCTestCase {
     func testSwitchLocale() {
         var config: Config = .make()
 
-        config.locale = AppLocale.english.id
+        Config.setLocale(AppLocale.english)
         let vc1 = TokensViewController(
                 session: .make(),
                 account: .make(),
@@ -34,7 +36,7 @@ class ConfigTests: XCTestCase {
         )
         XCTAssertEqual(vc1.title, "Wallet")
 
-        config.locale = AppLocale.simplifiedChinese.id
+        Config.setLocale(AppLocale.simplifiedChinese)
         let vc2 = TokensViewController(
                 session: .make(),
                 account: .make(),
@@ -43,28 +45,28 @@ class ConfigTests: XCTestCase {
         XCTAssertEqual(vc2.title, "我的钱包")
 
         //Must change this back to system, otherwise other tests will break either immediately or the next run
-        config.locale = AppLocale.system.id
+        Config.setLocale(AppLocale.system)
     }
 
     func testNibsAccessAfterSwitchingLocale() {
         var config: Config = .make()
 
-        config.locale = AppLocale.english.id
-        config.locale = AppLocale.simplifiedChinese.id
+        Config.setLocale(AppLocale.english)
+        Config.setLocale(AppLocale.simplifiedChinese)
 
         let tableView = UITableView()
         tableView.register(R.nib.bookmarkViewCell(), forCellReuseIdentifier: R.nib.bookmarkViewCell.name)
         XCTAssertNoThrow(tableView.dequeueReusableCell(withIdentifier: R.nib.bookmarkViewCell.name))
 
         //Must change this back to system, otherwise other tests will break either immediately or the next run
-        config.locale = AppLocale.system.id
+        Config.setLocale(AppLocale.system)
     }
 
     func testWeb3StillLoadsAfterSwitchingLocale() {
         var config: Config = .make()
 
-        config.locale = AppLocale.english.id
-        config.locale = AppLocale.simplifiedChinese.id
+        Config.setLocale(AppLocale.english)
+        Config.setLocale(AppLocale.simplifiedChinese)
 
         let expectation = XCTestExpectation(description: "web3 loaded")
         let web3 = Web3Swift()
@@ -77,6 +79,6 @@ class ConfigTests: XCTestCase {
         wait(for: [expectation], timeout: 4)
 
         //Must change this back to system, otherwise other tests will break either immediately or the next run
-        config.locale = AppLocale.system.id
+        Config.setLocale(AppLocale.system)
     }
 }

--- a/AlphaWalletTests/Settings/Coordinators/SettingsCoordinatorTests.swift
+++ b/AlphaWalletTests/Settings/Coordinators/SettingsCoordinatorTests.swift
@@ -34,6 +34,7 @@ class SettingsCoordinatorTests: XCTestCase {
         XCTAssertEqual(1, storage.count)
         
         let accountCoordinator = AccountsCoordinator(
+            config: .make(),
             navigationController: FakeNavigationController(),
             keystore: FakeEtherKeystore(),
             balanceCoordinator: FakeGetBalanceCoordinator()

--- a/AlphaWalletTests/Tokens/Coordinators/GetENSOwnerCoordinatorTests.swift
+++ b/AlphaWalletTests/Tokens/Coordinators/GetENSOwnerCoordinatorTests.swift
@@ -26,8 +26,6 @@ class GetENSOwnerCoordinatorTests: XCTestCase {
     }
 
     private func makeConfigOnMainnet() -> Config {
-        var config = Config.make()
-        config.chainID = RPCServer.main.chainID
-        return config
+        return Config.make(chainID: RPCServer.main.chainID)
     }
 }

--- a/AlphaWalletTests/Tokens/Helpers/TokenAdaptorTest.swift
+++ b/AlphaWalletTests/Tokens/Helpers/TokenAdaptorTest.swift
@@ -13,7 +13,7 @@ class TokenAdaptorTest: XCTestCase {
             Token(id: "2", index: 2, name: "Name", status: .available, values: ["city": "City", "venue": "Venue", "match": 1, "time": date, "numero": 2, "category": "1", "countryA": "Team A", "countryB": "Team B"]),
             Token(id: "3", index: 3, name: "Name", status: .available, values: ["city": "City", "venue": "Venue", "match": 1, "time": date, "numero": 4, "category": "1", "countryA": "Team A", "countryB": "Team B"]),
         ]
-        let bundles = TokenAdaptor(token: TokenObject()).bundle(tokens: tokens)
+        let bundles = TokenAdaptor(config: .make(), token: TokenObject()).bundle(tokens: tokens)
         XCTAssertEqual(bundles.count, 2)
     }
 
@@ -25,7 +25,7 @@ class TokenAdaptorTest: XCTestCase {
             Token(id: "3", index: 3, name: "Name", status: .available, values: ["city": "City", "venue": "Venue", "match": 1, "time": date, "numero": 4, "category": "1", "countryA": "Team A", "countryB": "Team B"]),
             Token(id: "4", index: 4, name: "Name", status: .available, values: ["city": "City", "venue": "Venue", "match": 1, "time": date, "numero": 2, "category": "1", "countryA": "Team A", "countryB": "Team B"]),
         ]
-        let bundles = TokenAdaptor(token: TokenObject()).bundle(tokens: tokens)
+        let bundles = TokenAdaptor(config: .make(), token: TokenObject()).bundle(tokens: tokens)
         XCTAssertEqual(bundles.count, 2)
     }
 

--- a/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
+++ b/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
@@ -10,7 +10,7 @@ class PaymentCoordinatorTests: XCTestCase {
         let address: Address = .make()
         let coordinator = PaymentCoordinator(
             navigationController: FakeNavigationController(),
-            flow: .send(type: .nativeCryptocurrency(config: Config(), destination: address)),
+            flow: .send(type: .nativeCryptocurrency(config: .make(), destination: address)),
             session: .make(),
             keystore: FakeKeystore(),
             storage: FakeTokensDataStore(),


### PR DESCRIPTION
This refactoring fixes places where `Config` instances are created locally by passing in a `Config` instance instead. This paves the way for a future refactor where Config instances-to-chain should be 1:1.
