### PR TITLE
Dismiss keyboard in add custom token screen after pasting contract (which kicks off auto detection) to improve usabiliity. Done button is shown immediately

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -414,7 +414,7 @@ extension NewTokenViewController: AddressTextFieldDelegate {
 
     func didPaste(in textField: AddressTextField) {
         updateContractValue(value: textField.value)
-        _ = symbolTextField.becomeFirstResponder()
+        view.endEditing(true)
     }
 
     func shouldReturn(in textField: AddressTextField) -> Bool {


### PR DESCRIPTION
Before this PR, after pasting and auto detection is completed, you'll have to tap the `name` textfield (which might be hidden if you have a shorter device), or hit Next a few times until the `name` textfield has the focus and hit the `Done` button in the keyboard to dismiss the keyboard before the green `Done` button is revealed.

An additional benefit of dismissing the keyboard immediately after pasting a contract is, the Done turns green when auto-detection has completed, so this change makes it easier to notice when auto-detection is completed.