### PR TITLE
Refactor: Extract common layout constraint creation code

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		5E7C71DC13B2040F5408BF3C /* ImportMagicTokenCardRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */; };
 		5E7C71F8050CCF990539B293 /* LockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79D674D45A07E694CE31 /* LockView.swift */; };
 		5E7C720C2A5CA7D41B12D666 /* RateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7A92352937F37294F12C /* RateLimiter.swift */; };
+		5E7C721B569E1CD1C68295F6 /* LayoutConstraintsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78C073F380B48D5BE94C /* LayoutConstraintsWrapper.swift */; };
 		5E7C72311A412C022AA20F51 /* PromptBackupWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C70165BA8A9F342DC7874 /* PromptBackupWalletView.swift */; };
 		5E7C7233A9A5F9D1A89FF569 /* TokensViewControllerTableViewSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7FB7C3FB2A9CC0CC51D7 /* TokensViewControllerTableViewSectionHeader.swift */; };
 		5E7C72402E57B627B6E56934 /* TokenInstanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75506A766DF9B746E62F /* TokenInstanceViewModel.swift */; };
@@ -1088,6 +1089,7 @@
 		5E7C78B001F9F95F404D5FEF /* HowDoIGetMyMoneyInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HowDoIGetMyMoneyInfoViewController.swift; sourceTree = "<group>"; };
 		5E7C78B61907C2C1E2BCD478 /* DappsHomeViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsHomeViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C78B63FDE2FAF25389260 /* TransferTokensCardViaWalletAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTokensCardViaWalletAddressViewController.swift; sourceTree = "<group>"; };
+		5E7C78C073F380B48D5BE94C /* LayoutConstraintsWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutConstraintsWrapper.swift; sourceTree = "<group>"; };
 		5E7C78E5C8FAEA752B32626D /* UIActivityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityViewController.swift; sourceTree = "<group>"; };
 		5E7C78EFAF641C41F06C46BF /* ServersCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServersCoordinatorTests.swift; sourceTree = "<group>"; };
 		5E7C78FAB9070B10A476DB29 /* AssetImplicitAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetImplicitAttributes.swift; sourceTree = "<group>"; };
@@ -2412,6 +2414,7 @@
 				5E7C772DC28C5110021894E3 /* ImageCache.swift */,
 				5E7C7914F01B5FEA5B20398B /* Collection+UIView.swift */,
 				5E7C799E4784815CB0202820 /* Core.swift */,
+				5E7C7543079DF1C7CA998A2D /* Views */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2704,6 +2707,14 @@
 				5E7C7778166E01A0D483C58D /* SecureEnclave.swift */,
 			);
 			path = KeyManagement;
