### PR TITLE
ensure overflowed integers on 721 balance count doesn't break

### DIFF
--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -281,7 +281,11 @@ class TokensDataStore {
         getERC721BalanceCoordinator.getERC721TokenBalance(for: account.address, contract: address) { result in
             switch result {
             case .success(let balance):
-                completion(.success([String](repeating: "0", count: Int(balance))))
+                if balance >= Int.max {
+                    completion(.failure(AnyError(Web3Error(description: ""))))
+                } else {
+                    completion(.success([String](repeating: "0", count: Int(balance))))
+                }
             case .failure(let error):
                 completion(.failure(error))
             }


### PR DESCRIPTION
This broke on Victor's phone, check if the max value is reached and if it has fail rather than crash (my try-catch block didn't work on this exception for some reason)

This only effects 721 tokens that are not supported by OpenSea