### PR TITLE
Fix: parts of function body should be in the caller instead for correct semantics

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -64,24 +64,23 @@ class SignMessageCoordinator: Coordinator {
                 result = keystore.signTypedMessage(typedData, for: account)
             }
         }
-        showFeedbackOnSuccess(result)
-    }
-
-    private func showFeedbackOnSuccess(_ result: Result<Data, KeystoreError>) {
         switch result {
         case .success(let data):
-            //TODO sound too
-            let feedbackGenerator = UINotificationFeedbackGenerator()
-            feedbackGenerator.prepare()
-            //Hackish, but delay necessary because of the switch to and from user-presence for signing
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                feedbackGenerator.notificationOccurred(.success)
-            }
-
+            showFeedback()
             didComplete?(.success(data))
         case .failure(let error):
             navigationController.displaySuccess(message: error.errorDescription)
             didComplete?(.failure(AnyError(error)))
+        }
+    }
+
+    private func showFeedback() {
+        //TODO sound too
+        let feedbackGenerator = UINotificationFeedbackGenerator()
+        feedbackGenerator.prepare()
+        //Hackish, but delay necessary because of the switch to and from user-presence for signing
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            feedbackGenerator.notificationOccurred(.success)
         }
     }
 }


### PR DESCRIPTION
No functional change.

Before this PR, the function name did more than its name suggested.