### PR TITLE
Fix baseline alignment of long token names in Wallet tab when the token name font size automatically shrink to fit

### DIFF
--- a/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
@@ -90,6 +90,7 @@ class EthTokenViewCell: UITableViewCell {
         titleLabel.font = viewModel.titleFont
         titleLabel.text = "\(viewModel.amount) \(viewModel.title)"
         titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.baselineAdjustment = .alignCenters
 
         blockChainTagLabel.textAlignment = viewModel.blockChainNameTextAlignment
         blockChainTagLabel.cornerRadius = 7

--- a/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
@@ -65,6 +65,7 @@ class FungibleTokenViewCell: UITableViewCell {
         titleLabel.font = viewModel.titleFont
         titleLabel.text = "\(viewModel.amount) \(viewModel.title)"
         titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.baselineAdjustment = .alignCenters
 
         blockChainTagLabel.textAlignment = viewModel.blockChainNameTextAlignment
         blockChainTagLabel.cornerRadius = 7

--- a/AlphaWallet/Tokens/Views/NonFungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/NonFungibleTokenViewCell.swift
@@ -66,6 +66,7 @@ class NonFungibleTokenViewCell: UITableViewCell {
         titleLabel.font = viewModel.titleFont
         titleLabel.text = "\(viewModel.amount) \(viewModel.title)"
         titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.baselineAdjustment = .alignCenters
 
         blockChainTagLabel.textAlignment = viewModel.blockChainNameTextAlignment
         blockChainTagLabel.cornerRadius = 7


### PR DESCRIPTION
Compare the position of the tiny token names before and after the PR:

Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/63677509-aa681500-c81f-11e9-8a79-77c757e69129.png" width=200> | <img src="https://user-images.githubusercontent.com/56189/63677437-8c9ab000-c81f-11e9-9560-9d0e6c456f2f.png" width=200>