### PR TITLE
only adds transaction contract addresses on overloaded function

### DIFF
--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -64,7 +64,6 @@ class TransactionsStorage {
         realm.beginWrite()
         realm.add(items, update: true)
         try! realm.commitWrite()
-        addTransactionContractAddresses(items)
         return items
     }
 


### PR DESCRIPTION
This is causing deleted tokens to return. 