### PR TITLE
Fix: Getting Started button height in onboarding screen did not take into account bottom safe area of iPhone X

### DIFF
--- a/AlphaWallet/Welcome/ViewControllers/WelcomeViewController.swift
+++ b/AlphaWallet/Welcome/ViewControllers/WelcomeViewController.swift
@@ -88,7 +88,7 @@ class WelcomeViewController: UIViewController {
 
             footerBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             footerBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            footerBar.heightAnchor.constraint(equalToConstant: walletButtonHeight),
+            footerBar.topAnchor.constraint(equalTo: view.layoutGuide.bottomAnchor, constant: -walletButtonHeight),
             footerBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 


### PR DESCRIPTION
Fix #1216 

Before PR:

<img src="https://user-images.githubusercontent.com/56189/59665695-fbd3a280-91e5-11e9-9007-0f4b01102529.png" width=200>

After PR (ignore the lack of the nav bar. It's a different screen):


iPhone X | non-iPhone X
-|-
<img src="https://user-images.githubusercontent.com/56189/59665693-fb3b0c00-91e5-11e9-9ad4-ad84f44152b7.png" width=200> | <img src="https://user-images.githubusercontent.com/56189/59665692-fb3b0c00-91e5-11e9-816c-5d92eb7ec924.png" width=200>
