### PR TITLE
Don't provide function for user to scan a QR code to load URL in the browsers that pop up

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -35,6 +35,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     }()
 
     private let sharedRealm: Realm
+    private let browserOnly: Bool
     private lazy var bookmarksStore: BookmarksStore = {
         return BookmarksStore(realm: sharedRealm)
     }()
@@ -76,12 +77,14 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     init(
         session: WalletSession,
         keystore: Keystore,
-        sharedRealm: Realm
+        sharedRealm: Realm,
+        browserOnly: Bool
     ) {
         self.navigationController = NavigationController(navigationBarClass: DappBrowserNavigationBar.self, toolbarClass: nil)
         self.session = session
         self.keystore = keystore
         self.sharedRealm = sharedRealm
+        self.browserOnly = browserOnly
 
         super.init()
 
@@ -141,7 +144,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
         navigationController.present(coordinator.navigationController, animated: true, completion: nil)
     }
 
-    func open(url: URL, browserOnly: Bool = false, animated: Bool = true) {
+    func open(url: URL, animated: Bool = true) {
         //TODO maybe not the best idea to check like this. Because it will always create the browserViewController twice the first time (or maybe it's ok. Just once)
         if navigationController.topViewController != browserViewController {
             browserViewController = BrowserViewController(account: session.account, config: session.config, server: server)
@@ -217,7 +220,11 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
         alertController.addAction(reloadAction)
         alertController.addAction(shareAction)
         alertController.addAction(addBookmarkAction)
-        alertController.addAction(scanQrCodeAction)
+        if browserOnly {
+            //no-op
+        } else {
+            alertController.addAction(scanQrCodeAction)
+        }
         alertController.addAction(cancelAction)
         return alertController
     }

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -211,7 +211,7 @@ class InCoordinator: Coordinator {
     }
 
     private func createBrowserCoordinator(session: WalletSession, keystore: Keystore, realm: Realm) -> DappBrowserCoordinator {
-        let coordinator = DappBrowserCoordinator(session: session, keystore: keystore, sharedRealm: realm)
+        let coordinator = DappBrowserCoordinator(session: session, keystore: keystore, sharedRealm: realm, browserOnly: false)
         coordinator.delegate = self
         coordinator.start()
         coordinator.rootViewController.tabBarItem = UITabBarItem(title: R.string.localizable.browserTabbarItemTitle(), image: R.image.dapps_icon(), selectedImage: nil)
@@ -546,13 +546,13 @@ extension InCoordinator: CanOpenURL {
                 balanceCoordinator: balance
         )
 
-        let browserCoordinator = DappBrowserCoordinator(session: session, keystore: keystore, sharedRealm: realm)
+        let browserCoordinator = DappBrowserCoordinator(session: session, keystore: keystore, sharedRealm: realm, browserOnly: true)
         browserCoordinator.delegate = self
         browserCoordinator.start()
         addCoordinator(browserCoordinator)
 
         let controller = browserCoordinator.navigationController
-        browserCoordinator.open(url: url, browserOnly: true, animated: false)
+        browserCoordinator.open(url: url, animated: false)
         viewController.present(controller, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
This is only supported in the Dapp browser tab. Consistent because we don't provide a URL bar in the pop up browsers.
