### PR TITLE
Fix: Order of transactions in tab within each day is displayed in reverse

### DIFF
--- a/AlphaWallet/Tokens/Types/TransactionCollection.swift
+++ b/AlphaWallet/Tokens/Types/TransactionCollection.swift
@@ -20,11 +20,10 @@ class TransactionCollection {
 
     var objects: [Transaction] {
         var transactions = [Transaction]()
-        //Concatenate arrays of hundreds/thousands of elements and then sort them. Room for speed improvement, but it seems good enough so far. It'll be much more efficient if we do a single read from Realm directly and sort with Realm
+        //Concatenate arrays of hundreds/thousands of elements. Room for speed improvement, but it seems good enough so far. It'll be much more efficient if we do a single read from Realm directly
         for each in transactionsStorages {
             transactions.append(contentsOf: Array(each.objects))
         }
-        transactions.sort { $0.date < $1.date }
         return transactions
     }
 }

--- a/AlphaWallet/Transactions/ViewModels/TransactionsViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionsViewModel.swift
@@ -20,7 +20,7 @@ struct TransactionsViewModel {
             newItems[date] = currentItems
         }
         //TODO. IMPROVE perfomance
-        let tuple = newItems.map { (key, values) in return (date: key, transactions: values) }
+        let tuple = newItems.map { (key, values) in return (date: key, transactions: values.sorted { $0.date > $1.date }) }
         items = tuple.sorted { (object1, object2) -> Bool in
             return formatter.date(from: object1.date)! > formatter.date(from: object2.date)!
         }


### PR DESCRIPTION
Before this PR, transactions were grouped correctly into days. But transactions within each day was shown in the reverse order, with oldest on top