### PR TITLE
Fix: TokenScript files with invalid signatures are wrongly matched, always to mainnet

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -55,18 +55,10 @@ private class PrivateXMLHandler {
     private var xml: XMLDocument
     private let signatureNamespacePrefix = "ds:"
     private let xhtmlNamespacePrefix = "xhtml:"
-    lazy private var xmlContext = PrivateXMLHandler.createXmlContext(withLang: lang)
+    private let xmlContext = PrivateXMLHandler.createXmlContext(withLang: PrivateXMLHandler.lang)
     private let contractAddress: AlphaWallet.Address
     private weak var assetDefinitionStore: AssetDefinitionStore?
-    lazy var server: RPCServer = { () -> RPCServer in
-        for (contract, chainId) in PrivateXMLHandler.getHoldingContracts(xml: xml, xmlContext: xmlContext) {
-            if contract == contractAddress {
-                return .init(chainID: chainId)
-            }
-        }
-        //TODO Shouldn't reach here!
-        return .main
-    }()
+    let server: RPCServer?
     //Explicit type so that the variable autocompletes with AppCode
     private lazy var fields: [AttributeId: AssetAttribute] = extractFieldsForToken()
     private let isOfficial: Bool
@@ -232,7 +224,7 @@ private class PrivateXMLHandler {
         }
     }
 
