### PR TITLE
Handle EIP681 links. ethereum: especially when scanning QR code which embeds them with Camera.app

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		5E7C74DBAE43954C185057B3 /* ChooseTokenCardTransferModeViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BA578BE5FB0E613A6D6 /* ChooseTokenCardTransferModeViewControllerViewModel.swift */; };
 		5E7C74E7DC2D79785240D757 /* GetERC875Balance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7251DB61EB9468910C81 /* GetERC875Balance.swift */; };
 		5E7C7507CC97BDE973FD4F0E /* GetENSOwnerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E9A5E7D36AA3BC108A4 /* GetENSOwnerCoordinatorTests.swift */; };
+		5E7C751D847B47B2BA67F6B5 /* CustomUrlSchemeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BF7C9B44B3C2D5330CE /* CustomUrlSchemeCoordinator.swift */; };
 		5E7C7521CA17E5C2A4506A20 /* DappsHomeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7FE5EEC96A7CDF62213F /* DappsHomeHeaderView.swift */; };
 		5E7C7567A690B6B8F889AE83 /* SendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C70088832B2D161EB4AAB /* SendViewController.swift */; };
 		5E7C7569C4D26E565F3E4F56 /* PreferenceOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7287B9288EAA0D66BAC4 /* PreferenceOption.swift */; };
@@ -1031,6 +1032,7 @@
 		5E7C7BD9B4BDAFC2D9EBD741 /* StatusViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C7BF09AD68C113D58344C /* LocalesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalesViewController.swift; sourceTree = "<group>"; };
 		5E7C7BF5551BF64D2AE8AD66 /* AssetDefinitionDiskBackingStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionDiskBackingStore.swift; sourceTree = "<group>"; };
+		5E7C7BF7C9B44B3C2D5330CE /* CustomUrlSchemeCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomUrlSchemeCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7C017A044087BEA30CC0 /* AssetDefinitionDiskBackingStoreWithOverrides.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionDiskBackingStoreWithOverrides.swift; sourceTree = "<group>"; };
 		5E7C7C01F8C42D7A43792C26 /* HiddenContract.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HiddenContract.swift; sourceTree = "<group>"; };
 		5E7C7C077372C3F2A4349FA1 /* TokenViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenViewCell.swift; sourceTree = "<group>"; };
@@ -3125,6 +3127,7 @@
 			isa = PBXGroup;
 			children = (
 				CCCD74FC1FD2D38D004A087D /* CheckDeviceCoordinator.swift */,
+				5E7C7BF7C9B44B3C2D5330CE /* CustomUrlSchemeCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -4015,6 +4018,7 @@
 				5E7C79284D45EF4C5440E546 /* EnabledServersCoordinator.swift in Sources */,
 				5E7C745ECFCAE8B1A52B7FAC /* EnabledServersViewModel.swift in Sources */,
 				5E7C78FF93B0DD68700FAFB6 /* NativeCryptoCurrencyBalanceView.swift in Sources */,
