### PR TITLE
Fix: OpenSea calls aren't made for the correct servers if both mainnet and Rinkeby are enabled

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -398,7 +398,7 @@ class InCoordinator: NSObject, Coordinator {
         coordinator.navigationController.dismiss(animated: true, completion: nil)
         coordinator.stop()
         removeAllCoordinators()
-        OpenSea.sharedInstance.reset()
+        OpenSea.resetInstances()
         showTabBar(for: account)
         fetchXMLAssetDefinitions()
         listOfBadTokenScriptFilesChanged(fileNames: assetDefinitionStore.listOfBadTokenScriptFiles + assetDefinitionStore.listOfConflictingTokenScriptFiles)

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -69,6 +69,7 @@ class TokensDataStore {
     }
     private var isFetchingPrices = false
     private let config: Config
+    private let openSea: OpenSea
 
     let server: RPCServer
     weak var delegate: TokensDataStoreDelegate?
@@ -145,6 +146,7 @@ class TokensDataStore {
         self.config = config
         self.assetDefinitionStore = assetDefinitionStore
         self.realm = realm
+        self.openSea = OpenSea.createInstance(forServer: server)
         self.addEthToken()
 
         //TODO not needed for setupCallForAssetAttributeCoordinators? Look for other callers of DataStore.updateDelegate
@@ -294,7 +296,7 @@ class TokensDataStore {
 
     private func getTokensFromOpenSea() -> OpenSea.PromiseResult {
         //TODO when we no longer create multiple instances of TokensDataStore, we don't have to use singleton for OpenSea class. This was to avoid fetching multiple times from OpenSea concurrently
-        return OpenSea.sharedInstance.makeFetchPromise(server: server, owner: account.address)
+        return openSea.makeFetchPromise(forOwner: account.address)
     }
 
     func getTokenType(for address: AlphaWallet.Address,


### PR DESCRIPTION
Fixes #1450

Before this PR, OpenSea API calls (for mainnet and Rinkeby) always takes results from either network (mainnet or Rinkeby, might be random) only. Because tokens on one network aren't present on the other network with the same contract (and hence balance 0) and because we encode the ERC721 token details obtained from OpenSea into the balance, the app thinks that they aren't ERC721 and render them wrongly (as ERC875).