### PR TITLE
Fix: remove Auto Layout warnings upon startup

### DIFF
--- a/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
+++ b/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
@@ -142,10 +142,16 @@ final class DappBrowserNavigationBar: UINavigationBar {
         stackView.spacing = 4
         addSubview(stackView)
 
+        let leadingAnchorConstraint = stackView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 10)
+        let trailingAnchorConstraint = stackView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -10)
+        //We really want these constraints to be `.required`, but can't because it AutoLayout complains the instance `this` is created, as it probably starts with a frame of zero and can't fulfill the constants
+        leadingAnchorConstraint.priority = .required - 1
+        trailingAnchorConstraint.priority = .required - 1
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 4),
-            stackView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 10),
-            stackView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -10),
+            leadingAnchorConstraint,
+            trailingAnchorConstraint,
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
 
             backButton.widthAnchor.constraint(equalToConstant: Layout.width),


### PR DESCRIPTION
Before this PR, each run of the app prints Auto Layout warnings to the console (at the bottom of this issue).

Reason being when the dapp navigation bar is created by the system, it has a frame of size zero (or at least the width is zero, maybe the height isn't), so Auto Layout can't fulfill both of these constraints:

```
stackView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 10),
stackView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -10),
```

The Auto Layout warnings:

```
2019-07-01 11:07:52.787892+0800 AlphaWallet[32452:3280887] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600000ccab20 UIButton:0x7fa786f44310.width == 34   (active)>",
    "<NSLayoutConstraint:0x600000cca710 UIView:0x7fa786f48640.width == 1   (active)>",
    "<NSLayoutConstraint:0x600000cca760 UIView:0x7fa786f48820.width == 1   (active)>",
    "<NSLayoutConstraint:0x600000ccab70 UIButton:0x7fa786f44630.width == 34   (active)>",
    "<NSLayoutConstraint:0x600000ccaa30 UIStackView:0x7fa786f42720.leading == UILayoutGuide:0x600001607720'UIViewSafeAreaLayoutGuide'.leading + 10   (active)>",
    "<NSLayoutConstraint:0x600000cca7b0 UIView:0x7fa786f48a00.width == 1   (active)>",
    "<NSLayoutConstraint:0x600000ccabc0 UIButton:0x7fa786f42920.width == 24   (active)>",
    "<NSLayoutConstraint:0x600000ccaa80 UIStackView:0x7fa786f42720.trailing == UILayoutGuide:0x600001607720'UIViewSafeAreaLayoutGuide'.trailing - 10   (active)>",
    "<NSLayoutConstraint:0x600000ccaf80 'UISV-canvas-connection' UIStackView:0x7fa786f42720.leading == UIView:0x7fa786f48640.leading   (active)>",
    "<NSLayoutConstraint:0x600000ccafd0 'UISV-canvas-connection' H:[UIButton:0x7fa786f42920]-(0)-|   (active, names: '|':UIStackView:0x7fa786f42720 )>",
    "<NSLayoutConstraint:0x600000ccb390 'UISV-spacing' H:[UIView:0x7fa786f48a00]-(4)-[UIButton:0x7fa786f42920]   (active)>",
    "<NSLayoutConstraint:0x600000ccb020 'UISV-spacing' H:[UIView:0x7fa786f48640]-(4)-[UIButton:0x7fa786f44310]   (active)>",
    "<NSLayoutConstraint:0x600000ccb070 'UISV-spacing' H:[UIButton:0x7fa786f44310]-(4)-[UIButton:0x7fa786f44630]   (active)>",
    "<NSLayoutConstraint:0x600000ccb0c0 'UISV-spacing' H:[UIButton:0x7fa786f44630]-(4)-[UITextField:0x7fa7888e6600]   (active)>",
    "<NSLayoutConstraint:0x600000ccb1b0 'UISV-spacing' H:[UITextField:0x7fa7888e6600]-(4)-[UIView:0x7fa786f48820]   (active)>",
    "<NSLayoutConstraint:0x600000ccb250 'UISV-spacing' H:[UIView:0x7fa786f48820]-(4)-[UIButton:0x7fa786f42c40]   (active)>",
    "<NSLayoutConstraint:0x600000ccb340 'UISV-spacing' H:[UIButton:0x7fa786f42c40]-(4)-[UIView:0x7fa786f48a00]   (active)>",
    "<NSLayoutConstraint:0x600000cc4a50 'UIView-Encapsulated-Layout-Width' AlphaWallet.DappBrowserNavigationBar:0x7fa786f423f0.width == 0   (active)>",
    "<NSLayoutConstraint:0x600000cca850 'UIViewSafeAreaLayoutGuide-left' H:|-(0)-[UILayoutGuide:0x600001607720'UIViewSafeAreaLayoutGuide'](LTR)   (active, names: '|':AlphaWallet.DappBrowserNavigationBar:0x7fa786f423f0 )>",
    "<NSLayoutConstraint:0x600000cca940 'UIViewSafeAreaLayoutGuide-right' H:[UILayoutGuide:0x600001607720'UIViewSafeAreaLayoutGuide']-(0)-|(LTR)   (active, names: '|':AlphaWallet.DappBrowserNavigationBar:0x7fa786f423f0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600000ccab70 UIButton:0x7fa786f44630.width == 34   (active)>
```