+				5E7C751D847B47B2BA67F6B5 /* CustomUrlSchemeCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -76,10 +76,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         return true
     }
 
-    // Respond to URI scheme links
+    // URI scheme links and AirDrop
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        let _ = appCoordinator.handleOpen(url: url)
-        return true
+        return appCoordinator.handleOpen(url: url)
     }
 
     // Respond to Universal Links

--- a/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
+++ b/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
@@ -1,0 +1,62 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import BigInt
+import TrustKeystore
+
+protocol CustomUrlSchemeCoordinatorDelegate: class {
+    func openSendPaymentFlow(_ paymentFlow: PaymentFlow, server: RPCServer, inCoordinator coordinator: CustomUrlSchemeCoordinator)
+}
+
+class CustomUrlSchemeCoordinator: Coordinator {
+    private let tokensDatastores: ServerDictionary<TokensDataStore>
+
+    var coordinators: [Coordinator] = []
+    weak var delegate: CustomUrlSchemeCoordinatorDelegate?
+
+    init(tokensDatastores: ServerDictionary<TokensDataStore>) {
+        self.tokensDatastores = tokensDatastores
+    }
+
+    /// Return true if handled
+    func handleOpen(url: URL) -> Bool {
+        guard let scheme = url.scheme, scheme == "ethereum" else { return false }
+
+        //TODO extract method and share code with SendViewController. Note that logic is slightly different
+        guard let result = QRURLParser.from(string: url.absoluteString) else { return false }
+
+        let server: RPCServer
+        if let chainIdStr = result.params["chainId"], let chainId = Int(chainIdStr) {
+            server = .init(chainID: chainId)
+        } else {
+            server = .main
+        }
+        //if erc20 (eip861 qr code)
+        if let recipient = result.params["address"], let amount = result.params["uint256"] {
+            guard recipient != "0" && amount != "0" else { return false }
+            guard let address = Address(string: recipient) else { return false }
+            let tokensDatastore = tokensDatastores[server]
+            guard let token = tokensDatastore.token(forContract: result.address) else {
+                //TODO we ignore EIP861 links that are for ERC20 tokens we don't have in our local database. Fix this by autodetecting the token, making sure it is ERC20 and then using it
+                return false
+            }
+
+            let transferType: TransferType = .ERC20Token(token, destination: address, amount: amount)
+            delegate?.openSendPaymentFlow(.send(type: transferType), server: server, inCoordinator: self)
+            return true
+        } else {
+            //if ether transfer (eip861 qr code)
+            guard let address = Address(string: result.address) else { return false }
+            let amount: BigInt?
+            //Double() import here because BigInt doesn't handle the scientific format, aka. 1.23e12
+            if let value = result.params["value"], let amountToSend = Double(value) {
+                amount = BigInt(amountToSend)
+            } else {
+                amount = nil
+            }
+            let transferType: TransferType = .nativeCryptocurrency(server: server, destination: address, amount: amount)
+            delegate?.openSendPaymentFlow(.send(type: transferType), server: server, inCoordinator: self)
+            return true
+        }
+    }
+}

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -39,6 +39,14 @@
 				<string>awallet</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Ethereum Links</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ethereum</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>269 </string>

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -202,9 +202,9 @@ extension TokensCoordinator: TokensViewControllerDelegate {
         let config = sessions[server].config
         switch token.type {
         case .nativeCryptocurrency:
-            coordinator.show(fungibleToken: token, transferType: .nativeCryptocurrency(server: server, destination: .none))
+            coordinator.show(fungibleToken: token, transferType: .nativeCryptocurrency(server: server, destination: .none, amount: nil))
         case .erc20:
-            coordinator.show(fungibleToken: token, transferType: .ERC20Token(token))
+            coordinator.show(fungibleToken: token, transferType: .ERC20Token(token, destination: nil, amount: nil))
         case .erc721:
             coordinator.showTokenList(for: .send(type: .ERC721Token(token)), token: token)
         case .erc875:

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -74,7 +74,7 @@ class TokenViewController: UIViewController {
         switch transferType {
         case .nativeCryptocurrency:
             header.verificationStatus = .verified(session.account.address.eip55String)
-        case .ERC20Token(let token), .ERC875TokenOrder(let token), .ERC875Token(let token), .ERC721Token(let token):
+        case .ERC20Token(let token, _, _), .ERC875TokenOrder(let token), .ERC875Token(let token), .ERC721Token(let token):
             header.verificationStatus = .unverified(token.contract)
         case .dapp:
             header.verificationStatus = .unverified(session.account.address.eip55String)
@@ -113,7 +113,7 @@ class TokenViewController: UIViewController {
                 }
             }
             session.refresh(.ethBalance)
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             let viewModel = BalanceTokenViewModel(token: token)
             let amount = viewModel.amountShort
             headerViewModel.title = "\(amount) \(viewModel.name) (\(viewModel.symbol))"

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -24,7 +24,7 @@ struct TokenViewControllerViewModel {
                     .filter({ $0.operation == nil })
                     .filter({ $0.value != "" && $0.value != "0" })
                     .prefix(3))
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             self.recentTransactions = Array(transactionsStore.objects.lazy
                     .filter({ $0.state == .completed || $0.state == .pending })
                     .filter({

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -73,7 +73,7 @@ class TransactionConfigurator {
         let to: Address? = {
             switch transaction.transferType {
             case .nativeCryptocurrency, .dapp: return transaction.to
-            case .ERC20Token(let token):
+            case .ERC20Token(let token, _, _):
                 return Address(string: token.contract)
             case .ERC875Token(let token):
                 return Address(string: token.contract)
@@ -250,7 +250,7 @@ class TransactionConfigurator {
         let address: Address? = {
             switch transaction.transferType {
             case .nativeCryptocurrency, .dapp: return transaction.to
-            case .ERC20Token(let token): return token.address
+            case .ERC20Token(let token, _, _): return token.address
             case .ERC875Token(let token): return token.address
             case .ERC875TokenOrder(let token): return token.address
             case .ERC721Token(let token): return token.address

--- a/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
@@ -37,7 +37,7 @@ class RequestCoordinator: Coordinator {
 
     func makeRequestViewController() -> RequestViewController {
         let controller = RequestViewController(viewModel: viewModel)
-        controller.navigationItem.titleView = BalanceTitleView.make(from: session, .nativeCryptocurrency(server: session.server, destination: .none))
+        controller.navigationItem.titleView = BalanceTitleView.make(from: session, .nativeCryptocurrency(server: session.server, destination: .none, amount: nil))
         controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         controller.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share(_:)))
         return controller

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -77,9 +77,12 @@ class SendCoordinator: Coordinator {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         }
         switch transferType {
-        case .nativeCryptocurrency(_, let destination):
-            controller.targetAddressTextField.value = destination?.description ?? ""
-        case .ERC20Token: break
+        case .nativeCryptocurrency(_, let destination, let amount):
+            controller.targetAddressTextField.value = destination?.eip55String ?? ""
+            controller.amountTextField.ethCost = EtherNumberFormatter.full.string(from: amount ?? BigInt(), units: .ether)
+        case .ERC20Token(_, let destination, let amount):
+            controller.targetAddressTextField.value = destination?.eip55String ?? ""
+            controller.amountTextField.ethCost = amount ?? ""
         case .ERC875Token: break
         case .ERC875TokenOrder: break
         case .ERC721Token: break

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import TrustKeystore
+import BigInt
 
 struct Transfer {
     let server: RPCServer
@@ -13,9 +14,9 @@ enum TransferType {
         self = {
             switch token.type {
 			case .nativeCryptocurrency:
-                return .nativeCryptocurrency(server: token.server, destination: nil)
+                return .nativeCryptocurrency(server: token.server, destination: nil, amount: nil)
             case .erc20:
-                return .ERC20Token(token)
+                return .ERC20Token(token, destination: nil, amount: nil)
             case .erc875:
                 return .ERC875Token(token)
             case .erc721:
@@ -24,8 +25,8 @@ enum TransferType {
         }()
     }
 
-    case nativeCryptocurrency(server: RPCServer, destination: Address?)
-    case ERC20Token(TokenObject)
+    case nativeCryptocurrency(server: RPCServer, destination: Address?, amount: BigInt?)
+    case ERC20Token(TokenObject, destination: Address?, amount: String?)
     case ERC875Token(TokenObject)
     case ERC875TokenOrder(TokenObject)
     case ERC721Token(TokenObject)
@@ -35,11 +36,11 @@ enum TransferType {
 extension TransferType {
     var symbol: String {
         switch self {
-        case .nativeCryptocurrency(let server, _):
+        case .nativeCryptocurrency(let server, _, _):
             return server.symbol
         case .dapp(let token, _):
             return token.symbol
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return token.symbol
         case .ERC875Token(let token):
             return token.symbol
@@ -52,11 +53,11 @@ extension TransferType {
 
     var server: RPCServer {
         switch self {
-        case .nativeCryptocurrency(let server, _):
+        case .nativeCryptocurrency(let server, _, _):
             return server
         case .dapp(let token, _):
             return token.server
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return token.server
         case .ERC875Token(let token):
             return token.server
@@ -71,7 +72,7 @@ extension TransferType {
         switch self {
         case .nativeCryptocurrency:
             return Address(uncheckedAgainstNullAddress: Constants.nativeCryptoAddressInDatabase)!
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return Address(string: token.contract)!
         case .ERC875Token(let token):
             return Address(string: token.contract)!

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -21,7 +21,6 @@ protocol SendViewControllerDelegate: class, CanOpenURL {
 class SendViewController: UIViewController, CanScanQRCode {
     private let roundedBackground = RoundedBackground()
     private let header = SendHeaderView()
-    lazy private var amountTextField = AmountTextField(server: session.server)
     private let targetAddressLabel = UILabel()
     private let amountLabel = UILabel()
     private let buttonsBar = ButtonsBar(numberOfButtons: 1)
@@ -38,10 +37,11 @@ class SendViewController: UIViewController, CanScanQRCode {
     }()
 
     let targetAddressTextField = AddressTextField()
+    lazy var amountTextField = AmountTextField(server: session.server)
     weak var delegate: SendViewControllerDelegate?
     var contract: String {
         switch transferType {
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return token.contract
         case .nativeCryptocurrency:
             return account.address.eip55String
@@ -205,7 +205,7 @@ class SendViewController: UIViewController, CanScanQRCode {
             switch transferType {
             case .nativeCryptocurrency, .dapp:
                 return EtherNumberFormatter.full.number(from: amountString, units: .ether)
-            case .ERC20Token(let token):
+            case .ERC20Token(let token, _, _):
                 return EtherNumberFormatter.full.number(from: amountString, decimals: token.decimals)
             case .ERC875Token(let token):
                 return EtherNumberFormatter.full.number(from: amountString, decimals: token.decimals)
@@ -267,7 +267,7 @@ class SendViewController: UIViewController, CanScanQRCode {
                 }
             }
             session.refresh(.ethBalance)
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             let viewModel = BalanceTokenViewModel(token: token)
             let amount = viewModel.amountShort
             headerViewModel.title = "\(amount) \(viewModel.name) (\(viewModel.symbol))"

--- a/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmPaymentDetailsViewModel.swift
@@ -98,7 +98,7 @@ struct ConfirmPaymentDetailsViewModel {
 
     var amountAttributedString: NSAttributedString {
         switch transaction.transferType {
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return amountAttributedText(
                 string: fullFormatter.string(from: transaction.value, decimals: token.decimals)
             )

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -27,7 +27,7 @@ struct SendViewModel {
         switch transferType {
         case .nativeCryptocurrency:
             return nil
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             return token
         case .ERC875Token(let token):
             return token

--- a/AlphaWallet/UI/BalanceTitleView.swift
+++ b/AlphaWallet/UI/BalanceTitleView.swift
@@ -102,7 +102,7 @@ extension BalanceTitleView {
                 guard let viewModel = viewModel else { return }
                 view?.viewModel = viewModel
             }
-        case .ERC20Token(let token):
+        case .ERC20Token(let token, _, _):
             view.viewModel = BalanceTokenViewModel(token: token)
         case .ERC875Token(let token):
             view.viewModel = BalanceTokenViewModel(token: token)

--- a/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
@@ -69,7 +69,7 @@ class InCoordinatorTests: XCTestCase {
         )
         coordinator.showTabBar(for: .make())
 
-        coordinator.showPaymentFlow(for: .send(type: .nativeCryptocurrency(server: .main, destination: .none)), server: .main)
+        coordinator.showPaymentFlow(for: .send(type: .nativeCryptocurrency(server: .main, destination: .none, amount: nil)), server: .main)
 
         let controller = (coordinator.navigationController.presentedViewController as? UINavigationController)?.viewControllers[0]
 

--- a/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
@@ -8,7 +8,7 @@ class SendCoordinatorTests: XCTestCase {
     
     func testRootViewController() {
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(server: .main, destination: .none),
+            transferType: .nativeCryptocurrency(server: .main, destination: .none, amount: nil),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),
@@ -25,7 +25,7 @@ class SendCoordinatorTests: XCTestCase {
     func testDestination() {
         let address: Address = .make()
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(server: .main, destination: address),
+            transferType: .nativeCryptocurrency(server: .main, destination: address, amount: nil),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),

--- a/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
+++ b/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
@@ -7,7 +7,7 @@ import BigInt
 
 extension UnconfirmedTransaction {
     static func make(
-        transferType: TransferType = .nativeCryptocurrency(server: .main, destination: .none),
+        transferType: TransferType = .nativeCryptocurrency(server: .main, destination: .none, amount: nil),
         value: BigInt = BigInt(1),
         to: Address = .make(),
         data: Data = Data(),

--- a/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
+++ b/AlphaWalletTests/ViewControllers/PaymentCoordinator.swift
@@ -10,7 +10,7 @@ class PaymentCoordinatorTests: XCTestCase {
         let address: Address = .make()
         let coordinator = PaymentCoordinator(
             navigationController: FakeNavigationController(),
-            flow: .send(type: .nativeCryptocurrency(server: .main, destination: address)),
+            flow: .send(type: .nativeCryptocurrency(server: .main, destination: address, amount: nil)),
             session: .make(),
             keystore: FakeKeystore(),
             storage: FakeTokensDataStore(),


### PR DESCRIPTION
For #1163 

Couple of links I tested with:

ethereum:0xf956F4D787F8CA0F363468859E54eAD5cA1e5184
ethereum:pay-0xf956F4D787F8CA0F363468859E54eAD5cA1e5184?value=1.23e18
ethereum:pay-0xf956F4D787F8CA0F363468859E54eAD5cA1e5184@3?value=1.23e18
ethereum:pay-0x087913a52D327F0CA037D497848ee31Ec146F07e@3/transfer?address=0xf956F4D787F8CA0F363468859E54eAD5cA1e5184&uint256=1.3

The last link is an ERC20 token transfer. It'll be ignored silently by the app if the token is not already in the Realm database.

Everyone's fighting for the only slot:

<img src="https://user-images.githubusercontent.com/56189/56483973-bf463c00-64ff-11e9-9260-6353f19bc4fd.PNG" width=300>
<img src="https://user-images.githubusercontent.com/56189/56483974-bfded280-64ff-11e9-9363-8cbc7e3d307a.PNG" width=300>
<img src="https://user-images.githubusercontent.com/56189/56483975-bfded280-64ff-11e9-9fd8-143fdfff865e.PNG" width=300>
<img src="https://user-images.githubusercontent.com/56189/56483976-bfded280-64ff-11e9-8f90-b644a98f0277.PNG" width=300>
<img src="https://user-images.githubusercontent.com/56189/56483977-c0776900-64ff-11e9-820a-b04c1addac6a.PNG" width=300>
