### PR TITLE
Display supported TokenScript schema version in Settings screen and support email template

### DIFF
--- a/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
+++ b/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
@@ -22,7 +22,7 @@ class ContactUsBannerView: UIView {
                \(R.string.localizable.aHelpContactEmailHelpfulToDevelopers())
                \(R.string.localizable.aHelpContactEmailIosVersion(UIDevice.current.systemVersion))
                \(R.string.localizable.aHelpContactEmailDeviceModel(UIDevice.current.model))
-               \(R.string.localizable.aHelpContactEmailAppVersion(Bundle.main.fullVersion))
+               \(R.string.localizable.aHelpContactEmailAppVersion("\(Bundle.main.fullVersion). \(TokenScript.supportedTokenScriptNamespaceVersion)"))
                \(R.string.localizable.aHelpContactEmailLocale(Locale.preferredLanguages.first ?? ""))
                """
     }

--- a/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SettingsViewController.swift
@@ -165,7 +165,7 @@ class SettingsViewController: FormViewController {
             $0.disabled = true
         }.cellSetup { cell, _ in
             cell.mainLabel.text = R.string.localizable.settingsVersionLabelTitle()
-            cell.subLabel.text = Bundle.main.fullVersion
+            cell.subLabel.text = "\(Bundle.main.fullVersion). \(TokenScript.supportedTokenScriptNamespaceVersion)"
         }
     }
 


### PR DESCRIPTION
Inspired by https://github.com/AlphaWallet/TokenScript/issues/217