### PR TITLE
Use http instead of https for showing domain name in CN for TokenScript signing certs. Some sites don't serve https

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
@@ -86,7 +86,8 @@ func createTokenScriptFileStatusButton(withStatus status: TokenLevelTokenScriptD
         if let domain = domain {
             button.handler = { urlOpener in
                 if !domain.starts(with: "*.") {
-                    URL(string: "https://\(domain)").flatMap { urlOpener.open(url: $0) }
+                    //http. Some sites don't serve https despite using a TLS cert for signing TokenScript
+                    URL(string: "http://\(domain)").flatMap { urlOpener.open(url: $0) }
                 }
             }
             message = "\(rawMessage) by \(domain)"


### PR DESCRIPTION
Specifically https://skstravel.cn vs http://skstravel.cn