### PR TITLE
Add check against XML entity injection in TokenScript client

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -129,6 +129,8 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
             guard let fileName = tokenScriptFileIndices.nonConflictingFileName(forContract: contract) else { return xmlContents }
             guard let entities = tokenScriptFileIndices.contractsToEntities[fileName] else { return xmlContents }
             for each in entities {
+                //Guard against XML entity injection
+                guard !each.fileName.contains("/") else { continue }
                 let url = directory.appendingPathComponent(each.fileName)
                 guard let contents = try? String(contentsOf: url) else { continue }
                 xmlContents = (xmlContents as NSString).replacingOccurrences(of: "&\(each.name);", with: contents)


### PR DESCRIPTION
iOS apps is sandboxed. But we still want to prevent TokenScript from accessing files it has permission to read but shouldn't read (It has permission because the client runs as part of the app).

eg.
 
```
<!ENTITY test SYSTEM "..\\assetDefinitions/indices">
```