### PR TITLE
Fix: entering a URL with leading or trailing space into dapp browser should work

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -630,7 +630,7 @@ extension DappBrowserCoordinator: DappBrowserNavigationBarDelegate {
     }
 
     func didEnter(text: String, inNavigationBar navigationBar: DappBrowserNavigationBar) {
-        guard let url = urlParser.url(from: text) else { return }
+        guard let url = urlParser.url(from: text.trimmed) else { return }
         open(url: url, animated: false)
     }
 }


### PR DESCRIPTION
For #1167 

Before this PR, the dapp browser ignores URL like "https://google.com.sg   "