### PR TITLE
Replace blockscout.com webpage URLs so that they load more reliably

### DIFF
--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -77,8 +77,9 @@ public struct Constants {
     public static let kovanEtherscanContractDetailsWebPageURL = "https://kovan.etherscan.io/address/"
     public static let rinkebyEtherscanContractDetailsWebPageURL = "https://rinkeby.etherscan.io/address/"
     public static let ropstenEtherscanContractDetailsWebPageURL = "https://ropsten.etherscan.io/address/"
-    public static let xDaiContractPage = "https://blockscout.com/poa/dai/address/"
-    public static let poaContractPage = "https://blockscout.com/poa/core/address/"
+    //Can't use https://blockscout.com/poa/dai/address/ even though it ultimately redirects there because blockscout (tested on 20190620), blockscout.com is only able to show that URL after the address has been searched (with the ?q= URL)
+    public static let xDaiContractPage = "https://blockscout.com/poa/dai/search?q="
+    public static let poaContractPage = "https://blockscout.com/poa/core/search?q="
     public static let goerliContractPage = "https://goerli.etherscan.io/address/"
 
     //OpenSea links for erc721 assets


### PR DESCRIPTION
This PR addresses this: We can't use https://blockscout.com/poa/dai/address/ to display an address even though blockscout.com ultimately redirects there because blockscout.com is only able to show that URL after the address has been searched (with the ?q= URL). So we use the search URL instead.

To observe this in the browser, visit a URL like:

1. https://blockscout.com/poa/dai/address/0xf64bd90bb0bfc05d667ba224be6f1cce817e7be0/transactions
2. If it displays a list of (maybe empty) transactions repeat (1) with a different address until it shows "Page not found".
3. Visit https://blockscout.com/poa/dai/search?q=0xf64bd90bb0bfc05d667ba224be6f1cce817e7be0 (replacing the address with the one in step 1)
4. Repeat (1) again and it should work now
