### PR TITLE
Make tapping on verified button in MagicLink import UI open all MagicLinks instead of etherscan page, not just mainnet MagicLinks

### DIFF
--- a/AlphaWallet/Market/ViewControllers/ImportMagicTokenViewController.swift
+++ b/AlphaWallet/Market/ViewControllers/ImportMagicTokenViewController.swift
@@ -234,20 +234,6 @@ class ImportMagicTokenViewController: UIViewController, OptionalTokenVerifiableS
         }
     }
 
-    func showContractWebPage() {
-        if case .main = server {
-            guard let url = url else { return }
-            delegate?.didPressViewContractWebPage(url, in: self)
-        } else {
-            guard let contract = contract else { return }
-            delegate?.didPressViewContractWebPage(forContract: contract, server: server, in: self)
-        }
-    }
-
-    //Just for protocol conformance. Do nothing
-    func showInfo() {
-    }
-
     class PaddedLabel: UILabel {
         override var intrinsicContentSize: CGSize {
             let size = super.intrinsicContentSize
@@ -256,3 +242,13 @@ class ImportMagicTokenViewController: UIViewController, OptionalTokenVerifiableS
     }
 }
 
+extension ImportMagicTokenViewController: VerifiableStatusViewController {
+    func showContractWebPage() {
+        guard let url = url else { return }
+        delegate?.didPressViewContractWebPage(url, in: self)
+    }
+
+    //Just for protocol conformance. Do nothing
+    func showInfo() {
+    }
+}


### PR DESCRIPTION
Since we support MagicLinks for every chain now:

This PR makes tapping on the verified button in import UI open all MagicLinks in a browser instead of etherscan. We used to only open MagicLinks in the browser for mainnet only, opening etherscan for non-Ethereum-mainnet