### PR TITLE
Fix: Clear button in Verify Seed Phrase screen overlaps with seed phrases on short screens

### DIFF
--- a/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
@@ -118,7 +118,7 @@ class VerifySeedPhraseViewController: UIViewController {
             seedPhraseTextView,
             UIView.spacer(height: 7),
             errorLabel,
-            UIView.spacer(height: 30),
+            UIView.spacer(height: 24),
             seedPhraseCollectionView,
         ].asStackView(axis: .vertical)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -146,7 +146,7 @@ class VerifySeedPhraseViewController: UIViewController {
 
             clearChooseSeedPhraseButton.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor, constant: 10),
             clearChooseSeedPhraseButton.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor, constant: -10),
-            clearChooseSeedPhraseButton.bottomAnchor.constraint(equalTo: footerBar.topAnchor, constant: -20),
+            clearChooseSeedPhraseButton.bottomAnchor.constraint(equalTo: footerBar.topAnchor, constant: -10),
 
             buttonsBar.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor),
             buttonsBar.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor),


### PR DESCRIPTION
It's easy to accidentally hit the clear button when trying to tap the seed phrases in the last row on short screens. This is before the PR:

<img src="https://user-images.githubusercontent.com/56189/64469753-26405680-d16a-11e9-8d9d-aed34599c666.png" width=200>
