### PR TITLE
Fix: xDai native cryptocurrency card in Wallet tab not appearing/disappearing correct with filters (Currency/Asset)

### DIFF
--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -116,7 +116,7 @@ extension Transaction {
 
     static private func mapTokenTypeToTransferOperationType(_ tokenType: TokenType) -> OperationType {
         switch tokenType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             return .nativeCurrencyTokenTransfer
         case .erc20:
             return .erc20TokenTransfer

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -359,7 +359,7 @@ class TokensCoordinator: Coordinator {
                         callCompletionFailed()
                     }
                 }
-            case .nativeCryptocurrency, .xDai:
+            case .nativeCryptocurrency:
                 break
             }
         }
@@ -396,7 +396,7 @@ class TokensCoordinator: Coordinator {
 
     private func makeCoordinatorReadOnlyIfNotSupportedByOpenSeaERC721(coordinator: TokensCardCoordinator, token: TokenObject) {
         switch token.type {
-        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875:
             break
         case .erc721:
             switch OpenSeaNonFungibleTokenHandling(token: token) {
@@ -433,8 +433,6 @@ extension TokensCoordinator: TokensViewControllerDelegate {
         switch token.type {
         case .nativeCryptocurrency:
             show(fungibleToken: token, transferType: .nativeCryptocurrency(config: session.config, destination: .none))
-        case .xDai:
-            show(fungibleToken: token, transferType: .xDai(config: session.config, destination: .none))
         case .erc20:
             show(fungibleToken: token, transferType: .ERC20Token(token))
         case .erc721:

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -21,7 +21,7 @@ class TokenAdaptor {
 
     public func getTokenHolders() -> [TokenHolder] {
         switch token.type {
-        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875:
             return getNotSupportedByOpenSeaTokenHolders()
         case .erc721:
             let tokenType = OpenSeaNonFungibleTokenHandling(token: token)
@@ -65,7 +65,7 @@ class TokenAdaptor {
 
     func bundle(tokens: [Token]) -> [TokenHolder] {
         switch token.type {
-        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875:
             if !tokens.isEmpty && tokens[0].isSpawnableMeetupContract {
                 return tokens.map { getTokenHolder(for: [$0]) }
             } else {

--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -22,11 +22,7 @@ class TokenObject: Object {
 
     var type: TokenType {
         get {
-            if name == "xDai" {
-                return .xDai
-            } else {
-                return TokenType(rawValue: rawType)!
-            }
+            return TokenType(rawValue: rawType)!
         }
         set {
             rawType = newValue.rawValue
@@ -89,7 +85,7 @@ class TokenObject: Object {
         switch type {
         case .erc721:
             return true
-        case .nativeCryptocurrency, .erc20, .erc875, .xDai:
+        case .nativeCryptocurrency, .erc20, .erc875:
             return false
         }
     }

--- a/AlphaWallet/Tokens/Types/TokenType.swift
+++ b/AlphaWallet/Tokens/Types/TokenType.swift
@@ -4,7 +4,6 @@ import Foundation
 
 enum TokenType: String {
     case nativeCryptocurrency = "ether"
-    case xDai = "xDai"
     case erc20 = "ERC20"
     case erc875 = "ERC875"
     case erc721 = "ERC721"

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -338,7 +338,7 @@ class TokensDataStore {
         }
         for tokenObject in tokens {
             switch tokenObject.type {
-            case .nativeCryptocurrency, .xDai:
+            case .nativeCryptocurrency:
                 incrementCountAndUpdateDelegate()
             case .erc20:
                 guard let contract = Address(string: tokenObject.contract) else {
@@ -415,7 +415,7 @@ class TokensDataStore {
 
                 if let tokenObject = tokens.first(where: { $0.contract.sameContract(as: contract) }) {
                     switch tokenObject.type {
-                    case .nativeCryptocurrency, .erc721, .erc875, .xDai:
+                    case .nativeCryptocurrency, .erc721, .erc875:
                         break
                     case .erc20:
                         strongSelf.update(token: tokenObject, action: .type(.erc721))

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -213,7 +213,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
     public func updateForm(forTokenType tokenType: TokenType) {
         self.tokenType = tokenType
         switch tokenType {
-        case .nativeCryptocurrency, .erc20, .xDai:
+        case .nativeCryptocurrency, .erc20:
             decimalsTextField.isHidden = false
             balanceTextField.isHidden = true
             decimalsTextField.label.isHidden = false
@@ -242,7 +242,7 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
         guard let tokenType = tokenType else { return false }
 
         switch tokenType {
-        case .nativeCryptocurrency, .erc20, .xDai:
+        case .nativeCryptocurrency, .erc20:
             guard !decimalsTextField.value.trimmed.isEmpty else {
                 displayError(title: R.string.localizable.decimals(), error: ValidationError(msg: R.string.localizable.warningFieldRequired()))
                 return false

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -72,7 +72,7 @@ class TokenViewController: UIViewController {
         headerViewModel.showAlternativeAmount = viewModel.showAlternativeAmount
 
         switch transferType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             header.verificationStatus = .verified(session.account.address.eip55String)
         case .ERC20Token(let token), .ERC875TokenOrder(let token), .ERC875Token(let token), .ERC721Token(let token):
             header.verificationStatus = .unverified(token.contract)
@@ -98,7 +98,7 @@ class TokenViewController: UIViewController {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -136,7 +136,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         transferButton.addTarget(self, action: #selector(transfer), for: .touchUpInside)
 
         switch tokenObject.type {
-        case .nativeCryptocurrency, .erc20, .xDai:
+        case .nativeCryptocurrency, .erc20:
             break
         case .erc875:
             buttonsBar.buttons[0].isHidden = false

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -270,7 +270,7 @@ extension TokensViewController: UITableViewDelegate {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
 
         switch token.type {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             let cellViewModel = EthTokenViewCellViewModel(
                     token: token,
                     ticker: viewModel.ticker(for: token),
@@ -320,7 +320,7 @@ extension TokensViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let token = viewModel.item(for: indexPath.row, section: indexPath.section)
         switch token.type {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             let cell = tableView.dequeueReusableCell(withIdentifier: EthTokenViewCell.identifier, for: indexPath) as! EthTokenViewCell
             cell.configure(
                     viewModel: .init(

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -18,7 +18,7 @@ struct TokenViewControllerViewModel {
         self.transactionsStore = transactionsStore
 
         switch transferType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             self.recentTransactions = Array(transactionsStore.objects.lazy
                     .filter({ $0.state == .completed || $0.state == .pending })
                     .filter({ $0.operation == nil })

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -487,7 +487,7 @@ extension TokensCardCoordinator: TransferTokensCardViewControllerDelegate {
             viewController.navigationController?.pushViewController(vc, animated: true)
         case .erc875:
             showEnterQuantityViewController(token: token, for: tokenHolder, in: viewController)
-        case .nativeCryptocurrency, .erc20, .xDai: break
+        case .nativeCryptocurrency, .erc20: break
         }
     }
 

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -73,7 +73,7 @@ class TransactionConfigurator {
     func estimateGasLimit() {
         let to: Address? = {
             switch transaction.transferType {
-            case .nativeCryptocurrency, .dapp, .xDai: return transaction.to
+            case .nativeCryptocurrency, .dapp: return transaction.to
             case .ERC20Token(let token):
                 return Address(string: token.contract)
             case .ERC875Token(let token):
@@ -113,7 +113,7 @@ class TransactionConfigurator {
 
     func load(completion: @escaping (Result<Void, AnyError>) -> Void) {
         switch transaction.transferType {
-        case .nativeCryptocurrency, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp:
             guard requestEstimateGas else {
                 return completion(.success(()))
             }
@@ -219,7 +219,7 @@ class TransactionConfigurator {
     func formUnsignedTransaction() -> UnsignedTransaction {
         let value: BigInt = {
             switch transaction.transferType {
-            case .nativeCryptocurrency, .dapp, .xDai: return transaction.value
+            case .nativeCryptocurrency, .dapp: return transaction.value
             case .ERC20Token: return 0
             case .ERC875Token: return 0
             case .ERC875TokenOrder: return transaction.value
@@ -228,7 +228,7 @@ class TransactionConfigurator {
         }()
         let address: Address? = {
             switch transaction.transferType {
-            case .nativeCryptocurrency, .dapp, .xDai: return transaction.to
+            case .nativeCryptocurrency, .dapp: return transaction.to
             case .ERC20Token(let token): return token.address
             case .ERC875Token(let token): return token.address
             case .ERC875TokenOrder(let token): return token.address

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -77,7 +77,7 @@ class SendCoordinator: Coordinator {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         }
         switch transferType {
-        case .nativeCryptocurrency(_, let destination), .xDai(_, let destination):
+        case .nativeCryptocurrency(_, let destination):
             controller.targetAddressTextField.value = destination?.description ?? ""
         case .ERC20Token: break
         case .ERC875Token: break

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -13,7 +13,7 @@ enum TransferType {
     init(config: Config, token: TokenObject) {
         self = {
             switch token.type {
-            case .nativeCryptocurrency, .xDai:
+			case .nativeCryptocurrency:
                 return .nativeCryptocurrency(config: config, destination: nil)
             case .erc20:
                 return .ERC20Token(token)
@@ -26,7 +26,6 @@ enum TransferType {
     }
 
     case nativeCryptocurrency(config: Config, destination: Address?)
-    case xDai(config: Config, destination: Address?)
     case ERC20Token(TokenObject)
     case ERC875Token(TokenObject)
     case ERC875TokenOrder(TokenObject)
@@ -37,7 +36,7 @@ enum TransferType {
 extension TransferType {
     func symbol(server: RPCServer) -> String {
         switch self {
-        case .nativeCryptocurrency, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp:
             return server.symbol
         case .ERC20Token(let token):
             return token.symbol
@@ -52,7 +51,7 @@ extension TransferType {
 
     func contract() -> Address {
         switch self {
-        case .nativeCryptocurrency(let config, _), .xDai(let config, _):
+        case .nativeCryptocurrency(let config, _):
             return Address(uncheckedAgainstNullAddress: TokensDataStore.etherToken(for: config).contract)!
         case .ERC20Token(let token):
             return Address(string: token.contract)!

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -43,7 +43,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         switch transferType {
         case .ERC20Token(let token):
             return token.contract
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             return account.address.eip55String
         case .dapp:
             return "0x"
@@ -85,7 +85,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
         switch transferType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             cryptoPrice.subscribe { [weak self] value in
                 if let value = value {
                     self?.amountTextField.cryptoToDollarRate = value
@@ -203,7 +203,7 @@ class SendViewController: UIViewController, CanScanQRCode {
         let amountString = amountTextField.ethCost
         let parsedValue: BigInt? = {
             switch transferType {
-            case .nativeCryptocurrency, .dapp, .xDai:
+            case .nativeCryptocurrency, .dapp:
                 return EtherNumberFormatter.full.number(from: amountString, units: .ether)
             case .ERC20Token(let token):
                 return EtherNumberFormatter.full.number(from: amountString, decimals: token.decimals)
@@ -252,7 +252,7 @@ class SendViewController: UIViewController, CanScanQRCode {
 
     private func configureBalanceViewModel() {
         switch transferType {
-        case .nativeCryptocurrency, .xDai:
+        case .nativeCryptocurrency:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
                 let amount = viewModel.amountShort

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -28,7 +28,7 @@ struct ConfigureTransactionViewModel {
 
     var isDataInputHidden: Bool {
         switch transferType {
-        case .nativeCryptocurrency, .dapp, .xDai: return false
+        case .nativeCryptocurrency, .dapp: return false
         case .ERC20Token: return true
         case .ERC875Token: return true
         case .ERC875TokenOrder: return true

--- a/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
@@ -102,7 +102,7 @@ struct ConfirmPaymentDetailsViewModel {
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value, decimals: token.decimals)
             )
-        case .nativeCryptocurrency, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp:
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value)
             )

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -25,7 +25,7 @@ struct SendViewModel {
 
     var token: TokenObject? {
         switch transferType {
-        case .nativeCryptocurrency(destination: _), .xDai:
+        case .nativeCryptocurrency(destination: _):
             return nil
         case .ERC20Token(let token):
             return token

--- a/AlphaWallet/UI/BalanceTitleView.swift
+++ b/AlphaWallet/UI/BalanceTitleView.swift
@@ -97,7 +97,7 @@ extension BalanceTitleView {
         let view = BalanceTitleView(frame: .zero)
         view.translatesAutoresizingMaskIntoConstraints = false
         switch transferType {
-        case .nativeCryptocurrency, .dapp, .xDai:
+        case .nativeCryptocurrency, .dapp:
             session.balanceViewModel.subscribe { [weak view] viewModel in
                 guard let viewModel = viewModel else { return }
                 view?.viewModel = viewModel


### PR DESCRIPTION
Side effect: Removed unnecessary .xDai enum cases

Reproduce before the PR:


1. Switch to xDai chain.
2. Tap Currency filter

Observed:
3. xDai card disappears

Expected:

3. xDai card remains

4. Repeat with Assets filter for the opposite effect.