### PR TITLE
Show more specific error messages when importing MagicLink(s)

### DIFF
--- a/AlphaWallet/Extensions/Date.swift
+++ b/AlphaWallet/Extensions/Date.swift
@@ -60,4 +60,8 @@ public extension Date {
     func formatAsShortDateString(withTimezone timezone: TimeZone? = nil) -> String {
         return format("dd MMM yyyy", withTimeZone: timezone)
     }
+
+    func isEarlierThan(date: Date) -> Bool {
+        return date.timeIntervalSince(self) > 0
+    }
 }

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -272,6 +272,8 @@
 "a.claim.token.failed.serverDown" = "Paymaster server down, please try again later";
 "a.claim.token.invalidLink.tryAgain" = "Invalid Link, please try again";
 "a.claim.token.noConnectivity.tryAgain" = "Not connected to the internet, please try again";
+"a.claim.token.linkExpired" = "Link has expired";
+"a.claim.token.linkAlreadyRedeemed" = "Link has already been redeemed";
 "a.claim.token.failed.notEnoughEth.title" = "You do not have enough ETH to import this ticket";
 "a.claim.token.failed.notEnoughXDAI.title" = "You do not have enough xDAI to import this ticket";
 "a.claim.token.validating.title" = "Processing...";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -271,6 +271,8 @@
 "a.claim.token.failed.title" = "Enlace de ticket no válido";
 "a.claim.token.invalidLink.tryAgain" = "Enlace no válido, inténtalo de nuevo";
 "a.claim.token.noConnectivity.tryAgain" = "No estás conectado a internet, inténtalo de nuevo";
+"a.claim.token.linkExpired" = "Link has expired";
+"a.claim.token.linkAlreadyRedeemed" = "Link has already been redeemed";
 "a.claim.token.failed.notEnoughEth.title" = "No tienes suficiente ETH para importar este ticket";
 "a.claim.token.validating.title" = "Procesando...";
 "a.claim.token.promptImport.title" = "¿Importar?";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -271,6 +271,8 @@
 "a.claim.token.failed.title" = "無効なチケットのリンク";
 "a.claim.token.invalidLink.tryAgain" = "無効なリンクです。もう一度試してください";
 "a.claim.token.noConnectivity.tryAgain" = "インターネットに接続していません。もう一度試してください";
+"a.claim.token.linkExpired" = "Link has expired";
+"a.claim.token.linkAlreadyRedeemed" = "Link has already been redeemed";
 "a.claim.token.failed.notEnoughEth.title" = "このチケットをインポートするのに十分な ETH がありません";
 "a.claim.token.validating.title" = "処理しています...";
 "a.claim.token.promptImport.title" = "インポート?";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -271,6 +271,8 @@
 "a.claim.token.failed.title" = "잘못된 티켓 링크";
 "a.claim.token.invalidLink.tryAgain" = "링크가 잘못되었습니다. 다시 시도하십시오";
 "a.claim.token.noConnectivity.tryAgain" = "인터넷에 연결되지 않았습니다. 다시 시도하십시오";
+"a.claim.token.linkExpired" = "Link has expired";
+"a.claim.token.linkAlreadyRedeemed" = "Link has already been redeemed";
 "a.claim.token.failed.notEnoughEth.title" = "이 티켓을 가져오는 데 필요한 ETH가 충분하지 않습니다";
 "a.claim.token.validating.title" = "처리 중...";
 "a.claim.token.promptImport.title" = "가져옵니까?";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -271,6 +271,8 @@
 "a.claim.token.failed.title" = "无效的MagicLink链接";
 "a.claim.token.invalidLink.tryAgain" = "链接无效，请重试";
 "a.claim.token.noConnectivity.tryAgain" = "Not connected to the internet, please try again";
+"a.claim.token.linkExpired" = "Link has expired";
+"a.claim.token.linkAlreadyRedeemed" = "Link has already been redeemed";
 "a.claim.token.failed.notEnoughEth.title" = "你没有足够的以太币来购买 MagicLink 内的门票";
 "a.claim.token.validating.title" = "处理中...";
 "a.claim.token.promptImport.title" = "导入?";


### PR DESCRIPTION
Instead of the general message "Invalid Link, please try again", we also show more specific error messages when we can:

* "Link has expired"
* "Link has already been redeemed"