### PR TITLE
Fix: addresses are not encoded correctly in certain transactions

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/ClaimOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimOrderCoordinator.swift
@@ -78,7 +78,7 @@ class ClaimOrderCoordinator {
                              completion: @escaping (Result<Data, AnyError>) -> Void) {
 
         do {
-            let parameters: [Any] = [expiry, tokenIds, BigUInt(v), Data(hex: r), Data(hex: s), recipient as Any]
+            let parameters: [Any] = [expiry, tokenIds, BigUInt(v), Data(hex: r), Data(hex: s), TrustKeystore.Address(address:  recipient)]
             let functionEncoder = Function(name: "spawnPassTo", parameters: [
                 .uint(bits: 256),
                 .dynamicArray(.uint(bits: 256)),

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -141,7 +141,7 @@ class TransactionConfigurator {
             }
         case .ERC875Token(let token):
             do {
-                let parameters: [Any] = [transaction.to!, transaction.indices!.map({ BigUInt($0) })]
+                let parameters: [Any] = [TrustKeystore.Address(address: transaction.to!), transaction.indices!.map({ BigUInt($0) })]
                 let arrayType: ABIType
                 if token.contractAddress.isLegacy875Contract {
                     arrayType = ABIType.uint(bits: 16)
@@ -204,10 +204,10 @@ class TransactionConfigurator {
                 let parameters: [Any]
                 if transaction.to!.isLegacy721Contract {
                     function = Function(name: "transfer", parameters: [.address, .uint(bits: 256)])
-                    parameters = [transaction.to!, BigUInt(transaction.tokenId!)!]
+                    parameters = [TrustKeystore.Address(address: transaction.to!), BigUInt(transaction.tokenId!)!]
                 } else {
                     function = Function(name: "safeTransferFrom", parameters: [.address, .address, .uint(bits: 256)])
-                    parameters = [self.account.address, transaction.to!, BigUInt(transaction.tokenId!)!]
+                    parameters = [TrustKeystore.Address(address: self.account.address), transaction.to!, BigUInt(transaction.tokenId!)!]
                 }
                 let encoder = ABIEncoder()
                 try encoder.encode(function: function, arguments: parameters)


### PR DESCRIPTION
Should partially help with #1438 but seems to be insufficient.

Encoding failure is definitely a problem (so this PR still can go through by itself if it passes review), but while transferring a FIFA ticket token on 0x007 Ropsten, it fails for some mysterious reason after making it past encoding.