### PR TITLE
Add more taptic feedback after user action is successful

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -64,8 +64,20 @@ class SignMessageCoordinator: Coordinator {
                 result = keystore.signTypedMessage(typedData, for: account)
             }
         }
+        showFeedbackOnSuccess(result)
+    }
+
+    private func showFeedbackOnSuccess(_ result: Result<Data, KeystoreError>) {
         switch result {
         case .success(let data):
+            //TODO sound too
+            let feedbackGenerator = UINotificationFeedbackGenerator()
+            feedbackGenerator.prepare()
+            //Hackish, but delay necessary because of the switch to and from user-presence for signing
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                feedbackGenerator.notificationOccurred(.success)
+            }
+
             didComplete?(.success(data))
         case .failure(let error):
             navigationController.displaySuccess(message: error.errorDescription)

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -160,11 +160,27 @@ class ConfirmPaymentViewController: UIViewController {
     @objc func send() {
         displayLoading()
 
-    let transaction = configurator.formUnsignedTransaction()
+        let transaction = configurator.formUnsignedTransaction()
         sendTransactionCoordinator.send(transaction: transaction) { [weak self] result in
             guard let strongSelf = self else { return }
             strongSelf.didCompleted?(result)
             strongSelf.hideLoading()
+            strongSelf.showFeedbackOnSuccess(result)
+        }
+    }
+
+    private func showFeedbackOnSuccess(_ result: Result<ConfirmResult, AnyError>) {
+        let feedbackGenerator = UINotificationFeedbackGenerator()
+        feedbackGenerator.prepare()
+        switch result {
+        case .success:
+            //Hackish, but delay necessary because of the switch to and from user-presence for signing
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                //TODO sound too
+                feedbackGenerator.notificationOccurred(.success)
+            }
+        case .failure:
+            break
         }
     }
 }

--- a/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
@@ -159,6 +159,15 @@ class RequestViewController: UIViewController {
 		hud.mode = .text
 		hud.label.text = viewModel.addressCopiedText
 		hud.hide(animated: true, afterDelay: 1.5)
+		
+		showFeedback()
+	}
+
+	private func showFeedback() {
+		//TODO sound too
+		let feedbackGenerator = UINotificationFeedbackGenerator()
+		feedbackGenerator.prepare()
+		feedbackGenerator.notificationOccurred(.success)
 	}
 
 	func generateQRCode(from string: String) -> UIImage? {


### PR DESCRIPTION
* Sign a message/transaction
* Send a payment
* Copy Ethereum address

(only activates for iPhone 7 and later, and not any iPads)