### PR TITLE
Adding BTU Hotel Dapp

### DIFF
--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -50,7 +50,9 @@ enum Dapps {
         Dapp(name: "Zerion", description: "Trade and manage your digital assets across different wallets in one interface", url: "https://zerion.io", cat: "Finance"),
         Dapp(name: "BTU Hotel", description: "BTU Hotel is a hotel booking Dapp takes 0% commission. Dapp user earns 100% of the hotel commission directly in crypto into their preferred browser wallet", url: "https://btu-hotel.com", cat: "Travel"),
         Dapp(name: "Bidali", description: "Buy from top brands with crypto", url: "https://commerce.bidali.com/dapp", cat: "Marketplace"),
-        Dapp(name: "ENS domain manager", description: "Manage ENS domains", url: "https://manager.ens.domains", cat: "Tool")
+        Dapp(name: "ENS domain manager", description: "Manage ENS domains", url: "https://manager.ens.domains", cat: "Tool",
+        Dapp(name: "BTU Hotel", description: "2 millions hotels available for booking at best price and with rewards in crypto", url: "https://btu-hotel.com", cat: "Marketplace")
+)
     ]
 
     struct Category {

--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -50,7 +50,7 @@ enum Dapps {
         Dapp(name: "Zerion", description: "Trade and manage your digital assets across different wallets in one interface", url: "https://zerion.io", cat: "Finance"),
         Dapp(name: "BTU Hotel", description: "BTU Hotel is a hotel booking Dapp takes 0% commission. Dapp user earns 100% of the hotel commission directly in crypto into their preferred browser wallet", url: "https://btu-hotel.com", cat: "Travel"),
         Dapp(name: "Bidali", description: "Buy from top brands with crypto", url: "https://commerce.bidali.com/dapp", cat: "Marketplace"),
-        Dapp(name: "ENS domain manager", description: "Manage ENS domains", url: "https://manager.ens.domains", cat: "Tool",
+        Dapp(name: "ENS domain manager", description: "Manage ENS domains", url: "https://manager.ens.domains", cat: "Tool"),
         Dapp(name: "BTU Hotel", description: "2 millions hotels available for booking at best price and with rewards in crypto", url: "https://btu-hotel.com", cat: "Marketplace")
 )
     ]


### PR DESCRIPTION
Adding BTU Hotel dapp. BTU Hotel is a hotel booking Dapp takes 0% commission. Dapp user earns 100% of the hotel commission directly in crypto into their prefered browser wallet