-    private var lang: String {
+    static private var lang: String {
         let lang = Locale.preferredLanguages[0]
         if lang.hasPrefix("en") {
             return "en"
@@ -281,10 +273,12 @@ private class PrivateXMLHandler {
                 xml = PrivateXMLHandler.emptyXML
                 hasValidTokenScriptFile = false
             }
+            server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: xmlContext, matchingContract: contract)
         } else {
             xml = (try? Kanna.XML(xml: xmlString, encoding: .utf8)) ?? PrivateXMLHandler.emptyXML
             //TODO check this again when we implement signature verification using the web API. We can't just set this to false first because we don't notify client code when it changes to false either. So when a TokenScript file changes, live-reloading thinks there's no TokenScript file
             hasValidTokenScriptFile = true
+            server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: xmlContext, matchingContract: contract)
             tokenScriptStatusPromise.done { tokenScriptStatus in
                 switch tokenScriptStatus {
                 case .type1GoodTokenScriptSignatureGoodOrOptional:
@@ -402,6 +396,16 @@ private class PrivateXMLHandler {
         cache.cache(attributes: fields, values: valuesAsDictionary, forContract: contractAddress, tokenId: tokenId)
     }
 
+    private static func extractServer(fromXML xml: XMLDocument, xmlContext: XmlContext, matchingContract contractAddress: AlphaWallet.Address) -> RPCServer? {
+        for (contract, chainId) in getHoldingContracts(xml: xml, xmlContext: xmlContext) {
+            if contract == contractAddress {
+                return .init(chainID: chainId)
+            }
+        }
+        //Might be possible?
+        return nil
+    }
+
     private static func verificationType(forXml xmlString: String, isCanonicalized: Bool, contractAddress: AlphaWallet.Address) -> Promise<TokenScriptSignatureVerificationType> {
         let verifier = TokenScriptSignatureVerifier()
         return verifier.verify(xml: xmlString)
@@ -426,6 +430,7 @@ private class PrivateXMLHandler {
 
     private func createFunctionOriginFrom(ethereumFunctionElement: XMLElement) -> FunctionOrigin? {
         if let contract = ethereumFunctionElement["contract"].nilIfEmpty {
+            guard let server = server else { return nil }
             return XMLHandler.getNonTokenHoldingContract(byName: contract, server: server, fromContractNamesAndAddresses: self.contractNamesAndAddresses)
                     .flatMap { FunctionOrigin(forEthereumFunctionTransactionElement: ethereumFunctionElement, attributeId: "", originContract: $0, xmlContext: xmlContext) }
         } else {
@@ -464,7 +469,7 @@ private class PrivateXMLHandler {
         for each in XMLHandler.getAttributeTypeElements(fromElement: element, xmlContext: xmlContext) {
             guard let id = each["id"] else { continue }
             //TODO we pass in server because we are assuming the server used for non-token-holding contracts are the same as the token-holding contract for now. Not always true. We'll have to fix it in the future when TokenScript supports it
-            guard let attribute = AssetAttribute(attribute: each, xmlContext: xmlContext, server: server, contractNamesAndAddresses: contractNamesAndAddresses) else { continue }
+            guard let attribute = server.flatMap({ AssetAttribute(attribute: each, xmlContext: xmlContext, server: $0, contractNamesAndAddresses: contractNamesAndAddresses) }) else { continue }
             fields[id] = attribute
         }
         return fields
@@ -553,7 +558,7 @@ public class XMLHandler {
         return privateXMLHandler.actions
     }
 
-    var server: RPCServer {
+    var server: RPCServer? {
         return privateXMLHandler.server
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -77,7 +77,7 @@ class TokenViewController: UIViewController {
         headerViewModel.showAlternativeAmount = viewModel.showAlternativeAmount
 
         let xmlHandler = XMLHandler(contract: transferType.contract, assetDefinitionStore: assetDefinitionStore)
-        if xmlHandler.server == session.server {
+        if let server = xmlHandler.server, server == session.server {
             let tokenScriptStatusPromise = xmlHandler.tokenScriptStatus
             if tokenScriptStatusPromise.isPending {
                 tokenScriptStatusPromise.done { _ in

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -52,7 +52,7 @@ struct TokenViewControllerViewModel {
                 return actionsFromTokenScript
             case .nativeCryptocurrency:
                 //TODO we should support retrieval of XML (and XMLHandler) based on address + server. For now, this is only important for native cryptocurrency. So might be ok to check like this for now
-                if xmlHandler.server == token.server {
+                if let server = xmlHandler.server, server == token.server {
                     return actionsFromTokenScript
                 } else {
                     //TODO .erc20Send and .erc20Receive names aren't appropriate

--- a/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
+++ b/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
@@ -47,19 +47,25 @@ class XMLHandlerTest: XCTestCase {
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://tokenscript.org/2019/05/tokenscript ../../tsml.xsd"
                     xmlns:xml="http://www.w3.org/XML/1998/namespace">
-          <ts:contract id="holding_contract" type="holding">
+          <ts:name>
+            <ts:string xml:lang="en">Tickets</ts:string>
+            <ts:string xml:lang="zh">门票</ts:string>
+            <ts:string xml:lang="es">Entradas</ts:string>
+          </ts:name>
+          <ts:contract name="Token">
             <ts:address network="1">0x830E1650a87a754e37ca7ED76b700395A7C61614</ts:address>
-            <ts:name xml:lang="en">Tickets</ts:name>
-            <ts:name xml:lang="zh">门票</ts:name>
-            <ts:name xml:lang="es">Entradas</ts:name>
-            <ts:interface>erc875</ts:interface>
           </ts:contract>
+          <ts:origins>
+              <ts:ethereum contract="Token"/>
+          </ts:origins>
           <ts:attribute-types>
             <ts:attribute-type id="locality" syntax="1.3.6.1.4.1.1466.115.121.1.15">
-              <ts:name xml:lang="en">City</ts:name>
-              <ts:name xml:lang="zh">城市</ts:name>
-              <ts:name xml:lang="es">Ciudad</ts:name>
-              <ts:name xml:lang="ru">город</ts:name>
+              <ts:name>
+                <ts:string xml:lang="en">City</ts:string>
+                <ts:string xml:lang="zh">城市</ts:string>
+                <ts:string xml:lang="es">Ciudad</ts:string>
+                <ts:string xml:lang="ru">город</ts:string>
+              </ts:nam>
               <ts:origins>
                 <ts:token-id bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="uint">
                   <ts:mapping>
@@ -79,7 +85,7 @@ class XMLHandlerTest: XCTestCase {
           </ts:attribute-types>
         </ts:token>
         """
-        let contractAddress = AlphaWallet.Address.make()
+        let contractAddress = AlphaWallet.Address(string: "0x830E1650a87a754e37ca7ED76b700395A7C61614")!
         let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
         store[contractAddress] = xml
         let xmlHandler = XMLHandler(contract: contractAddress, assetDefinitionStore: store)


### PR DESCRIPTION
For #1314