### PR TITLE
Fix crash if any other test (any test) waits too long to complete

### DIFF
--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -15,9 +15,11 @@ class ConfigTests: XCTestCase {
 
     func testSwitchLocale() {
         let assetDefinitionStore = AssetDefinitionStore()
+        var sessions = ServerDictionary<WalletSession>()
+        sessions[.main] = WalletSession.make()
         Config.setLocale(AppLocale.english)
         let vc1 = TokensViewController(
-                sessions: .init(),
+                sessions: sessions,
                 account: .make(),
                 tokenCollection: .init(tokenDataStores: [FakeTokensDataStore()]),
                 assetDefinitionStore: assetDefinitionStore
@@ -26,7 +28,7 @@ class ConfigTests: XCTestCase {
 
         Config.setLocale(AppLocale.simplifiedChinese)
         let vc2 = TokensViewController(
-                sessions: .init(),
+                sessions: sessions,
                 account: .make(),
                 tokenCollection: .init(tokenDataStores: [FakeTokensDataStore()]),
                 assetDefinitionStore: assetDefinitionStore


### PR DESCRIPTION
I can reproduce this locally on my laptop, but might not be noticeable on Travis.

Applying this PR will fix the crash when running `TokenScriptSignatureVerifierTest`, where it crashes at an unrelated line of code due to it waiting for the API to complete, exposing the bug fix in this particular test (`ConfigTests`).