### PR TITLE
Fix: deleted tokens are automatically added back when we detect ERC20 transactions involving them

### DIFF
--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -39,8 +39,7 @@ class TransactionsStorage {
         return objects.filter { $0.state == TransactionState.pending }
     }
 
-    private func addTransactionContractAddresses(_ transactions: [Transaction]) {
-        // store contract addresses associated with transactions
+    private func addTokensWithContractAddresses(fromTransactions transactions: [Transaction]) {
         let tokens = self.tokens(from: transactions)
         if !tokens.isEmpty {
             TokensDataStore.update(in: realm, tokens: tokens)
@@ -48,13 +47,13 @@ class TransactionsStorage {
     }
 
     @discardableResult
-    func add(_ items: [Transaction], _ filteredTransactions: [Transaction]) -> [Transaction] {
-        guard !items.isEmpty else { return [] }
+    func add(transactions: [Transaction], transactionsToPullContractsFrom: [Transaction]) -> [Transaction] {
+        guard !transactions.isEmpty else { return [] }
         realm.beginWrite()
-        realm.add(items, update: true)
+        realm.add(transactions, update: true)
         try! realm.commitWrite()
-        addTransactionContractAddresses(filteredTransactions)
-        return items
+        addTokensWithContractAddresses(fromTransactions: transactionsToPullContractsFrom)
+        return transactions
     }
 
     @discardableResult


### PR DESCRIPTION
This is because `TransactionsStorage.tokens(from:)` performs an update/addition to the tokens database with:

```
let operation = transaction.localizedOperations.first,
let contract = operation.contractAddress,
```

updating/adding a token with `contract` as the contract address.

@James-Sangalli  But maybe we need to check both `to` and `operation?.contractAddress` when filtering? Is the former still needed to handle when there's an Ether transfer to the contract?

ie. the PR changes:

```
guard let addressToCheck = AlphaWallet.Address(string: $0.to) else { return false }
return !contractsToAvoid.contains(addressToCheck)
```

to:

```
guard let addressToCheck = $0.operation?.contractAddress else { return false }
return !contractsToAvoid.contains(addressToCheck)
```

Maybe we need to check both `AlphaWallet.Address(string: $0.to)` and `$0.operation?.contractAddress` instead?