### PR TITLE
Fix: should also fetch TokenScript files from repo for ERC20 tokens

### DIFF
--- a/AlphaWallet/AssetDefinition/Coordinators/FetchAssetDefinitionsCoordinator.swift
+++ b/AlphaWallet/AssetDefinition/Coordinators/FetchAssetDefinitionsCoordinator.swift
@@ -15,7 +15,14 @@ class FetchAssetDefinitionsCoordinator: Coordinator {
     func start() {
         var contracts = [String]()
         for each in tokensDataStores.values {
-            contracts.append(contentsOf: each.enabledObject.filter { $0.type == .erc875 || $0.type == .erc721 }.map { $0.contract })
+            contracts.append(contentsOf: each.enabledObject.filter {
+                switch $0.type {
+                case .erc20, .erc721, .erc875:
+                    return true
+                case .nativeCryptocurrency:
+                    return false
+                }
+            }.map { $0.contract })
         }
         assetDefinitionStore.fetchXMLs(forContracts: contracts.compactMap { AlphaWallet.Address(string: $0) })
     }


### PR DESCRIPTION
Before this PR, when we fetch TokenScript files from the repo for tokens already in the local database, we only include ERC721 and ERC875 tokens.

This PR includes ERC20.

(Running this on a device might have worked before this PR if the token has just been detected and or is just manually added).