### PR TITLE
Disable swipe to delete tokens in Wallet tab to avoid crash (temporarily)

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -366,7 +366,8 @@ extension TokensViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return viewModel.canDelete(for: indexPath.row, section: indexPath.section)
+        //Disabled deleting until we figure why it crashes when deleting
+        return false
     }
 
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Just a stopgap measure in case we need to release based on master branch. Should be alright since it's a well-hidden feature.

I'll work on fixing it in the mean time.