### PR TITLE
Fix: native crypto currency balance sometimes displayed at the wrong position

### DIFF
--- a/AlphaWallet/Browser/Views/NativeCryptoCurrencyBalanceView.swift
+++ b/AlphaWallet/Browser/Views/NativeCryptoCurrencyBalanceView.swift
@@ -28,7 +28,11 @@ class NativeCryptoCurrencyBalanceView: UIView {
         return amountAttributedString(for: amount)
     }
 
-    var topMargin: CGFloat
+    var topMargin: CGFloat {
+        didSet {
+            configure()
+        }
+    }
 
     init(session: WalletSession, rightMargin: CGFloat, topMargin: CGFloat) {
         self.session = session


### PR DESCRIPTION
Because updating the position of the label was previously done only when the balance is refreshed. If the balance isn't available quickly enough, the label will not be positioned correctly.