### PR TITLE
Fix: empty blue bar appears below Wallet tab filters after the first launch for a new app installation

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -59,7 +59,6 @@ class AppCoordinator: NSObject, Coordinator {
         }
 
         assetDefinitionStore.delegate = self
-        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles + assetDefinitionStore.listOfConflictingTokenScriptFiles)
     }
 
     /// Return true if handled
@@ -95,6 +94,7 @@ class AppCoordinator: NSObject, Coordinator {
         coordinator.delegate = self
         coordinator.start()
         addCoordinator(coordinator)
+        inCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles + assetDefinitionStore.listOfConflictingTokenScriptFiles)
     }
 
     private func closeWelcomeWindow() {


### PR DESCRIPTION
Blue bar between filters and the Ethereum token card:

<img src="https://user-images.githubusercontent.com/56189/59825039-770f9280-9365-11e9-8d5c-d5b1a2e20deb.png" width=200>