### PR TITLE
Fix baseline alignment of long button names in green action buttons when the font size automatically shrink to fit

### DIFF
--- a/AlphaWallet/UI/ButtonsBar.swift
+++ b/AlphaWallet/UI/ButtonsBar.swift
@@ -93,7 +93,11 @@ class ButtonsBar: UIView {
     }
 
     private static func bar(numberOfButtons: Int) -> [ContainerViewWithShadow<UIButton>] {
-        return (0..<numberOfButtons).map { _ in ContainerViewWithShadow(aroundView: UIButton(type: .system)) }
+         return (0..<numberOfButtons).map { _ in
+             let button = UIButton(type: .system)
+             button.titleLabel?.baselineAdjustment = .alignCenters
+             return ContainerViewWithShadow(aroundView: button)
+         }
     }
 }
 


### PR DESCRIPTION
Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/64319396-dab56d80-cfee-11e9-80f4-bf5138f1ec7e.png" width=200> | <img src="https://user-images.githubusercontent.com/56189/64319397-dab56d80-cfee-11e9-95c1-844710e3c038.png" width=200>