### PR TITLE
Show green tick after action succeeds for user feedback

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -271,6 +271,10 @@ extension TokenInstanceActionViewController: TokenInstanceWebViewDelegate {
     }
 
     func shouldClose(tokenInstanceWebView: TokenInstanceWebView) {
+        //Bit of delay to wait for the UI animation to almost finish
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            SuccessOverlayView.show()
+        }
         delegate?.shouldCloseFlow(inViewController: self)
     }
 }


### PR DESCRIPTION
Closes #1454 

Like this:

Before Confirm|After Confirm and successful|
-|-
<img src="https://user-images.githubusercontent.com/56189/65128506-2bd05300-da2c-11e9-9e31-c2de6ccdbe5a.png" width=200>|<img src="https://user-images.githubusercontent.com/56189/65128507-2c68e980-da2c-11e9-8017-4f6bd87461cc.png" width=200>