### PR TITLE
Fix: crash when user taps http(s)://aw.app(/)

### DIFF
--- a/AlphaWallet/Market/UniversalLinkHandler.swift
+++ b/AlphaWallet/Market/UniversalLinkHandler.swift
@@ -74,6 +74,7 @@ public class UniversalLinkHandler {
 
     //link has shortened price and expiry and must be expanded
     func parseUniversalLink(url: String, prefix: String) -> SignedOrder? {
+        guard url.count > prefix.count else { return nil }
         let linkInfo = b64SafeEncodingToRegularEncoding(url.substring(from: prefix.count))
         guard var linkBytes = Data(base64Encoded: linkInfo)?.array else { return nil }
         let encodingByte = linkBytes[0]

--- a/AlphaWalletTests/Market/UniversalLinkHandlerTests.swift
+++ b/AlphaWalletTests/Market/UniversalLinkHandlerTests.swift
@@ -43,4 +43,12 @@ class UniversalLinkHandlerTests: XCTestCase {
 //        let url = UniversalLinkHandler().createUniversalLink(signedOrder: signedOrder[0])
     }
 
+    func testUniversalLinkParserDoesNotCrashWhenInvalid() {
+        let server: RPCServer = .main
+        let parser = UniversalLinkHandler(server: server)
+        XCTAssertNil(parser.parseUniversalLink(url: "https://aw.app/", prefix: RPCServer.main.magicLinkPrefix.absoluteString))
+        XCTAssertNil(parser.parseUniversalLink(url: "https://aw.app", prefix: RPCServer.main.magicLinkPrefix.absoluteString))
+        XCTAssertNil(parser.parseUniversalLink(url: "http://aw.app", prefix: RPCServer.main.magicLinkPrefix.absoluteString))
+        XCTAssertNil(parser.parseUniversalLink(url: "http://aw.app/", prefix: RPCServer.main.magicLinkPrefix.absoluteString))
+    }
 }


### PR DESCRIPTION
Tap http://aw.app or https://aw.app on iOS simulator/device.