### PR TITLE
Fix: tapping verified in import MagicLink UI for mainnet token does not load URL in browser correctly

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -173,7 +173,8 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     }
 
     func open(url: URL, animated: Bool = true) {
-        if isMagicLink(url) {
+        //If users tap on the verified button in the import MagicLink UI, we don't want to treat it as a MagicLink to import and show the UI again. Just open in browser. This check means when we tap MagicLinks in browserOnly mode, the import UI doesn't show up; which is probably acceptable
+        if !browserOnly && isMagicLink(url) {
             delegate?.importUniversalLink(url: url, forCoordinator: self)
             return
         }


### PR DESCRIPTION
This PR fixes a bug introduced by #1178. When the verified button in the import MagicLink UI is tapped, the browser doesn't load the MagicLink. ((because it sees a MagicLink and tries again, and failed, to load up the MagicLink UI according to #1178)