+			sourceTree = "<group>";
+		};
+		5E7C7543079DF1C7CA998A2D /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C78C073F380B48D5BE94C /* LayoutConstraintsWrapper.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		5E7C755521B5CAF98176AB84 /* ViewModels */ = {
@@ -4346,6 +4357,7 @@
 				5E7C70CF44075CF73F03AD4B /* TokensViewControllerTableViewHeader.swift in Sources */,
 				5E7C7233A9A5F9D1A89FF569 /* TokensViewControllerTableViewSectionHeader.swift in Sources */,
 				5E7C756B31278B71E68D5E10 /* TokensViewControllerCollectiblesCollectionViewHeader.swift in Sources */,
+				5E7C721B569E1CD1C68295F6 /* LayoutConstraintsWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AlphaWalletHelp/ViewControllers/HelpContentsViewController.swift
+++ b/AlphaWallet/AlphaWalletHelp/ViewControllers/HelpContentsViewController.swift
@@ -17,10 +17,7 @@ class HelpContentsViewController: StaticHTMLViewController {
         footer.addSubview(banner)
 
         NSLayoutConstraint.activate([
-            banner.leadingAnchor.constraint(equalTo: footer.leadingAnchor),
-            banner.trailingAnchor.constraint(equalTo: footer.trailingAnchor),
-            banner.topAnchor.constraint(equalTo: footer.topAnchor),
-            banner.bottomAnchor.constraint(equalTo: footer.bottomAnchor),
+            banner.anchorsConstraint(to: footer)
         ])
 
         configure()

--- a/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
+++ b/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
@@ -44,10 +44,7 @@ class ContactUsBannerView: UIView {
             stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            button.leadingAnchor.constraint(equalTo: leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor),
-            button.topAnchor.constraint(equalTo: topAnchor),
-            button.bottomAnchor.constraint(equalTo: bottomAnchor),
+            button.anchorsConstraint(to: self),
         ])
     }
 

--- a/AlphaWallet/Browser/ViewControllers/BrowserHistoryViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserHistoryViewController.swift
@@ -41,10 +41,7 @@ final class BrowserHistoryViewController: UIViewController {
         }()
 
         NSLayoutConstraint.activate([
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view),
         ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -80,20 +80,14 @@ final class BrowserViewController: UIViewController {
         view.addSubview(errorView)
 
         NSLayoutConstraint.activate([
-            webView.topAnchor.constraint(equalTo: view.topAnchor),
-            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webView.anchorsConstraint(to: view),
 
             progressView.topAnchor.constraint(equalTo: view.layoutGuide.topAnchor),
             progressView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
             progressView.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
             progressView.heightAnchor.constraint(equalToConstant: 2),
 
-            errorView.topAnchor.constraint(equalTo: webView.topAnchor),
-            errorView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
-            errorView.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
-            errorView.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
+            errorView.anchorsConstraint(to: webView),
         ])
         view.backgroundColor = .white
         webView.addObserver(self, forKeyPath: Keys.estimatedProgress, options: .new, context: &myContext)

--- a/AlphaWallet/Browser/ViewControllers/DappsAutoCompletionViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/DappsAutoCompletionViewController.swift
@@ -29,10 +29,7 @@ class DappsAutoCompletionViewController: UIViewController {
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view)
         ])
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/AlphaWallet/Browser/ViewControllers/DappsHomeViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/DappsHomeViewController.swift
@@ -89,10 +89,7 @@ class DappsHomeViewController: UIViewController {
         view.addSubview(dappsCollectionView)
 
         NSLayoutConstraint.activate([
-            dappsCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dappsCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            dappsCollectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            dappsCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            dappsCollectionView.anchorsConstraint(to: view)
         ])
         configure(viewModel: viewModel)
 

--- a/AlphaWallet/Browser/ViewControllers/DiscoverDappsViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/DiscoverDappsViewController.swift
@@ -33,10 +33,7 @@ class DiscoverDappsViewController: UIViewController {
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view)
         ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -147,10 +144,7 @@ private class SectionHeaderView: UIView {
         addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 31),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor),
-            label.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            label.anchorsConstraint(to: self, edgeInsets: .init(top: 12, left: 31, bottom: 10, right: 0))
         ])
 
         configure()

--- a/AlphaWallet/Browser/ViewControllers/MyDappsViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/MyDappsViewController.swift
@@ -46,10 +46,7 @@ class MyDappsViewController: UIViewController {
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view)
         ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)

--- a/AlphaWallet/Core/Views/LayoutConstraintsWrapper.swift
+++ b/AlphaWallet/Core/Views/LayoutConstraintsWrapper.swift
@@ -1,0 +1,37 @@
+// Copyright © 2019 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+
+///This let us do this do effectively this:
+///
+///NSLayoutConstraint.activate([
+///    constraintsArray1,
+///    constraintsArray2,
+///    constraint3,
+///    constraint4,
+///    constraint5,
+///])
+///
+///Alternatives involve appending of arrays which ends up with code that is hard to indent
+protocol LayoutConstraintsWrapper {
+    var constraints: [NSLayoutConstraint] { get }
+}
+
+extension Array: LayoutConstraintsWrapper where Element: NSLayoutConstraint {
+    var constraints: [NSLayoutConstraint] {
+        return self
+    }
+}
+
+extension NSLayoutConstraint: LayoutConstraintsWrapper {
+    var constraints: [NSLayoutConstraint] {
+        return [self]
+    }
+}
+
+extension NSLayoutConstraint {
+    class func activate(_ constraints: [LayoutConstraintsWrapper]) {
+        activate(constraints.flatMap { $0.constraints })
+    }
+}

--- a/AlphaWallet/Extensions/UIView.swift
+++ b/AlphaWallet/Extensions/UIView.swift
@@ -4,13 +4,17 @@ import Foundation
 import UIKit
 
 extension UIView {
-    func anchor(to view: UIView, margin: CGFloat = 0) {
-        NSLayoutConstraint.activate([
-            topAnchor.constraint(equalTo: view.topAnchor, constant: margin),
-            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -margin),
-            bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor, constant: -margin),
-            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: margin),
-        ])
+    func anchorsConstraint(to view: UIView, edgeInsets: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
+        return [
+            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: edgeInsets.left),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -edgeInsets.right),
+            topAnchor.constraint(equalTo: view.topAnchor, constant: edgeInsets.top),
+            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -edgeInsets.bottom),
+        ]
+    }
+
+    func anchorsConstraint(to view: UIView, margin: CGFloat) -> [NSLayoutConstraint] {
+        return anchorsConstraint(to: view, edgeInsets: .init(top: margin, left: margin, bottom: margin, right: margin))
     }
 
     var layoutGuide: UILayoutGuide {

--- a/AlphaWallet/Settings/Views/AlphaWalletSettingsSwitchRow.swift
+++ b/AlphaWallet/Settings/Views/AlphaWalletSettingsSwitchRow.swift
@@ -35,21 +35,7 @@ open class AlphaWalletSwitchCell: Cell<Bool>, CellType {
         let xMargin  = CGFloat(7)
         let yMargin  = CGFloat(4)
         NSLayoutConstraint.activate([
-//            mainLabel.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 21),
-//            mainLabel.trailingAnchor.constraint(equalTo: subLabel.leadingAnchor, constant: -10),
-//            mainLabel.centerYAnchor.constraint(equalTo: background.centerYAnchor),
-//            mainLabel.topAnchor.constraint(equalTo: background.topAnchor, constant: 18),
-//            mainLabel.bottomAnchor.constraint(lessThanOrEqualTo: background.bottomAnchor, constant: -18),
-
-//            subLabel.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -18),
-//            subLabel.centerYAnchor.constraint(equalTo: background.centerYAnchor),
-//            subLabel.topAnchor.constraint(equalTo: background.topAnchor, constant: 18),
-//            subLabel.bottomAnchor.constraint(lessThanOrEqualTo: background.bottomAnchor, constant: -18),
-
-            background.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xMargin),
-            background.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -xMargin),
-            background.topAnchor.constraint(equalTo: topAnchor, constant: yMargin),
-            background.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -yMargin),
+            background.anchorsConstraint(to: self, edgeInsets: .init(top: yMargin, left: xMargin, bottom: yMargin, right: xMargin))
         ])
     }
 

--- a/AlphaWallet/Settings/Views/LocaleViewCell.swift
+++ b/AlphaWallet/Settings/Views/LocaleViewCell.swift
@@ -36,15 +36,8 @@ class LocaleViewCell: UITableViewCell {
         NSLayoutConstraint.activate([
             selectedIcon.widthAnchor.constraint(equalToConstant: 44),
 
-            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: StyleLayout.sideMargin),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -StyleLayout.sideMargin),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -StyleLayout.sideMargin),
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: StyleLayout.sideMargin),
-
-            background.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xMargin),
-            background.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -xMargin),
-            background.topAnchor.constraint(equalTo: topAnchor, constant: yMargin),
-            background.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -yMargin),
+            stackView.anchorsConstraint(to: background, margin: StyleLayout.sideMargin),
+            background.anchorsConstraint(to: self, edgeInsets: .init(top: yMargin, left: xMargin, bottom: yMargin, right: xMargin)),
         ])
     }
 

--- a/AlphaWallet/Settings/Views/ServerViewCell.swift
+++ b/AlphaWallet/Settings/Views/ServerViewCell.swift
@@ -36,15 +36,9 @@ class ServerViewCell: UITableViewCell {
         NSLayoutConstraint.activate([
             selectedIcon.widthAnchor.constraint(equalToConstant: 44),
 
-            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: StyleLayout.sideMargin),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -StyleLayout.sideMargin),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -StyleLayout.sideMargin),
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: StyleLayout.sideMargin),
+            stackView.anchorsConstraint(to: background, margin: StyleLayout.sideMargin),
 
-            background.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xMargin),
-            background.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -xMargin),
-            background.topAnchor.constraint(equalTo: topAnchor, constant: yMargin),
-            background.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -yMargin),
+            background.anchorsConstraint(to: self, edgeInsets: .init(top: yMargin, left: xMargin, bottom: yMargin, right: xMargin)),
         ])
     }
 

--- a/AlphaWallet/Settings/Views/SettingsHeaderView.swift
+++ b/AlphaWallet/Settings/Views/SettingsHeaderView.swift
@@ -26,10 +26,7 @@ class SettingsHeaderView: UIView {
         addSubview(titleLabel)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            titleLabel.topAnchor.constraint(equalTo: topAnchor),
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            titleLabel.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 0)),
         ])
     }
 

--- a/AlphaWallet/Settings/Views/WalletSecurityLevelIndicator.swift
+++ b/AlphaWallet/Settings/Views/WalletSecurityLevelIndicator.swift
@@ -26,10 +26,7 @@ class WalletSecurityLevelIndicator: UIView {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -rightMargin),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 0, bottom: 0, right: rightMargin)),
         ])
 
         configure()

--- a/AlphaWallet/TokenScriptClient/ViewControllers/AssetDefinitionsOverridesViewController.swift
+++ b/AlphaWallet/TokenScriptClient/ViewControllers/AssetDefinitionsOverridesViewController.swift
@@ -28,10 +28,7 @@ class AssetDefinitionsOverridesViewController: UIViewController {
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view),
         ])
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/PeekOpenSeaNonFungibleTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/PeekOpenSeaNonFungibleTokenViewController.swift
@@ -25,10 +25,7 @@ class PeekOpenSeaNonFungibleTokenViewController: UIViewController {
             //Using trailingAnchor doesn't work correctly. The width width of the child is too narrow. So we use widthAnchor
             tokenRowView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
 
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.anchorsConstraint(to: view),
         ])
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -54,16 +54,15 @@ class TokenViewController: UIViewController {
             header.leadingAnchor.constraint(equalTo: roundedBackground.leadingAnchor),
             header.trailingAnchor.constraint(equalTo: roundedBackground.trailingAnchor),
 
-            tableView.leadingAnchor.constraint(equalTo: roundedBackground.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: roundedBackground.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: roundedBackground.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: roundedBackground.bottomAnchor),
+            tableView.anchorsConstraint(to: roundedBackground),
 
             buttonsBar.leadingAnchor.constraint(equalTo: roundedBackground.leadingAnchor),
             buttonsBar.trailingAnchor.constraint(equalTo: roundedBackground.trailingAnchor),
             buttonsBar.heightAnchor.constraint(equalToConstant: ButtonsBar.buttonsHeight),
             buttonsBar.bottomAnchor.constraint(equalTo: view.layoutGuide.bottomAnchor, constant: -ButtonsBar.marginAtBottomScreen),
-        ] + roundedBackground.createConstraintsWithContainer(view: view))
+
+            roundedBackground.createConstraintsWithContainer(view: view),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -101,10 +101,7 @@ class TokensViewController: UIViewController {
                 promptBackupWalletView.translatesAutoresizingMaskIntoConstraints = false
                 promptBackupWalletViewHolder.addSubview(promptBackupWalletView)
                 NSLayoutConstraint.activate([
-                    promptBackupWalletView.leadingAnchor.constraint(equalTo: promptBackupWalletViewHolder.leadingAnchor, constant: 7),
-                    promptBackupWalletView.trailingAnchor.constraint(equalTo: promptBackupWalletViewHolder.trailingAnchor, constant: -7),
-                    promptBackupWalletView.topAnchor.constraint(equalTo: promptBackupWalletViewHolder.topAnchor, constant: 7),
-                    promptBackupWalletView.bottomAnchor.constraint(equalTo: promptBackupWalletViewHolder.bottomAnchor, constant: -4),
+                    promptBackupWalletView.anchorsConstraint(to: promptBackupWalletViewHolder, edgeInsets: .init(top: 7, left: 7, bottom: 4, right: 7)),
                 ])
 
                 isPromptBackupWalletViewHolderHidden = shouldHidePromptBackupWalletViewHolderBecauseSearchIsActive
@@ -167,15 +164,8 @@ class TokensViewController: UIViewController {
         view.addSubview(collectiblesCollectionView)
 
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-            tableView.leadingAnchor.constraint(equalTo: collectiblesCollectionView.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: collectiblesCollectionView.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: collectiblesCollectionView.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: collectiblesCollectionView.bottomAnchor),
+            tableView.anchorsConstraint(to: view),
+            tableView.anchorsConstraint(to: collectiblesCollectionView),
         ])
         errorView = ErrorView(onRetry: { [weak self] in
             self?.startLoading()

--- a/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
+++ b/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
@@ -56,10 +56,7 @@ class BaseTokenCardTableViewCell: UITableViewCell {
         contentView.addSubview(rowView)
 
         NSLayoutConstraint.activate([
-            rowView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rowView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            rowView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            rowView.anchorsConstraint(to: contentView),
         ])
     }
 }

--- a/AlphaWallet/Tokens/Views/BaseTokenListFormatTableViewCell.swift
+++ b/AlphaWallet/Tokens/Views/BaseTokenListFormatTableViewCell.swift
@@ -25,10 +25,7 @@ class BaseTokenListFormatTableViewCell: UITableViewCell {
         contentView.addSubview(rowView)
 
         NSLayoutConstraint.activate([
-            rowView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rowView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            rowView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            rowView.anchorsConstraint(to: contentView),
         ])
     }
 

--- a/AlphaWallet/Tokens/Views/OpenSea/BaseOpenSeaNonFungibleTokenCardTableViewCell.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/BaseOpenSeaNonFungibleTokenCardTableViewCell.swift
@@ -27,10 +27,7 @@ class BaseOpenSeaNonFungibleTokenCardTableViewCell: UITableViewCell {
         contentView.addSubview(rowView)
 
         NSLayoutConstraint.activate([
-            rowView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rowView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            rowView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            rowView.anchorsConstraint(to: contentView),
         ])
     }
 

--- a/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenCardRowView.swift
@@ -257,10 +257,7 @@ class OpenSeaNonFungibleTokenCardRowView: UIView {
         ]
 
         NSLayoutConstraint.activate([
-            mainVerticalStackView.leadingAnchor.constraint(equalTo: background.leadingAnchor),
-            mainVerticalStackView.trailingAnchor.constraint(equalTo: background.trailingAnchor),
-            mainVerticalStackView.topAnchor.constraint(equalTo: background.topAnchor, constant: marginForBigImageView),
-            mainVerticalStackView.bottomAnchor.constraint(equalTo: background.bottomAnchor),
+            mainVerticalStackView.anchorsConstraint(to: background, edgeInsets: .init(top: marginForBigImageView, left: 0, bottom: 0, right: 0)),
 
             background.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -xMargin),
             background.topAnchor.constraint(equalTo: topAnchor, constant: yMargin),
@@ -287,11 +284,11 @@ class OpenSeaNonFungibleTokenCardRowView: UIView {
             statsCollectionViewHeightConstraint,
 
             descriptionLabel.widthAnchor.constraint(equalTo: col0.widthAnchor),
-        ] +
-                bigImageViewRelatedConstraintsWithPositiveBleed +
-                bigImageViewRelatedConstraintsWithNegativeBleed +
-                thumbnailRelatedConstraints
-        )
+
+            bigImageViewRelatedConstraintsWithPositiveBleed,
+            bigImageViewRelatedConstraintsWithNegativeBleed,
+            thumbnailRelatedConstraints,
+        ])
 
         viewsVisibleWhenDetailsAreNotVisibleImagesAvailable = [
             spacers.aboveTitle,

--- a/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenViewCell.swift
@@ -33,22 +33,13 @@ class OpenSeaNonFungibleTokenViewCell: UICollectionViewCell {
         let yMargin = CGFloat(0)
         let imageViewBleed = CGFloat(12)
         NSLayoutConstraint.activate([
-            background.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: xMargin),
-            background.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -xMargin),
-            background.topAnchor.constraint(equalTo: contentView.topAnchor, constant: yMargin),
-            background.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -yMargin),
+            background.anchorsConstraint(to: contentView, edgeInsets: .init(top: yMargin, left: xMargin, bottom: yMargin, right: xMargin)),
 
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: background.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor),
+            stackView.anchorsConstraint(to: background),
 
             imageHolder.widthAnchor.constraint(equalTo: imageHolder.heightAnchor),
 
-            imageView.leadingAnchor.constraint(equalTo: imageHolder.leadingAnchor, constant: -imageViewBleed),
-            imageView.trailingAnchor.constraint(equalTo: imageHolder.trailingAnchor, constant: imageViewBleed),
-            imageView.topAnchor.constraint(equalTo: imageHolder.topAnchor, constant: -imageViewBleed),
-            imageView.bottomAnchor.constraint(equalTo: imageHolder.bottomAnchor, constant: imageViewBleed),
+            imageView.anchorsConstraint(to: imageHolder, margin: imageViewBleed),
         ])
     }
 

--- a/AlphaWallet/Tokens/Views/TextField.swift
+++ b/AlphaWallet/Tokens/Views/TextField.swift
@@ -89,10 +89,8 @@ class TextField: UIControl {
         addSubview(textField)
 
         NSLayoutConstraint.activate([
-            textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 22),
-            textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -22),
-            textField.topAnchor.constraint(equalTo: topAnchor),
-            textField.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textField.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 22, bottom: 0, right: 22)),
+
             heightAnchor.constraint(equalToConstant: ScreenChecker().isNarrowScreen ? 30 : 50),
         ])
     }

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -48,11 +48,10 @@ class TokenInstanceWebView: UIView {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
 
         NSLayoutConstraint.activate([
-            webView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            webView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            webView.topAnchor.constraint(equalTo: topAnchor),
-            webView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ] +  [heightConstraint])
+            webView.anchorsConstraint(to: self),
+
+            heightConstraint,
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AlphaWallet/Tokens/Views/TokenViewControllerHeaderView.swift
+++ b/AlphaWallet/Tokens/Views/TokenViewControllerHeaderView.swift
@@ -55,10 +55,7 @@ class TokenViewControllerHeaderView: UIView {
         NSLayoutConstraint.activate([
             border.heightAnchor.constraint(equalToConstant: 1),
 
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 30, bottom: 0, right: 30)),
         ])
 
         configure()

--- a/AlphaWallet/Tokens/Views/TokenViewControllerTransactionCell.swift
+++ b/AlphaWallet/Tokens/Views/TokenViewControllerTransactionCell.swift
@@ -35,10 +35,7 @@ class TokenViewControllerTransactionCell: UITableViewCell {
             typeImageView.widthAnchor.constraint(equalToConstant: 12),
             typeImageView.widthAnchor.constraint(equalTo: typeImageView.heightAnchor),
 
-            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            mainStackView.topAnchor.constraint(equalTo: topAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            mainStackView.anchorsConstraint(to: self),
         ])
     }
 

--- a/AlphaWallet/Tokens/Views/TokensViewControllerCollectiblesCollectionViewHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokensViewControllerCollectiblesCollectionViewHeader.swift
@@ -19,10 +19,7 @@ extension TokensViewController {
                 addSubview(filterView)
 
                 NSLayoutConstraint.activate([
-                    filterView.leadingAnchor.constraint(equalTo: leadingAnchor),
-                    filterView.trailingAnchor.constraint(equalTo: trailingAnchor),
-                    filterView.topAnchor.constraint(equalTo: topAnchor),
-                    filterView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -7),
+                    filterView.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 0, bottom: 7, right: 0)),
                 ])
             }
         }

--- a/AlphaWallet/Tokens/Views/TokensViewControllerTableViewHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokensViewControllerTableViewHeader.swift
@@ -24,10 +24,7 @@ extension TokensViewController {
             addSubview(stackView)
 
             NSLayoutConstraint.activate([
-                stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-                stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-                stackView.topAnchor.constraint(equalTo: topAnchor),
-                stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                stackView.anchorsConstraint(to: self),
             ])
         }
 

--- a/AlphaWallet/Tokens/Views/TokensViewControllerTableViewSectionHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokensViewControllerTableViewSectionHeader.swift
@@ -19,10 +19,7 @@ extension TokensViewController {
                 contentView.addSubview(filterView)
 
                 NSLayoutConstraint.activate([
-                    filterView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                    filterView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-                    filterView.topAnchor.constraint(equalTo: contentView.topAnchor),
-                    filterView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -7),
+                    filterView.anchorsConstraint(to: contentView, edgeInsets: .init(top: 0, left: 0, bottom: 7, right: 0)),
                 ])
             }
         }

--- a/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
@@ -44,10 +44,7 @@ class TransactionsViewController: UIViewController {
         view.addSubview(tableView)
 
         NSLayoutConstraint.activate([
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.anchorsConstraint(to: view),
         ])
 
         dataCoordinator.delegate = self

--- a/AlphaWallet/Transactions/Views/TransactionHeaderView.swift
+++ b/AlphaWallet/Transactions/Views/TransactionHeaderView.swift
@@ -22,7 +22,13 @@ class TransactionHeaderView: UIView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stackView)
 
-        stackView.anchor(to: self, margin: 15)
+        let margin = CGFloat(15)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor, constant: margin),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
+            stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -margin),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AlphaWallet/Transactions/Views/TransactionViewCell.swift
+++ b/AlphaWallet/Transactions/Views/TransactionViewCell.swift
@@ -61,15 +61,9 @@ class TransactionViewCell: UITableViewCell {
         NSLayoutConstraint.activate([
             statusImageView.widthAnchor.constraint(lessThanOrEqualToConstant: 26),
 
-            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: StyleLayout.sideMargin),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -StyleLayout.sideMargin),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -StyleLayout.sideMargin),
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: StyleLayout.sideMargin),
+            stackView.anchorsConstraint(to: background, margin: StyleLayout.sideMargin),
 
-            background.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: xMargin),
-            background.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -xMargin),
-            background.topAnchor.constraint(equalTo: contentView.topAnchor, constant: yMargin),
-            background.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -yMargin),
+            background.anchorsConstraint(to: contentView, edgeInsets: .init(top: yMargin, left: xMargin, bottom: yMargin, right: xMargin)),
         ])
     }
 

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
@@ -68,10 +68,7 @@ class ConfirmSignMessageViewController: UIViewController {
             header.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
             header.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
 
-            visualEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            visualEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            visualEffectView.topAnchor.constraint(equalTo: view.topAnchor),
-            visualEffectView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            visualEffectView.anchorsConstraint(to: view),
 
             detailsBackground.leadingAnchor.constraint(equalTo: background.leadingAnchor),
             detailsBackground.trailingAnchor.constraint(equalTo: background.trailingAnchor),
@@ -85,10 +82,7 @@ class ConfirmSignMessageViewController: UIViewController {
             actionButton.heightAnchor.constraint(equalToConstant: 47),
             cancelButton.heightAnchor.constraint(equalTo: actionButton.heightAnchor),
 
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 30),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -30),
-            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: 16),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -16),
+            stackView.anchorsConstraint(to: background, edgeInsets: .init(top: 16, left: 30, bottom: 16, right: 30)),
 
             background.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
             background.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),

--- a/AlphaWallet/Transfer/ViewControllers/GenerateTransferMagicLinkViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/GenerateTransferMagicLinkViewController.swift
@@ -69,10 +69,7 @@ class GenerateTransferMagicLinkViewController: UIViewController {
             header.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
             header.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
 
-            visualEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            visualEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            visualEffectView.topAnchor.constraint(equalTo: view.topAnchor),
-            visualEffectView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            visualEffectView.anchorsConstraint(to: view),
 
             detailsBackground.leadingAnchor.constraint(equalTo: background.leadingAnchor),
             detailsBackground.trailingAnchor.constraint(equalTo: background.trailingAnchor),
@@ -82,10 +79,7 @@ class GenerateTransferMagicLinkViewController: UIViewController {
             actionButton.heightAnchor.constraint(equalToConstant: 47),
             cancelButton.heightAnchor.constraint(equalTo: actionButton.heightAnchor),
 
-            stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 40),
-            stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -40),
-            stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: 16),
-            stackView.bottomAnchor.constraint(equalTo: background.bottomAnchor, constant: -16),
+            stackView.anchorsConstraint(to: background, edgeInsets: .init(top: 16, left: 40, bottom: 16, right: 40)),
 
             background.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 42),
             background.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -42),

--- a/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
@@ -107,15 +107,14 @@ class RequestViewController: UIViewController {
 			addressContainerTrailingAnchorConstraint,
 
 			//Leading/trailing anchor needed to make label fit when on narrow iPhones
-			addressLabel.leadingAnchor.constraint(greaterThanOrEqualTo: addressContainerView.leadingAnchor, constant: 10),
-			addressLabel.trailingAnchor.constraint(lessThanOrEqualTo: addressContainerView.trailingAnchor, constant: -10),
 			addressLabel.centerXAnchor.constraint(lessThanOrEqualTo: addressContainerView.centerXAnchor),
-			addressLabel.topAnchor.constraint(equalTo: addressContainerView.topAnchor, constant: 20),
-			addressLabel.bottomAnchor.constraint(equalTo: addressContainerView.bottomAnchor, constant: -20),
+			addressLabel.anchorsConstraint(to: addressContainerView, edgeInsets: .init(top: 20, left: 10, bottom: 20, right: 10)),
 
 			imageView.widthAnchor.constraint(equalToConstant: 260),
 			imageView.heightAnchor.constraint(equalToConstant: 260),
-		] + roundedBackground.createConstraintsWithContainer(view: view))
+
+			roundedBackground.createConstraintsWithContainer(view: view),
+		])
 
 		changeQRCode(value: 0)
 	}

--- a/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
@@ -169,15 +169,9 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
             noteBorderView.leadingAnchor.constraint(equalTo: tokenRowView.background.leadingAnchor),
             noteBorderView.trailingAnchor.constraint(equalTo: tokenRowView.background.trailingAnchor),
 
-            noteStackView.leadingAnchor.constraint(equalTo: noteBorderView.leadingAnchor, constant: 10),
-            noteStackView.trailingAnchor.constraint(equalTo: noteBorderView.trailingAnchor, constant: -10),
-            noteStackView.topAnchor.constraint(equalTo: noteBorderView.topAnchor, constant: 10),
-            noteStackView.bottomAnchor.constraint(equalTo: noteBorderView.bottomAnchor, constant: -10),
+            noteStackView.anchorsConstraint(to: noteBorderView, margin: 10),
 
-            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.anchorsConstraint(to: scrollView),
 
             buttonsBar.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor),
             buttonsBar.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor),
@@ -193,7 +187,9 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: footerBar.topAnchor),
-        ] + roundedBackground.createConstraintsWithContainer(view: view))
+
+            roundedBackground.createConstraintsWithContainer(view: view),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -68,10 +68,7 @@ class AddressTextField: UIControl {
         ensAddressLabel.textAlignment = .center
 
         NSLayoutConstraint.activate([
-            textField.leadingAnchor.constraint(equalTo: leadingAnchor),
-            textField.trailingAnchor.constraint(equalTo: trailingAnchor),
-            textField.topAnchor.constraint(equalTo: topAnchor),
-            textField.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textField.anchorsConstraint(to: self),
             heightAnchor.constraint(equalToConstant: ScreenChecker().isNarrowScreen ? 30 : 50),
         ])
     }

--- a/AlphaWallet/UI/BalanceTitleView.swift
+++ b/AlphaWallet/UI/BalanceTitleView.swift
@@ -48,10 +48,7 @@ class BalanceTitleView: UIView {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.anchorsConstraint(to: self),
         ])
 
         stackView.addGestureRecognizer(

--- a/AlphaWallet/UI/ButtonsBar.swift
+++ b/AlphaWallet/UI/ButtonsBar.swift
@@ -44,10 +44,7 @@ class ButtonsBar: UIView {
 
         let margin = CGFloat(20)
         NSLayoutConstraint.activate([
-            buttonsStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: margin),
-            buttonsStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -margin),
-            buttonsStackView.topAnchor.constraint(equalTo: topAnchor),
-            buttonsStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            buttonsStackView.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: margin, bottom: 0, right: margin)),
         ])
     }
 

--- a/AlphaWallet/UI/ContainerViewWithShadow.swift
+++ b/AlphaWallet/UI/ContainerViewWithShadow.swift
@@ -15,10 +15,7 @@ class ContainerViewWithShadow<T: UIView>: UIView {
         addSubview(childView)
 
         NSLayoutConstraint.activate([
-            childView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            childView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            childView.topAnchor.constraint(equalTo: topAnchor),
-            childView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            childView.anchorsConstraint(to: self),
         ])
     }
 

--- a/AlphaWallet/UI/RoundedBackground.swift
+++ b/AlphaWallet/UI/RoundedBackground.swift
@@ -16,11 +16,6 @@ class RoundedBackground: UIView {
 
     func createConstraintsWithContainer(view: UIView) -> [NSLayoutConstraint] {
         let marginToHideBottomRoundedCorners = CGFloat(30)
-        return [
-            leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            topAnchor.constraint(equalTo: view.topAnchor),
-            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: marginToHideBottomRoundedCorners),
-        ]
+        return view.anchorsConstraint(to: self, edgeInsets: .init(top: 0, left: 0, bottom: marginToHideBottomRoundedCorners, right: 0))
     }
 }

--- a/AlphaWallet/UI/SuccessOverlayView.swift
+++ b/AlphaWallet/UI/SuccessOverlayView.swift
@@ -27,10 +27,7 @@ class SuccessOverlayView: UIView {
         addGestureRecognizer(tapGestureRecognizer)
 
         NSLayoutConstraint.activate([
-            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            blurView.topAnchor.constraint(equalTo: topAnchor),
-            blurView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            blurView.anchorsConstraint(to: self),
 
             imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -118,10 +118,7 @@ class AmountTextField: UIControl {
         computeAlternateAmount()
 
         NSLayoutConstraint.activate([
-            textField.leadingAnchor.constraint(equalTo: leadingAnchor),
-            textField.trailingAnchor.constraint(equalTo: trailingAnchor),
-            textField.topAnchor.constraint(equalTo: topAnchor),
-            textField.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textField.anchorsConstraint(to: self),
         ])
     }
 

--- a/AlphaWallet/UI/Views/DateEntryField.swift
+++ b/AlphaWallet/UI/Views/DateEntryField.swift
@@ -30,10 +30,7 @@ class DateEntryField: UIControl {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.anchorsConstraint(to: self),
         ])
 
         configure()

--- a/AlphaWallet/UI/Views/TextView.swift
+++ b/AlphaWallet/UI/Views/TextView.swift
@@ -68,10 +68,7 @@ class TextView: UIControl {
         addSubview(textView)
 
         NSLayoutConstraint.activate([
-            textView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            textView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            textView.topAnchor.constraint(equalTo: topAnchor),
-            textView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            textView.anchorsConstraint(to: self),
         ])
     }
 

--- a/AlphaWallet/UI/Views/TimeEntryField.swift
+++ b/AlphaWallet/UI/Views/TimeEntryField.swift
@@ -30,10 +30,7 @@ class TimeEntryField: UIControl {
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.anchorsConstraint(to: self),
         ])
 
         configure()

--- a/AlphaWallet/UI/WhereIsWalletAddressFoundOverlayView.swift
+++ b/AlphaWallet/UI/WhereIsWalletAddressFoundOverlayView.swift
@@ -29,10 +29,7 @@ class WhereIsWalletAddressFoundOverlayView: UIView {
         addSubview(dialog)
 
         NSLayoutConstraint.activate([
-            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            blurView.topAnchor.constraint(equalTo: topAnchor),
-            blurView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            blurView.anchorsConstraint(to: self),
 
             dialog.rightAnchor.constraint(equalTo: rightAnchor, constant: -20),
             dialog.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -120),
@@ -112,10 +109,7 @@ fileprivate class Dialog: UIView {
             widthAnchor.constraint(equalToConstant: 300),
             heightAnchor.constraint(equalToConstant: 250),
 
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: 30),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -30),
+            stackView.anchorsConstraint(to: self, edgeInsets: .init(top: 30, left: 20, bottom: 30, right: 20)),
         ])
     }
 

--- a/AlphaWallet/Wallet/ViewControllers/CreateInitialWalletViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/CreateInitialWalletViewController.swift
@@ -71,10 +71,7 @@ class CreateInitialWalletViewController: UIViewController {
         NSLayoutConstraint.activate([
             imageView.heightAnchor.constraint(equalToConstant: imageViewDimension),
 
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            stackView.topAnchor.constraint(equalTo: view.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: footerBar.topAnchor),
+            stackView.anchorsConstraint(to: view, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 20)),
 
             createWalletButtonBar.heightAnchor.constraint(equalToConstant: ButtonsBar.buttonsHeight),
 
@@ -87,7 +84,9 @@ class CreateInitialWalletViewController: UIViewController {
             footerBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             footerBar.topAnchor.constraint(equalTo: view.layoutGuide.bottomAnchor, constant: -ButtonsBar.buttonsHeight - ButtonsBar.marginAtBottomScreen),
             footerBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ] + roundedBackground.createConstraintsWithContainer(view: view))
+
+            roundedBackground.createConstraintsWithContainer(view: view),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
@@ -109,10 +109,7 @@ class ShowSeedPhraseViewController: UIViewController {
         footerBar.addSubview(buttonsBar)
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            stackView.topAnchor.constraint(equalTo: view.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            stackView.anchorsConstraint(to: view, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 20)),
 
             buttonsBar.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor),
             buttonsBar.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor),
@@ -123,7 +120,9 @@ class ShowSeedPhraseViewController: UIViewController {
             footerBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             footerBar.topAnchor.constraint(equalTo: view.layoutGuide.bottomAnchor, constant: -ButtonsBar.buttonsHeight - ButtonsBar.marginAtBottomScreen),
             footerBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ] + roundedBackground.createConstraintsWithContainer(view: view))
+
+            roundedBackground.createConstraintsWithContainer(view: view),
+        ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(appWillResignsActive), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)

--- a/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
@@ -142,10 +142,7 @@ class VerifySeedPhraseViewController: UIViewController {
         NSLayoutConstraint.activate([
             seedPhraseTextView.heightAnchor.constraint(equalToConstant: 140),
 
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            stackView.topAnchor.constraint(equalTo: view.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            stackView.anchorsConstraint(to: view, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 20)),
 
             clearChooseSeedPhraseButton.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor, constant: 10),
             clearChooseSeedPhraseButton.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor, constant: -10),
@@ -160,7 +157,9 @@ class VerifySeedPhraseViewController: UIViewController {
             footerBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             footerBar.topAnchor.constraint(equalTo: view.layoutGuide.bottomAnchor, constant: -ButtonsBar.buttonsHeight - ButtonsBar.marginAtBottomScreen),
             footerBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ] + roundedBackground.createConstraintsWithContainer(view: view))
+
+            roundedBackground.createConstraintsWithContainer(view: view),
+        ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(appWillResignsActive), name: UIApplication.willResignActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)

--- a/AlphaWallet/Wallet/Views/ImportWalletTabBar.swift
+++ b/AlphaWallet/Wallet/Views/ImportWalletTabBar.swift
@@ -75,11 +75,8 @@ class ImportWalletTabBar: UIView {
             keystoreButton.widthAnchor.constraint(equalTo: privateKeyButton.widthAnchor),
 			keystoreButton.widthAnchor.constraint(equalTo: watchButton.widthAnchor),
 
-			fullWidthBar.leadingAnchor.constraint(equalTo: leadingAnchor),
-			fullWidthBar.trailingAnchor.constraint(equalTo: trailingAnchor),
 			barHeightConstraint,
-			fullWidthBar.topAnchor.constraint(equalTo: topAnchor),
-			fullWidthBar.bottomAnchor.constraint(equalTo: bottomAnchor),
+			fullWidthBar.anchorsConstraint(to: self),
 
 			tabHighlightView.topAnchor.constraint(equalTo: fullWidthBar.topAnchor),
 			tabHighlightView.bottomAnchor.constraint(equalTo: fullWidthBar.bottomAnchor, constant: 20),

--- a/AlphaWallet/Wallet/Views/PassphraseView.swift
+++ b/AlphaWallet/Wallet/Views/PassphraseView.swift
@@ -39,10 +39,7 @@ class PassphraseView: UIView {
         collectionView.register(R.nib.wordCollectionViewCell)
 
         NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            collectionView.anchorsConstraint(to: self)
         ])
     }
 

--- a/AlphaWallet/Wallet/Views/SeedPhraseCell.swift
+++ b/AlphaWallet/Wallet/Views/SeedPhraseCell.swift
@@ -24,10 +24,7 @@ class SeedPhraseCell: UICollectionViewCell {
             sequenceLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 4),
             sequenceLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 2),
 
-            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: horizontalMargin),
-            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalMargin),
-            label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: verticalMargin),
-            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -verticalMargin),
+            label.anchorsConstraint(to: contentView, edgeInsets: .init(top: verticalMargin, left: horizontalMargin, bottom: verticalMargin, right: horizontalMargin)),
         ])
     }
 

--- a/AlphaWallet/Welcome/ViewControllers/WelcomeViewController.swift
+++ b/AlphaWallet/Welcome/ViewControllers/WelcomeViewController.swift
@@ -73,10 +73,7 @@ class WelcomeViewController: UIViewController {
         collectionViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            collectionViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            collectionViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionViewController.view.anchorsConstraint(to: view),
 
             pageControl.centerYAnchor.constraint(equalTo: collectionViewController.view.centerYAnchor, constant: -120),
             pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),


### PR DESCRIPTION
No functional change.

This PR introduces a new function `UIView.anchorsConstraint(to:)` which is helpful to use when we want to make a view be constrained by its parent using all 4 of the leading, trailing, top and bottom anchors with optional insets around the child view.

i.e. replace this code:

```
NSLayoutConstraint.activate([
    tableView.topAnchor.constraint(equalTo: view.topAnchor),
    tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
    tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
    tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
])
```

with:

```
NSLayoutConstraint.activate([
    tableView.anchorsConstraint(to: view)
])
```

The `NSLayoutConstraint.activate()` call is not abstracted away so we can mix in other constraints. Constraints should usually be activated with a single `NSLayoutConstraint.activate()` call for efficiency.

This mixing relies on a new extension that let us mix sub-arrays of constraints and constraints in an array and pass it to `NSLayoutConstraint.activate()` like that:

```
NSLayoutConstraint.activate([
    constraintsArray1,
    constraintsArray2,
    constraint3,
    constraint4,
    constraint5,
])
```

Have to be careful here to not introduce too much syntax sugar and create a new dialect that makes it hard for us and future team members to pick up.
