### PR TITLE
Fix: clear textbox and hides clear button in verify seed phrase screen after we auto-clear shuffled seed phrase (from app going to background)

### DIFF
--- a/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
@@ -57,6 +57,9 @@ class VerifySeedPhraseViewController: UIViewController {
                 seedPhraseTextView.borderColor = viewModel.seedPhraseTextViewBorderErrorColor
             case .notDisplayedSeedPhrase:
                 seedPhraseCollectionView.viewModel = .init(words: [], isSelectable: true)
+                seedPhraseTextView.text = ""
+                clearChooseSeedPhraseButton.isHidden = true
+                continueButton.isEnabled = false
             case .errorDisplaySeedPhrase(let error):
                 seedPhraseCollectionView.viewModel = .init(words: [], isSelectable: true)
                 errorLabel.text = error.errorDescription


### PR DESCRIPTION
Fixes #1394

If we tap 1 or more words in the verify seed phrase screen and then switch to another app or home screen and switch back to AlphaWallet:

Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/63826664-cc35d900-c992-11e9-9552-c07db61d9414.png" width=200> | <img src="https://user-images.githubusercontent.com/56189/63826665-cc35d900-c992-11e9-993e-8a552c6c5b4b.png" width=200>