### PR TITLE
Fix: TokenScript files with the same contents wrongly detected as conflicts

### DIFF
--- a/AlphaWallet/AssetDefinition/TokenScriptFileIndices.swift
+++ b/AlphaWallet/AssetDefinition/TokenScriptFileIndices.swift
@@ -20,8 +20,8 @@ struct TokenScriptFileIndices: Codable {
 
     var conflictingTokenScriptFileNames: [FileName] {
         var result = [FileName]()
-        for (_, fileNames) in contractsToFileNames {
-            if fileNames.count > 1 {
+        for (contract, fileNames) in contractsToFileNames {
+            if nonConflictingFileName(forContract: contract) == nil {
                 result.append(contentsOf: fileNames)
             }
         }


### PR DESCRIPTION
This is more common with files from the repo server.

The same TokenScript file for the entry token is downloaded several times because it applies to several contract address over different networks. Before this PR, the app thinks that these TokenScript files have a conflict. It should not, because the file contents are the same.