### PR TITLE
In Dapp browser, fallback to first enabled network when selected network is disabled in the app

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -76,7 +76,15 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
 
     private var server: RPCServer {
         get {
-            return .init(chainID: Config.getChainId())
+            let selected = RPCServer(chainID: Config.getChainId())
+            let enabled = config.enabledServers
+            if enabled.contains(selected) {
+                return selected
+            } else {
+                let fallback = enabled[0]
+                server = fallback
+                return fallback
+            }
         }
         set {
             Config.setChainId(newValue.chainID)


### PR DESCRIPTION
Fixes #1453 