### PR TITLE
Reduce unnecessary Ether price and Ether balance fetching

### DIFF
--- a/AlphaWallet/Core/Types/ServerDictionary.swift
+++ b/AlphaWallet/Core/Types/ServerDictionary.swift
@@ -23,4 +23,12 @@ struct ServerDictionary<T> {
     var anyValue: T {
         return backingStore.values.first!
     }
+
+    var count: Int {
+        return backingStore.count
+    }
+
+    var isEmpty: Bool {
+        return backingStore.isEmpty
+    }
 }


### PR DESCRIPTION
For #1192 

This PR improves data transfer usage by reducing unnecessary Ether price and balance fetching. Just simple de-dup. No fancy exponential backup etc.