### PR TITLE
Fix: Wallet tab should still show the 'Show Errors' button when there are conflicting TokenScript files (even if there are no bad TokenScript files)

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -59,7 +59,7 @@ class AppCoordinator: NSObject, Coordinator {
         }
 
         assetDefinitionStore.delegate = self
-        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles)
+        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles + assetDefinitionStore.listOfConflictingTokenScriptFiles)
     }
 
     /// Return true if handled
@@ -302,6 +302,6 @@ extension AppCoordinator: AssetDefinitionStoreCoordinatorDelegate {
 
 extension AppCoordinator: AssetDefinitionStoreDelegate {
     func listOfBadTokenScriptFilesChanged(in: AssetDefinitionStore ) {
-        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles)
+        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles + assetDefinitionStore.listOfConflictingTokenScriptFiles)
     }
 }

--- a/AlphaWallet/AssetDefinition/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/AssetDefinition/AssetDefinitionDiskBackingStore.swift
@@ -223,13 +223,11 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
                     contracts = []
                     tokenScriptFileIndices.badTokenScriptFileNames += [fileName]
                 }
-                delegate?.badTokenScriptFilesChanged(in: self)
             } else {
                 contracts = []
                 tokenScriptFileIndices.removeHash(forFile: fileName)
                 tokenScriptFileIndices.removeBadTokenScriptFileName(fileName)
                 tokenScriptFileIndices.removeOldTokenScriptFileName(fileName)
-                delegate?.badTokenScriptFilesChanged(in: self)
             }
 
             contractsAffected = contracts + contractsPreviouslyForThisXmlFile
@@ -246,5 +244,6 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
             changeHandler(each)
         }
         writeIndicesToDisk()
+        delegate?.badTokenScriptFilesChanged(in: self)
     }
 }

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -44,6 +44,7 @@ class TokensViewController: UIViewController {
     private let consoleButton = UIButton(type: .system)
 
     weak var delegate: TokensViewControllerDelegate?
+    //TODO The name "bad" isn't correct. Because it includes "conflicts" too
     var listOfBadTokenScriptFiles: [TokenScriptFileIndices.FileName] = .init() {
         didSet {
             if listOfBadTokenScriptFiles.isEmpty {


### PR DESCRIPTION
Before this PR:

When they are only conflicting TokenScript files but no bad TokenScript files identified, the "Show Errors" button isn't displayed in the Wallet tab despite the conflicting TokenScript files being listed in the Console screen.

This PR fixes it.