### PR TITLE
Only accept erc721 from OpenSea

### DIFF
--- a/AlphaWallet/Core/Initializers/MigrationInitializer.swift
+++ b/AlphaWallet/Core/Initializers/MigrationInitializer.swift
@@ -15,7 +15,7 @@ class MigrationInitializer: Initializer {
     }
 
     func perform() {
-        config.schemaVersion = 3
+        config.schemaVersion = 4
         config.migrationBlock = { migration, oldSchemaVersion in
             if oldSchemaVersion < 2 {
                 //Fix bug created during multi-chain implementation. Where TokenObject instances are created from transfer Transaction instances, with the primaryKey as a empty string; so instead of updating an existing TokenObject, a duplicate TokenObject instead was created but with primaryKey empty
@@ -35,6 +35,17 @@ class MigrationInitializer: Initializer {
                     guard let _ = oldObject else { return }
                     guard let newObject = newObject else { return }
                     newObject["isERC20Interaction"] = false 
+                }
+            }
+        }
+        config.migrationBlock = { migration, oldSchemaVersion in
+            if oldSchemaVersion < 4 {
+                migration.enumerateObjects(ofType: TokenObject.className()) { oldObject, newObject in
+                    guard let oldObject = oldObject else { return }
+                    guard let newObject = newObject else { return }
+                    //Fix bug introduced when OpenSea suddenly includes the DAI stablecoin token in their results with an existing versioned API endpoint, and we wrongly tagged it as ERC721, possibly crashing when we fetch the balance (casting a very large ERC20 balance with 18 decimals to an Int)
+                    guard let contract = oldObject["contract"] as? String, contract == "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359" else { return }
+                    newObject["rawType"] = "ERC20"
                 }
             }
         }

--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -95,6 +95,8 @@ class OpenSea {
                 var results = sum
                 var currentPageCount = 0
                 for (_, each): (String, JSON) in json["assets"] {
+                    let type = each["asset_contract"]["schema_name"].stringValue
+                    guard type == "ERC721" else { continue }
                     let tokenId = each["token_id"].stringValue
                     let contractName = each["asset_contract"]["name"].stringValue
                     let symbol = each["asset_contract"]["symbol"].stringValue


### PR DESCRIPTION
Fixes #1427 

This PR

* makes the app only accept ERC721 from OpenSea API
* adds a migration to fix the DAI token which is wrongly tagged as ERC721
