### PR TITLE
Accept user input addresses that has leading or trailing whitespaces as valid addresses

### DIFF
--- a/AlphaWallet/Foundation/QRURLParser.swift
+++ b/AlphaWallet/Foundation/QRURLParser.swift
@@ -10,6 +10,8 @@ struct ParserResult: Equatable {
 
 struct QRURLParser {
     static func from(string: String) -> ParserResult? {
+        let string = string.trimmed
+        //TODO improve parsing. At least only replace the prefix pay- instead of the whole string
         let result = string.replacingOccurrences(of: "pay-", with: "")
         let parts = result.components(separatedBy: ":")
         if parts.count == 1, let address = parts.first.flatMap({ AlphaWallet.Address(string: $0) }) {

--- a/AlphaWallet/Market/UniversalLinkHandler.swift
+++ b/AlphaWallet/Market/UniversalLinkHandler.swift
@@ -101,7 +101,7 @@ public class UniversalLinkHandler {
     private func handleNormalLink(linkBytes: [UInt8]) -> SignedOrder? {
         let price = getPriceFromLinkBytes(linkBytes: linkBytes)
         let expiry = getExpiryFromLinkBytes(linkBytes: linkBytes)
-        guard let contractAddress = AlphaWallet.Address(string: getContractAddressFromLinkBytes(linkBytes: linkBytes)) else { return nil }
+        guard let contractAddress = getNonNullContractAddressFromLinkBytes(linkBytes: linkBytes) else { return nil }
         let tokenIndices = getTokenIndicesFromLinkBytes(linkBytes: linkBytes)
         let (v, r, s) = getVRSFromLinkBytes(linkBytes: linkBytes)
         let order = Order(
@@ -159,7 +159,7 @@ public class UniversalLinkHandler {
         bytes.remove(at: 0) //remove encoding byte
         let price = getPriceFromLinkBytes(linkBytes: bytes)
         let expiry = getExpiryFromLinkBytes(linkBytes: bytes)
-        guard let contractAddress = AlphaWallet.Address(uncheckedAgainstNullAddress: getContractAddressFromLinkBytes(linkBytes: bytes)) else { return nil }
+        guard let contractAddress = getNonNullContractAddressFromLinkBytes(linkBytes: bytes) else { return nil }
         let tokenIds = getTokenIdsFromSpawnableLink(linkBytes: bytes)
         let (v, r, s) = getVRSFromLinkBytes(linkBytes: bytes)
         let order = Order(
@@ -265,12 +265,13 @@ public class UniversalLinkHandler {
         return BigUInt(expiry, radix: 16)!
     }
 
-    private func getContractAddressFromLinkBytes(linkBytes: [UInt8]) -> String {
+    //Specifically not for null (0x0...0) address
+    private func getNonNullContractAddressFromLinkBytes(linkBytes: [UInt8]) -> AlphaWallet.Address? {
         var contractAddrBytes = [UInt8]()
         for i in 8...27 {
             contractAddrBytes.append(linkBytes[i])
         }
-        return Data(bytes: contractAddrBytes).hex()
+        return AlphaWallet.Address(string: Data(bytes: contractAddrBytes).hex())
     }
 
     private func getTokenIndicesFromLinkBytes(linkBytes: [UInt8]) -> [UInt16] {

--- a/AlphaWallet/TokenScriptClient/Models/UserEntryOrigin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/UserEntryOrigin.swift
@@ -21,7 +21,7 @@ struct UserEntryOrigin {
     func extractValue(fromUserEntry userEntry: String) -> AssetInternalValue? {
         switch asType {
         case .address:
-            return AlphaWallet.Address(string: userEntry).flatMap { .address($0) }
+            return AlphaWallet.Address(string: userEntry.trimmed).flatMap { .address($0) }
         case .uint:
             return BigUInt(userEntry).flatMap { .uint($0) }
         case .utf8:

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -436,7 +436,7 @@ private class PrivateXMLHandler {
             guard let name = eachContractElement["name"] else { continue }
             let addressElements = XMLHandler.getAddressElements(fromContractElement: eachContractElement, xmlContext: xmlContext)
             result[name] = addressElements.compactMap {
-                guard let address = $0.text.flatMap({ AlphaWallet.Address(string: $0) }), let chainId = $0["network"].flatMap({ Int($0) }) else { return nil }
+                guard let address = $0.text.flatMap({ AlphaWallet.Address(string: $0.trimmed) }), let chainId = $0["network"].flatMap({ Int($0) }) else { return nil }
                 return (address: address, server: RPCServer(chainID: chainId))
             }
         }
@@ -811,7 +811,7 @@ extension XMLHandler {
     }
 
     fileprivate static func getRecipientAddress(fromEthereumFunctionElement ethereumFunctionElement: XMLElement, xmlContext: XmlContext) -> AlphaWallet.Address? {
-        return ethereumFunctionElement.at_xpath("to".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)?.text.flatMap { AlphaWallet.Address(string: $0) }
+        return ethereumFunctionElement.at_xpath("to".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)?.text.flatMap { AlphaWallet.Address(string: $0.trimmed) }
     }
 
     static func getTokenScriptTokenViewIconifiedHtmlElement(fromRoot root: XMLDocument, xmlContext: XmlContext) -> XMLElement? {

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -369,8 +369,8 @@ class NewTokenViewController: UIViewController, CanScanQRCode {
     }
 
     func redetectToken() {
-        let contract = addressTextField.value
-        if let contract = AlphaWallet.Address(string: addressTextField.value) {
+        let contract = addressTextField.value.trimmed
+        if let contract = AlphaWallet.Address(string: contract) {
             updateContractValue(value: contract.eip55String)
         }
     }
@@ -413,7 +413,7 @@ extension NewTokenViewController: AddressTextFieldDelegate {
     }
 
     func didPaste(in textField: AddressTextField) {
-        updateContractValue(value: textField.value)
+        updateContractValue(value: textField.value.trimmed)
         view.endEditing(true)
     }
 

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -192,7 +192,7 @@ class SendViewController: UIViewController, CanScanQRCode {
     }
 
     @objc func send() {
-        let input = targetAddressTextField.value
+        let input = targetAddressTextField.value.trimmed
         guard let address = AlphaWallet.Address(string: input) else { return displayError(error: Errors.invalidAddress) }
         let amountString = amountTextField.ethCost
         let parsedValue: BigInt? = {


### PR DESCRIPTION
Examples include:

A) QR code for address which has a trailing newline character
B) User enters an address with a trailing space into a TokenScript rendered view which is captured by a user-entry-origin based attribute with the origin having `as="address"`.

You can generate A) with this:

```
$ echo "0x007bEe82BDd9e866b2bd114780a47f2261C684E3" | qrencode -o ~/Desktop/token-qr.png
```

The correct command to generate without a trailing newline character is:

```
$ echo -n "0x007bEe82BDd9e866b2bd114780a47f2261C684E3" | qrencode -o ~/Desktop/token-qr.png
```