### PR TITLE
Fix: Tokens and transactions on Ethereum mainnet are (also) wrongly appearing on Ethereum Classic and a few other networks

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -60,36 +60,36 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
-    var getEtherscanURL: String {
+    var getEtherscanURL: String? {
         switch self {
         case .main: return Constants.mainnetEtherscanAPI
         case .ropsten: return Constants.ropstenEtherscanAPI
         case .rinkeby: return Constants.rinkebyEtherscanAPI
         case .kovan: return Constants.kovanEtherscanAPI
         case .poa: return Constants.poaNetworkCoreAPI
-        case .sokol: return Constants.mainnetEtherscanAPI
-        case .classic: return Constants.mainnetEtherscanAPI
-        case .callisto: return Constants.mainnetEtherscanAPI
+        case .sokol: return nil
+        case .classic: return nil
+        case .callisto: return nil
         case .goerli: return Constants.goerliEtherscanAPI
         case .xDai: return Constants.xDaiAPI
-        case .custom: return Constants.mainnetEtherscanAPI
+        case .custom: return nil
         }
     }
 
     //TODO fix up all the networks
-    var getEtherscanURLERC20Events: String {
+    var getEtherscanURLERC20Events: String? {
         switch self {
         case .main: return Constants.mainnetEtherscanAPIErc20Events
         case .ropsten: return Constants.ropstenEtherscanAPIErc20Events
         case .rinkeby: return Constants.rinkebyEtherscanAPIErc20Events
         case .kovan: return Constants.kovanEtherscanAPIErc20Events
         case .poa: return Constants.poaNetworkCoreAPIErc20Events
-        case .sokol: return Constants.mainnetEtherscanAPIErc20Events
-        case .classic: return Constants.mainnetEtherscanAPIErc20Events
-        case .callisto: return Constants.mainnetEtherscanAPIErc20Events
+        case .sokol: return nil
+        case .classic: return nil
+        case .callisto: return nil
         case .goerli: return Constants.goerliEtherscanAPIErc20Events
         case .xDai: return Constants.xDaiAPIErc20Events
-        case .custom: return Constants.mainnetEtherscanAPIErc20Events
+        case .custom: return nil
         }
     }
 
@@ -106,12 +106,12 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
-    func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address) -> URL {
-        return URL(string: getEtherscanURL + address.eip55String)!
+    func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address) -> URL? {
+        return getEtherscanURL.flatMap { URL(string: $0 + address.eip55String) }
     }
 
-    func etherscanAPIURLForERC20TxList(for address: AlphaWallet.Address) -> URL {
-        return URL(string: getEtherscanURLERC20Events + address.eip55String)!
+    func etherscanAPIURLForERC20TxList(for address: AlphaWallet.Address) -> URL? {
+        return getEtherscanURLERC20Events.flatMap { URL(string: $0 + address.eip55String) }
     }
 
     func etherscanContractDetailsWebPageURL(for address: AlphaWallet.Address) -> URL {

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -10,7 +10,7 @@ import SwiftyJSON
 class GetContractInteractions {
 
     func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, completion: @escaping ([Transaction]) -> Void) {
-        let etherscanURL = server.etherscanAPIURLForERC20TxList(for: address)
+        guard let etherscanURL = server.etherscanAPIURLForERC20TxList(for: address) else { return }
         Alamofire.request(etherscanURL).validate().responseJSON { response in
             switch response.result {
             case .success(let value):
@@ -62,9 +62,17 @@ class GetContractInteractions {
     func getContractList(address: AlphaWallet.Address, server: RPCServer, erc20: Bool, completion: @escaping ([AlphaWallet.Address]) -> Void) {
         let etherscanURL: URL
         if erc20 {
-            etherscanURL = server.etherscanAPIURLForERC20TxList(for: address)
+            if let url = server.etherscanAPIURLForERC20TxList(for: address) {
+                etherscanURL = url
+            } else {
+                return
+            }
         } else {
-            etherscanURL = server.etherscanAPIURLForTransactionList(for: address)
+            if let url = server.etherscanAPIURLForTransactionList(for: address) {
+                etherscanURL = url
+            } else {
+                return
+            }
         }
         Alamofire.request(etherscanURL).validate().responseJSON { response in
             switch response.result {


### PR DESCRIPTION
For #1282 
fixes #1220 

Before this PR, when we are fetching transactions via ERC20 interactions and when we auto-detect contracts for Ethereum Classic (and a few other networks), we are (wrongly) fetching them using endpoints for Ethereum mainnet, hence getting those from mainnet instead.