### PR TITLE
Fix: Crash if switch to Collectibles while scrolling under with any other filter in Wallet tab

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -155,6 +155,9 @@ class TokensViewController: UIViewController {
                     currentCollectiblesContractsDisplayed = contractsForCollectibles
                     collectiblesCollectionView.reloadData()
                 }
+                tableView.dataSource = nil
+            } else {
+                tableView.dataSource = self
             }
             hideImportWalletImage()
         } else {


### PR DESCRIPTION
This PR fixes this issue:

1. Be under ALL filter in Wallets tab
2. Pan a few times quickly to scroll
3. While it's still scrolling, tap on the COLLECTIBLES tab