### PR TITLE
Fix: crash when etherscan API returns malformed ERC20 transfer transaction data, with missing `to`

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -4684,7 +4684,7 @@
 			buildSettings = {
 				ALPHAWALLET_INFO_PLIST_FILE = AlphaWallet/Info.plist;
 				ALPHAWALLET_PRODUCT_BUNDLE_IDENTIFIER = com.stormbird.alphawallet;
-				ALPHAWALLET_PRODUCT_NAME = "AlphaWallet";
+				ALPHAWALLET_PRODUCT_NAME = AlphaWallet;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = AlphaWallet/AlphaWallet.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4703,7 +4703,6 @@
 					"\"$(PODS_ROOT)/libsodium/src/libsodium/include/sodium\"",
 					"\"$(PODS_ROOT)/libsodium/src/libsodium/include\"",
 				);
-				INFOPLIST_FILE = AlphaWallet/Info.plist;
 				INFOPLIST_FILE = "$(ALPHAWALLET_INFO_PLIST_FILE)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -D DEBUG";
@@ -4725,7 +4724,7 @@
 			buildSettings = {
 				ALPHAWALLET_INFO_PLIST_FILE = AlphaWallet/Info.plist;
 				ALPHAWALLET_PRODUCT_BUNDLE_IDENTIFIER = com.stormbird.alphawallet;
-				ALPHAWALLET_PRODUCT_NAME = "AlphaWallet";
+				ALPHAWALLET_PRODUCT_NAME = AlphaWallet;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = AlphaWallet/AlphaWallet.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -4744,7 +4743,6 @@
 					"\"$(PODS_ROOT)/libsodium/src/libsodium/include/sodium\"",
 					"\"$(PODS_ROOT)/libsodium/src/libsodium/include\"",
 				);
-				INFOPLIST_FILE = AlphaWallet/Info.plist;
 				INFOPLIST_FILE = "$(ALPHAWALLET_INFO_PLIST_FILE)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(ALPHAWALLET_PRODUCT_BUNDLE_IDENTIFIER)";

--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -18,9 +18,15 @@ struct RawTransaction: Decodable {
     let gasUsed: String
     let error: String?
 
-    var toAddress: AlphaWallet.Address {
+    ///
+    ///It is possible for the etherscan.io API to return an empty `to` even if the transaction actually has a `to`. It doesn't seem to be linked to `"isError" = "1"`, because other transactions that fail (with isError="1") has a non-empty `to`.
+    ///
+    ///Eg. transaction with an empty `to` in API despite `to` is shown as non-empty in the etherscan.io web page:https: //ropsten.etherscan.io/tx/0x0c87d2acb0ecaf1221e599ad4f65edf77c97956d6534feb0afa68ee5c41c4e28
+    ///
+    ///So it must be a optional
+    var toAddress: AlphaWallet.Address? {
         //TODO We use the unchecked version because it was easier to provide an Address instance this way. Good to remove it
-        return AlphaWallet.Address(uncheckedAgainstNullAddress: to)!
+        return AlphaWallet.Address(uncheckedAgainstNullAddress: to)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -94,8 +100,7 @@ extension Transaction {
             let amount = BigInt(amount1, radix: 16)
             //Extract the address and strip the first 12 (x2 = 24) characters of 0s
             let to = "0x\(transaction.input[transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 24)..<transaction.input.index(transaction.input.startIndex, offsetBy: 10 + 64)])"
-            if let amount = amount, let to = AlphaWallet.Address(string: to)?.eip55String {
-                let contract = transaction.toAddress
+            if let amount = amount, let contract = transaction.toAddress, let to = AlphaWallet.Address(string: to)?.eip55String {
                 if let token = tokensStorage.token(forContract: contract) {
                     let operationType = mapTokenTypeToTransferOperationType(token.type)
                     let result = LocalizedOperationObject(from: transaction.from, to: to, contract: contract, type: operationType.rawValue, value: String(amount), symbol: token.symbol, name: token.name, decimals: token.decimals)

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -38,7 +38,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12</string>
+	<string>2.14</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -59,7 +59,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>300</string>
+	<string>304</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Fixes #1449 

This particular transaction https://ropsten.etherscan.io/tx/0x0c87d2acb0ecaf1221e599ad4f65edf77c97956d6534feb0afa68ee5c41c4e28

There should be a "to" value.

Anyway, it reminds us that forced unwraps are bad :)