### PR TITLE
Fix: should allow taps on crypto balance in dapp browser to passthrough to the content in the dapp browser

### DIFF
--- a/AlphaWallet/Browser/Views/NativeCryptoCurrencyBalanceView.swift
+++ b/AlphaWallet/Browser/Views/NativeCryptoCurrencyBalanceView.swift
@@ -48,6 +48,9 @@ class NativeCryptoCurrencyBalanceView: UIView {
 
         super.init(frame: .zero)
 
+        //So we can tap through to the content in the dapp browser
+        isUserInteractionEnabled = false
+
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
 


### PR DESCRIPTION
Fixes #1208 