### PR TITLE
Only allow users to switch to enabled networks in Dapp browser and when adding a token

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -18,6 +18,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     }
     private let sessions: ServerDictionary<WalletSession>
     private let keystore: Keystore
+    private let config: Config
 
     private var browserNavBar: DappBrowserNavigationBar? {
         return navigationController.navigationBar as? DappBrowserNavigationBar
@@ -111,12 +112,14 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     init(
         sessions: ServerDictionary<WalletSession>,
         keystore: Keystore,
+        config: Config,
         sharedRealm: Realm,
         browserOnly: Bool
     ) {
         self.navigationController = NavigationController(navigationBarClass: DappBrowserNavigationBar.self, toolbarClass: nil)
         self.sessions = sessions
         self.keystore = keystore
+        self.config = config
         self.sharedRealm = sharedRealm
         self.browserOnly = browserOnly
 
@@ -347,7 +350,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     }
 
     private func showServers() {
-        let coordinator = ServersCoordinator(defaultServer: server)
+        let coordinator = ServersCoordinator(defaultServer: server, config: config)
         coordinator.delegate = self
         coordinator.start()
         addCoordinator(coordinator)

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -294,6 +294,7 @@ class InCoordinator: NSObject, Coordinator {
         let coordinator = TokensCoordinator(
                 sessions: walletSessions,
                 keystore: keystore,
+                config: config,
                 tokenCollection: tokenCollection,
                 nativeCryptoCurrencyPrices: nativeCryptoCurrencyPrices,
                 assetDefinitionStore: assetDefinitionStore,
@@ -324,7 +325,7 @@ class InCoordinator: NSObject, Coordinator {
     }
 
     private func createBrowserCoordinator(sessions: ServerDictionary<WalletSession>, realm: Realm, browserOnly: Bool) -> DappBrowserCoordinator {
-        let coordinator = DappBrowserCoordinator(sessions: sessions, keystore: keystore, sharedRealm: realm, browserOnly: browserOnly)
+        let coordinator = DappBrowserCoordinator(sessions: sessions, keystore: keystore, config: config, sharedRealm: realm, browserOnly: browserOnly)
         coordinator.delegate = self
         coordinator.start()
         coordinator.rootViewController.tabBarItem = UITabBarItem(title: R.string.localizable.browserTabbarItemTitle(), image: R.image.dapps_icon(), selectedImage: nil)

--- a/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
@@ -22,9 +22,11 @@ class ServersCoordinator: Coordinator {
 
     private let defaultServer: RPCServerOrAuto
     private let includeAny: Bool
+    private let config: Config
 
     private var serverChoices: [RPCServerOrAuto] {
-        let servers: [RPCServerOrAuto] = ServersCoordinator.serversOrdered.map { .server($0) }
+        let enabledServers = ServersCoordinator.serversOrdered.filter { config.enabledServers.contains($0) }
+        let servers: [RPCServerOrAuto] = enabledServers.map { .server($0) }
         if includeAny {
             return [.auto] + servers
         } else {
@@ -43,14 +45,16 @@ class ServersCoordinator: Coordinator {
     }()
     weak var delegate: ServersCoordinatorDelegate?
 
-    init(defaultServer: RPCServerOrAuto) {
+    init(defaultServer: RPCServerOrAuto, config: Config) {
         self.defaultServer = defaultServer
         self.includeAny = true
+        self.config = config
     }
 
-    init(defaultServer: RPCServer) {
+    init(defaultServer: RPCServer, config: Config) {
         self.defaultServer = .server(defaultServer)
         self.includeAny = false
+        self.config = config
     }
 
     func start() {

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -16,6 +16,7 @@ fileprivate struct NoContractDetailsDetected: Error {
 class TokensCoordinator: Coordinator {
     private let sessions: ServerDictionary<WalletSession>
     private let keystore: Keystore
+    private let config: Config
     private let tokenCollection: TokenCollection
     private let nativeCryptoCurrencyPrices: ServerDictionary<Subscribable<Double>>
     private let assetDefinitionStore: AssetDefinitionStore
@@ -73,6 +74,7 @@ class TokensCoordinator: Coordinator {
             navigationController: UINavigationController = NavigationController(),
             sessions: ServerDictionary<WalletSession>,
             keystore: Keystore,
+            config: Config,
             tokenCollection: TokenCollection,
             nativeCryptoCurrencyPrices: ServerDictionary<Subscribable<Double>>,
             assetDefinitionStore: AssetDefinitionStore,
@@ -82,6 +84,7 @@ class TokensCoordinator: Coordinator {
         self.navigationController.modalPresentationStyle = .formSheet
         self.sessions = sessions
         self.keystore = keystore
+        self.config = config
         self.tokenCollection = tokenCollection
         self.nativeCryptoCurrencyPrices = nativeCryptoCurrencyPrices
         self.assetDefinitionStore = assetDefinitionStore
@@ -142,7 +145,7 @@ class TokensCoordinator: Coordinator {
     }
 
     private func showServers(inViewController viewController: UIViewController) {
-        let coordinator = ServersCoordinator(defaultServer: serverToAddCustomTokenOn)
+        let coordinator = ServersCoordinator(defaultServer: serverToAddCustomTokenOn, config: config)
         coordinator.delegate = self
         coordinator.start()
         addCoordinator(coordinator)

--- a/AlphaWalletTests/Coordinators/TokensCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/TokensCoordinatorTests.swift
@@ -8,14 +8,16 @@ class TokensCoordinatorTests: XCTestCase {
     func testRootViewController() {
         var sessions = ServerDictionary<WalletSession>()
         sessions[.main] = WalletSession.make()
+        let config: Config = .make()
         let coordinator = TokensCoordinator(
             navigationController: FakeNavigationController(),
             sessions: sessions,
             keystore: FakeKeystore(),
+            config: config,
             tokenCollection: .init(tokenDataStores: []),
             nativeCryptoCurrencyPrices: .init(),
             assetDefinitionStore: AssetDefinitionStore(),
-            promptBackupCoordinator: PromptBackupCoordinator(keystore: FakeKeystore(), wallet: .make(), config: .make())
+            promptBackupCoordinator: PromptBackupCoordinator(keystore: FakeKeystore(), wallet: .make(), config: config)
         )
         coordinator.start()
 


### PR DESCRIPTION
Before this PR, even if a network is not enabled, the user can add a token to it or switch to it in the Dapp browser. This isn't consistent in the UI and can also post problems internally as we might (now or in the future) assume in our code that if a network is not enabled, all resources for it is switched off.

Closes #1275 