### PR TITLE
Fix: while running in the simulator. Dapp browser's URL bar can only become first responder once

### DIFF
--- a/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
+++ b/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
@@ -24,6 +24,7 @@ private struct Layout {
 }
 
 final class DappBrowserNavigationBar: UINavigationBar {
+    private let stackView = UIStackView()
     private let moreButton = UIButton()
     private let changeServerButton = UIButton()
     private let cancelEditingButton = UIButton()
@@ -53,6 +54,9 @@ final class DappBrowserNavigationBar: UINavigationBar {
             }
             hide.hideAll()
             show.showAll()
+            UIView.animate(withDuration: 0.3) {
+                self.stackView.layoutIfNeeded()
+            }
         }
     }
     var isBrowserOnly: Bool {
@@ -119,7 +123,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
 
         changeServerButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         changeServerButton.setContentHuggingPriority(.required, for: .horizontal)
-        let stackView = UIStackView(arrangedSubviews: [
+        stackView.addArrangedSubviews([
             spacer0,
             backButton,
             forwardButton,
@@ -136,7 +140,6 @@ final class DappBrowserNavigationBar: UINavigationBar {
         stackView.axis = .horizontal
         stackView.distribution = .fill
         stackView.spacing = 4
-
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
@@ -200,9 +203,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
         dismissKeyboard()
         switch state {
         case .editingURLTextField:
-            UIView.animate(withDuration: 0.3) {
-                self.state = .notEditingURLTextField
-            }
+            self.state = .notEditingURLTextField
         case .notEditingURLTextField, .browserOnly:
             //We especially don't want to switch (and animate) to .notEditingURLTextField when we are closing .browserOnly mode
             break
@@ -280,9 +281,7 @@ extension DappBrowserNavigationBar: UITextFieldDelegate {
     }
 
     public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-        UIView.animate(withDuration: 0.3) {
-            self.state = .editingURLTextField
-        }
+        self.state = .editingURLTextField
         return true
     }
 }

--- a/AlphaWallet/Core/Collection+UIView.swift
+++ b/AlphaWallet/Core/Collection+UIView.swift
@@ -3,6 +3,17 @@
 import UIKit
 
 extension Collection where Element == UIView {
+    var alpha: CGFloat {
+        set {
+            for each in self {
+                each.alpha = alpha
+            }
+        }
+        get {
+            return 1
+        }
+    }
+
     func hideAll() {
         for each in self {
             each.isHidden = true


### PR DESCRIPTION
Fix #1228 

It's actually strange. I'm not sure if this PR is relying on an undocumented behaviour, but it should be safe even if that changes. Here's what's happening.

iOS should fire `UIResponder.keyboardWillShowNotification` when the keyboard is going to be displayed, and `UIResponder.keyboardWillHideNotification` when the keyboard is going to be hidden. For both notifications, this code retrieves the frame of the keyboard:

```
let beginRect = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue
let endRect = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
```

What's strange is that in the iOS simulator, if the software keyboard is toggled off (so simulating an external keyboard), `UIResponder.keyboardWillShowNotification` is never fired (which is understandable) and `UIResponder.keyboardWillHideNotification` is fired both when a text box becomes first responder (i.e. gains focus) and when the textbox resigns first responder (i.e. loses focus). I guess the rationale is that these notifications are fired for the software keyboard and in both cases the keyboard is hidden. Empirically, in iOS 12 (and iPhone X):

A. When a text box becomes first responder, beginRect.size.height=0 and endRect.size.height ~54. Both origin.y remains at ~812 (out of the screen).
B. When a text box resigns first responder, beginRect.size.height ~54 and endRect.size.height=0. Both origin.y remains at ~812 (out of the screen).

The fix is to test for A and ignore it when handling `UIResponder.keyboardWillHideNotification`