### PR TITLE
Get received transactions

### DIFF
--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -16,7 +16,7 @@ class MigrationInitializer: Initializer {
     }
 
     func perform() {
-        config.schemaVersion = 2
+        config.schemaVersion = 3
         config.migrationBlock = { migration, oldSchemaVersion in
             if oldSchemaVersion < 2 {
                 //Fix bug created during multi-chain implementation. Where TokenObject instances are created from transfer Transaction instances, with the primaryKey as a empty string; so instead of updating an existing TokenObject, a duplicate TokenObject instead was created but with primaryKey empty
@@ -27,6 +27,15 @@ class MigrationInitializer: Initializer {
                         migration.delete(newObject)
                         return
                     }
+                }
+            }
+        }
+        config.migrationBlock = { migration, oldSchemaVersion in
+            if oldSchemaVersion < 3 {
+                migration.enumerateObjects(ofType: Transaction.className()) { oldObject, newObject in
+                    guard let oldObject = oldObject else { return }
+                    guard let newObject = newObject else { return }
+                    newObject["isERC20Interaction"] = false 
                 }
             }
         }

--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -66,7 +66,9 @@ extension Transaction {
                     nonce: transaction.nonce,
                     date: NSDate(timeIntervalSince1970: TimeInterval(transaction.timeStamp) ?? 0) as Date,
                     localizedOperations: operations,
-                    state: state)
+                    state: state,
+                    isErc20Interaction: false
+            )
             return .value(result)
         }
     }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -69,6 +69,15 @@ public struct Constants {
     public static let poaNetworkCoreAPI = "https://blockscout.com/poa/core/api?module=account&action=txlist&address="
     public static let goerliEtherscanAPI = "https://api-goerli.etherscan.io/api?module=account&action=txlist&address="
 
+    //etherscan-compatible erc20 transaction event APIs
+    public static let mainnetEtherscanAPIErc20Events = "https://api.etherscan.io/api?module=account&action=tokentx&address="
+    public static let ropstenEtherscanAPIErc20Events = "https://ropsten.etherscan.io/api?module=account&action=tokentx&address="
+    public static let kovanEtherscanAPIErc20Events = "https://api-kovan.etherscan.io/api?module=account&action=tokentx&address="
+    public static let rinkebyEtherscanAPIErc20Events = "https://rinkeby.etherscan.io/api?module=account&action=tokentx&address="
+    public static let xDaiAPIErc20Events = "https://blockscout.com/poa/dai/api?module=account&action=tokentx&address="
+    public static let poaNetworkCoreAPIErc20Events = "https://blockscout.com/poa/core/api?module=account&action=tokentx&address="
+    public static let goerliEtherscanAPIErc20Events = "https://api-goerli.etherscan.io/api?module=account&action=tokentx&address="
+
     //etherscan-compatible contract details web page
     public static let mainnetEtherscanContractDetailsWebPageURL = "https://etherscan.io/address/"
     public static let kovanEtherscanContractDetailsWebPageURL = "https://kovan.etherscan.io/address/"

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -77,6 +77,23 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    //TODO fix up all the networks
+    var getEtherscanURLERC20Events: String {
+        switch self {
+        case .main: return Constants.mainnetEtherscanAPIErc20Events
+        case .ropsten: return Constants.ropstenEtherscanAPIErc20Events
+        case .rinkeby: return Constants.rinkebyEtherscanAPIErc20Events
+        case .kovan: return Constants.kovanEtherscanAPIErc20Events
+        case .poa: return Constants.poaNetworkCoreAPIErc20Events
+        case .sokol: return Constants.mainnetEtherscanAPIErc20Events
+        case .classic: return Constants.mainnetEtherscanAPIErc20Events
+        case .callisto: return Constants.mainnetEtherscanAPIErc20Events
+        case .goerli: return Constants.goerliEtherscanAPIErc20Events
+        case .xDai: return Constants.xDaiAPIErc20Events
+        case .custom: return Constants.mainnetEtherscanAPIErc20Events
+        }
+    }
+
     var etherscanContractDetailsWebPageURL: String {
         switch self {
         case .main: return Constants.mainnetEtherscanContractDetailsWebPageURL
@@ -92,6 +109,10 @@ enum RPCServer: Hashable, CaseIterable {
 
     func etherscanAPIURLForTransactionList(for address: String) -> URL {
         return URL(string: getEtherscanURL + address)!
+    }
+
+    func etherscanAPIURLForERC20TxList(for address: String) -> URL {
+        return URL(string: getEtherscanURLERC20Events + address)!
     }
 
     func etherscanContractDetailsWebPageURL(for address: String) -> URL {

--- a/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
@@ -31,3 +31,33 @@ func callSmartContract(withServer server: RPCServer, contract: Address, function
         return promiseCreator.callPromise(options: nil)
     }
 }
+
+func getEventLogs(
+        withServer server: RPCServer,
+        contract: String,
+        eventName: String,
+        abiString: String
+) -> Promise<[EventParserResultProtocol]> {
+    return firstly { () -> Promise<(EthereumAddress)> in
+        //EthereumAddress(Data) is much faster than EthereumAddress(String). This is significant because we call this function for each applicable token and there could be hundreds of calls
+        guard let data = Data.fromHex(contract), let contractAddress = EthereumAddress(data) else {
+            return Promise(error: Web3Error(description: "Error converting contract address: \(contract)"))
+        }
+        return .value(contractAddress)
+    }.then { contractAddress -> Promise<[EventParserResultProtocol]> in
+        guard let webProvider = Web3HttpProvider(server.rpcURL, network: server.web3Network) else {
+            return Promise(error: Web3Error(description: "Error creating web provider for: \(server.rpcURL) + \(server.web3Network)"))
+        }
+
+        let web3 = web3swift.web3(provider: webProvider)
+
+        guard let contractInstance = web3swift.web3.web3contract(web3: web3, abiString: abiString, at: contractAddress, options: web3.options) else {
+            return Promise(error: Web3Error(description: "Error creating web3swift contract instance to call \(eventName)()"))
+        }
+
+        return contractInstance.getIndexedEventsPromise(
+                eventName: eventName,
+                filter: EventFilter(fromBlock: nil, toBlock: nil)
+        )
+    }
+}

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -3,13 +3,16 @@
 import Foundation
 import UIKit
 import TrustKeystore
+import web3swift
+import Alamofire
+import PromiseKit
 
-struct TokenViewControllerViewModel {
+class TokenViewControllerViewModel {
     private let transferType: TransferType
     private let session: WalletSession
     private let tokensStore: TokensDataStore
     private let transactionsStore: TransactionsStorage
-    let recentTransactions: [Transaction]
+    var recentTransactions: [Transaction] = []
 
     init(transferType: TransferType, session: WalletSession, tokensStore: TokensDataStore, transactionsStore: TransactionsStorage) {
         self.transferType = transferType

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -3,16 +3,13 @@
 import Foundation
 import UIKit
 import TrustKeystore
-import web3swift
-import Alamofire
-import PromiseKit
 
-class TokenViewControllerViewModel {
+struct TokenViewControllerViewModel {
     private let transferType: TransferType
     private let session: WalletSession
     private let tokensStore: TokensDataStore
     private let transactionsStore: TransactionsStorage
-    var recentTransactions: [Transaction] = []
+    let recentTransactions: [Transaction]
 
     init(transferType: TransferType, session: WalletSession, tokensStore: TokensDataStore, transactionsStore: TransactionsStorage) {
         self.transferType = transferType

--- a/AlphaWallet/Transactions/Storage/Transaction.swift
+++ b/AlphaWallet/Transactions/Storage/Transaction.swift
@@ -17,6 +17,7 @@ class Transaction: Object {
     @objc dynamic var nonce: String = ""
     @objc dynamic var date = Date()
     @objc dynamic var internalState: Int = TransactionState.completed.rawValue
+    @objc dynamic var isERC20Interaction: Bool = false
     var localizedOperations = List<LocalizedOperationObject>()
 
     convenience init(
@@ -32,7 +33,8 @@ class Transaction: Object {
         nonce: String,
         date: Date,
         localizedOperations: [LocalizedOperationObject],
-        state: TransactionState
+        state: TransactionState,
+        isErc20Interaction: Bool
     ) {
 
         self.init()
@@ -49,6 +51,7 @@ class Transaction: Object {
         self.nonce = nonce
         self.date = date
         self.internalState = state.rawValue
+        self.isERC20Interaction = isErc20Interaction
 
         let list = List<LocalizedOperationObject>()
         localizedOperations.forEach { element in

--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -28,6 +28,15 @@ class TransactionsStorage {
         return objects.filter { $0.state == .completed }
     }
 
+    var transactionObjectsThatDoNotComeFromEventLogs: Results<Transaction> {
+        return realm.objects(Transaction.self)
+                .sorted(byKeyPath: "date", ascending: false)
+                .filter("chainId = \(self.server.chainID)")
+                .filter("id != ''")
+                .filter("internalState == \(TransactionState.completed.rawValue)")
+                .filter("isERC20Interaction == false")
+    }
+
     var pendingObjects: [Transaction] {
         return objects.filter { $0.state == TransactionState.pending }
     }

--- a/AlphaWallet/Transfer/Types/SentTransaction.swift
+++ b/AlphaWallet/Transfer/Types/SentTransaction.swift
@@ -24,7 +24,8 @@ extension SentTransaction {
             date: Date(),
             //TODO we should know what type of transaction (transfer) here and create accordingly if it's ERC20, ERC721, ERC875
             localizedOperations: [],
-            state: .pending
+            state: .pending,
+            isErc20Interaction: false
         )
     }
 }

--- a/AlphaWalletTests/Coordinators/ClaimOrderCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/ClaimOrderCoordinatorTests.swift
@@ -20,7 +20,7 @@ class ClaimOrderCoordinatorTests: XCTestCase {
         expectations.append(expectation)
         var indices = [UInt16]()
         indices.append(14)
-        let expiry = BigUInt("0")
+        let expiry = BigUInt("0")!
         let v = UInt8(27)
         let r = "0x2d8e40406bf6175036ab1e1099b48590438bf48d429a8b209120fecd07894566"
         let s = "0x59ccf58ca36f681976228309fdd9de7e30e860084d9d63014fa79d48a25bb93d"
@@ -39,7 +39,7 @@ class ClaimOrderCoordinatorTests: XCTestCase {
         
         let order = Order(price: BigUInt(0),
                           indices: indices,
-                          expiry: expiry!,
+                          expiry: expiry,
                           contractAddress: token.contract,
                           count: 1,
                           nonce: BigUInt(0),

--- a/AlphaWalletTests/Factories/Transaction.swift
+++ b/AlphaWalletTests/Factories/Transaction.swift
@@ -31,7 +31,8 @@ extension Transaction {
             nonce: nonce,
             date: date,
             localizedOperations: localizedOperations,
-            state: state
+            state: state,
+            isErc20Interaction: false 
         )
     }
 }


### PR DESCRIPTION
This PR:

- Enables an event lookup for erc20 transactions meaning you can get incoming transactions and pick up contracts you haven't transacted with directly (from Etherscan)

- Adds a flag to the Transaction object to prevent getting the block number from one of these event transactions and thus miss some of the older transactions you might have done 

- Adds a function to call for generic events 

Solves #1211 and issues related to it 

@JamesSmartCell This is relevant for Android too. 