### PR TITLE
Don't show errors for asset definition files that are based on pre-2019/04 schema

### DIFF
--- a/AlphaWallet/AssetDefinition/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/AssetDefinition/AssetDefinitionDiskBackingStore.swift
@@ -20,7 +20,12 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
     }
 
     var badTokenScriptFileNames: [TokenScriptFileIndices.FileName] {
-        return tokenScriptFileIndices.badTokenScriptFileNames
+        if isOfficial {
+            //We exclude .xml in the directory for files downloaded from the repo. Because this are based on pre 2019/04 schemas. We should just delete them
+            return tokenScriptFileIndices.badTokenScriptFileNames.filter { !$0.hasSuffix(".xml") }
+        } else {
+            return tokenScriptFileIndices.badTokenScriptFileNames
+        }
     }
 
     var conflictingTokenScriptFileNames: [TokenScriptFileIndices.FileName] {


### PR DESCRIPTION
This PR ignore those files so that they don't show up as bad TokenScript files in the top of the Wallet tab and in Settings > Console.

(The desirable general approach when encountering files based on old Schema files should be to let user tap a button to try to download an updated version instead).