### PR TITLE
Fix etherscan-like webpage used to display contract/wallet details for numerous networks including Ethereum Classic

### DIFF
--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -81,6 +81,9 @@ public struct Constants {
     public static let xDaiContractPage = "https://blockscout.com/poa/dai/search?q="
     public static let poaContractPage = "https://blockscout.com/poa/core/search?q="
     public static let goerliContractPage = "https://goerli.etherscan.io/address/"
+    public static let sokolContractPage = "https://blockscout.com/poa/sokol/search?q="
+    public static let etcContractPage = "https://blockscout.com/etc/mainnet/search?q="
+    public static let callistoContractPage = "https://blockscout.com/callisto/mainnet/search?q="
 
     //OpenSea links for erc721 assets
     public static let openseaAPI = "https://api.opensea.io/"

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -102,7 +102,10 @@ enum RPCServer: Hashable, CaseIterable {
         case .xDai: return Constants.xDaiContractPage
         case .goerli: return Constants.goerliContractPage
         case .poa: return Constants.poaContractPage
-        case .sokol, .classic, .callisto, .custom: return Constants.mainnetEtherscanContractDetailsWebPageURL
+        case .sokol: return Constants.sokolContractPage
+        case .classic: return Constants.etcContractPage
+        case .callisto: return Constants.callistoContractPage
+        case .custom: return Constants.mainnetEtherscanContractDetailsWebPageURL
         }
     }
 


### PR DESCRIPTION
After applying this PR, every network we support, other than ETC, the app will load the correct page when we tap to display the Etherscan (like) page.

This PR includes the URL for ETC but I couldn't get the one for ETC to work though: <https://blockscout.com/etc/mainnet/search?q=>. Feel free to fix it if you know why :)