### PR TITLE
Fix warnings after Xcode upgrade

### DIFF
--- a/AlphaWallet/Browser/ViewControllers/MyDappsViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/MyDappsViewController.swift
@@ -62,7 +62,6 @@ class MyDappsViewController: UIViewController {
 
     @objc private func keyboardWillShow(notification: NSNotification) {
         if let keyboardEndFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue, let keyboardBeginFrame = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue {
-            let keyboardHeight = keyboardEndFrame.size.height
             tableView.contentInset.bottom = keyboardEndFrame.size.height
         }
     }

--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -21,7 +21,7 @@ enum AlphaWalletService {
 extension AlphaWalletService: TargetType {
     var baseURL: URL {
         switch self {
-        case .getTransactions(let config, let server, _, _, _, _):
+        case .getTransactions(_, let server, _, _, _, _):
             return server.transactionInfoEndpoints
         case .priceOfEth(let config), .priceOfDai(let config):
             return config.priceInfoEndpoints

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -201,7 +201,7 @@ class InCoordinator: NSObject, Coordinator {
             callForAssetAttributeCoordinators[each] = callForAssetAttributeCoordinator
             //Since this is called at launch, we don't want it to block launching
             DispatchQueue.global().async {
-                DispatchQueue.main.async { [weak self] in
+                DispatchQueue.main.async {
                     callForAssetAttributeCoordinator.refreshFunctionCallBasedAssetAttributesForAllTokens()
                 }
             }
@@ -510,7 +510,6 @@ class InCoordinator: NSObject, Coordinator {
             let strongSelf = self
             switch result {
             case .success(let payload):
-                let address: Address = strongSelf.wallet.address
                 let session = strongSelf.walletSessions[server]
                 let account = try! EtherKeystore().getAccount(for: wallet.address)!
                 //Note: since we have the data payload, it is unnecessary to load an UnconfirmedTransaction struct
@@ -586,7 +585,7 @@ extension InCoordinator: CanOpenURL {
         guard let account = keystore.recentlyUsedWallet else { return }
 
         //TODO duplication of code to set up a BrowserCoordinator when creating the application's tabbar
-        let realm = self.realm(forAccount: keystore.recentlyUsedWallet!)
+        let realm = self.realm(forAccount: account)
         let browserCoordinator = createBrowserCoordinator(sessions: walletSessions, realm: realm, browserOnly: true)
         let controller = browserCoordinator.navigationController
         browserCoordinator.open(url: url, animated: false)

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -40,7 +40,7 @@ class UniversalLinkCoordinator: Coordinator {
     private var isNotProcessingYet: Bool {
         guard let importTokenViewController = importTokenViewController else { return false }
         switch importTokenViewController.state {
-        case .ready(var viewModel):
+        case .ready(let viewModel):
             switch viewModel.state {
             case .validating, .promptImport:
                 return true

--- a/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
@@ -13,7 +13,7 @@ class UniversalLinkInPasteboardCoordinator: Coordinator {
     func start() {
         guard let contents = UIPasteboard.general.string?.trimmed else { return }
         guard let url = URL(string: contents) else { return }
-        guard let server = RPCServer(withMagicLink: url) else { return }
+        guard RPCServer(withMagicLink: url) != nil else { return }
         UIPasteboard.general.string = ""
         delegate?.importUniversalLink(url: url, for: self)
     }

--- a/AlphaWallet/PushNotificationsCoordinator.swift
+++ b/AlphaWallet/PushNotificationsCoordinator.swift
@@ -21,7 +21,6 @@ class PushNotificationsCoordinator: NSObject, Coordinator {
 
     private func promptToEnableNotification(in navigationController: UINavigationController) {
         authorizationNotDetermined { [weak self] in
-            guard let strongSelf = self else { return }
             navigationController.visibleViewController?.confirm(
                     //TODO We'll just say "Ether" in the prompt. Note that this is not the push notification itself. We could refer to it as "native cryptocurrency", but that's vague. Could be xDai!
                     title: R.string.localizable.transactionsReceivedEtherNotificationPrompt(RPCServer.main.cryptoCurrencyName),

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -80,7 +80,6 @@ struct Config {
 
     var enabledServers: [RPCServer] {
         get {
-            var addresses: [String]
             if let chainIds = defaults.array(forKey: Keys.enabledServers) as? [Int] {
                 return chainIds.map { .init(chainID: $0) }
             } else {

--- a/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
@@ -100,8 +100,7 @@ class SettingsViewController: FormViewController {
             self.run(action: .enabledServers)
         }.cellSetup { cell, _ in
             cell.imageView?.tintColor = Colors.appBackground
-        }.cellUpdate { [weak self] cell, _ in
-            guard let strongSelf = self else { return }
+        }.cellUpdate { cell, _ in
             cell.imageView?.image = R.image.settings_server()?.withRenderingMode(.alwaysTemplate)
             cell.textLabel?.text = R.string.localizable.settingsEnabledNetworksButtonTitle()
             cell.accessoryType = .disclosureIndicator

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -20,7 +20,6 @@ class GetContractInteractions {
                 //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
                 DispatchQueue.global().async {
                     let json = JSON(value)
-                    let c = json["result"]
                     let contracts: [String] = json["result"].map { _, transactionJson in
                         if transactionJson["input"] != "0x" {
                             //every transaction that has input is by default a transaction to a contract

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -199,7 +199,6 @@ extension TokensCoordinator: TokensViewControllerDelegate {
     func didSelect(token: TokenObject, in viewController: UIViewController) {
         let server = token.server
         guard let coordinator = singleChainTokenCoordinator(forServer: server) else { return }
-        let config = sessions[server].config
         switch token.type {
         case .nativeCryptocurrency:
             coordinator.show(fungibleToken: token, transferType: .nativeCryptocurrency(server: server, destination: .none, amount: nil))

--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionDataCoordinator.swift
@@ -184,7 +184,6 @@ class SingleChainTransactionDataCoordinator: Coordinator {
     private func notifyUserEtherReceived(for transactionId: String, amount: String) {
         let notificationCenter = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
-        let config = session.config
         switch session.server {
         case .main, .xDai:
             content.body = R.string.localizable.transactionsReceivedEther(amount, session.server.symbol)

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -123,7 +123,7 @@ class TransactionConfigurator {
                     data: transaction.data ?? configuration.data
             )
             completion(.success(()))
-        case .ERC20Token(let token):
+        case .ERC20Token:
             do {
                 let function = Function(name: "transfer", parameters: [ABIType.address, ABIType.uint(bits: 256)])
                 //Note: be careful here with the BigUInt and BigInt, the type needs to be exact
@@ -198,7 +198,7 @@ class TransactionConfigurator {
                 completion(.failure(AnyError(Web3Error(description: "malformed tx"))))
             }
 
-        case .ERC721Token(let token):
+        case .ERC721Token:
             do {
                 let function: Function
                 let parameters: [Any]


### PR DESCRIPTION
This PR removes a few warnings. Only obviously safe looking changes are made. So there are a few warnings left.