### PR TITLE
Don't open the domain name for the cert used to sign the current TokenScript file if it's a wildcard

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
@@ -84,7 +84,11 @@ func createTokenScriptFileStatusButton(withStatus status: TokenLevelTokenScriptD
     case .type1GoodTokenScriptSignatureGoodOrOptional(let isDebugMode, let isSigned, let domain, let rawMessage):
         let message: String
         if let domain = domain {
-            button.handler = { urlOpener in URL(string: "https://\(domain)").flatMap { urlOpener.open(url: $0) } }
+            button.handler = { urlOpener in
+                if !domain.starts(with: "*.") {
+                    URL(string: "https://\(domain)").flatMap { urlOpener.open(url: $0) }
+                }
+            }
             message = "\(rawMessage) by \(domain)"
         } else {
             message = rawMessage


### PR DESCRIPTION
i.e. do nothing when user taps on "Verified by *.aw.app"