### PR TITLE
Only show the Redeem action button for FIFA ticket tokens and not for other ERC875 tokens

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -415,7 +415,11 @@ private class PrivateXMLHandler {
         case .erc721:
             actions = [.nonFungibleTransfer]
         case .erc875:
-            actions = [.erc875Redeem, .erc875Sell, .nonFungibleTransfer]
+            if contractAddress.isFifaTicketcontract {
+                actions = [.erc875Redeem, .erc875Sell, .nonFungibleTransfer]
+            } else {
+                actions = [.erc875Sell, .nonFungibleTransfer]
+            }
         }
         return actions.map { .init(type: $0) }
     }

--- a/AlphaWallet/Tokens/ViewModels/TokenInstanceViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenInstanceViewModel.swift
@@ -17,7 +17,6 @@ struct TokenInstanceViewModel {
             switch token.type {
             case .erc875:
                 return [
-                    .init(type: .erc875Redeem),
                     .init(type: .erc875Sell),
                     .init(type: .nonFungibleTransfer)
                 ]

--- a/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
@@ -23,7 +23,6 @@ struct TokensCardViewModel {
             switch token.type {
             case .erc875:
                 return [
-                    .init(type: .erc875Redeem),
                     .init(type: .erc875Sell),
                     .init(type: .nonFungibleTransfer)
                 ]


### PR DESCRIPTION
Before this PR, all ERC875 tokens including those with TokenScript files marketing `interface="erc875"` includes a redeem action.

After applying this PR, only FIFA tokens (with the 2 hardcoded contract addresses) will have the redeem action.