### PR TITLE
Upon detecting that a TokenScript file has an invalid signature, the currently render view should be re-rendered without the TokenScript file (unless debug mode)

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -189,6 +189,10 @@ class AssetDefinitionStore {
     func forEachContractWithXML(_ body: (AlphaWallet.Address) -> Void) {
         backingStore.forEachContractWithXML(body)
     }
+
+    func invalidateSignatureStatus(forContract contract: AlphaWallet.Address) {
+        subscribers.forEach { $0(contract) }
+    }
 }
 
 extension AssetDefinitionStore: AssetDefinitionBackingStoreDelegate {

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -271,7 +271,6 @@ private class PrivateXMLHandler {
             self.server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: xmlContext, matchingContract: contract)
         } else {
             xml = (try? Kanna.XML(xml: xmlString, encoding: .utf8)) ?? PrivateXMLHandler.emptyXML
-            //TODO check this again when we implement signature verification using the web API. We can't just set this to false first because we don't notify client code when it changes to false either. So when a TokenScript file changes, live-reloading thinks there's no TokenScript file
             hasValidTokenScriptFile = true
             server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: xmlContext, matchingContract: contract)
             tokenScriptStatusPromise.done { tokenScriptStatus in
@@ -279,6 +278,7 @@ private class PrivateXMLHandler {
                 self.xml = xml
                 self.hasValidTokenScriptFile = hasValidTokenScriptFile
                 self.server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: self.xmlContext, matchingContract: contract)
+                self.assetDefinitionStore?.invalidateSignatureStatus(forContract: self.contractAddress)
             }
         }
     }


### PR DESCRIPTION
This only affects overridden TokenScript files.

Before this PR:

1. Tap on token with TokenScript file with a valid signature
2. Iconified view is rendered
3. Modify TokenScript file so that signature is now invalid
4. Iconified view remains unchanged.

After this PR:

4. Iconified view is now replaced by the fallback when no TokenScript file is available