### PR TITLE
Cache tokenscript sig verification status

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
@@ -14,6 +14,8 @@ protocol AssetDefinitionBackingStore {
     func isCanonicalized(contract: AlphaWallet.Address) -> Bool
     func hasConflictingFile(forContract contract: AlphaWallet.Address) -> Bool
     func hasOutdatedTokenScript(forContract contract: AlphaWallet.Address) -> Bool
+    func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType?
+    func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String)
 }
 
 protocol AssetDefinitionBackingStoreDelegate: class {

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -91,7 +91,7 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
                 }
             }
         }
-
+        tokenScriptFileIndices.copySignatureVerificationTypes(previousTokenScriptFileIndices.signatureVerificationTypes)
         writeIndicesToDisk()
     }
 
@@ -165,6 +165,15 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
 
     func hasOutdatedTokenScript(forContract contract: AlphaWallet.Address) -> Bool {
         return !tokenScriptFileIndices.contractsToOldTokenScriptFileNames[contract].isEmpty
+    }
+
+    func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType? {
+        return tokenScriptFileIndices.signatureVerificationTypes[tokenScriptFileIndices.hash(contents: xmlString)]
+    }
+
+    func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
+        tokenScriptFileIndices.signatureVerificationTypes[tokenScriptFileIndices.hash(contents: xmlString)] = verificationType
+        tokenScriptFileIndices.write(toUrl: indicesFileUrl)
     }
 
     func lastModifiedDateOfCachedAssetDefinitionFile(forContract contract: AlphaWallet.Address) -> Date? {

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
@@ -17,6 +17,7 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
         return officialStore.conflictingTokenScriptFileNames + overridesStore.conflictingTokenScriptFileNames
     }
 
+
     init(overridesStore: AssetDefinitionBackingStore? = nil) {
         if let overridesStore = overridesStore {
             self.overridesStore = overridesStore
@@ -91,6 +92,22 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
             if !overriddenContracts.contains(contract) {
                 body(contract)
             }
+        }
+    }
+
+    func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType? {
+        return overridesStore.getCacheTokenScriptSignatureVerificationType(forXmlString: xmlString) ?? officialStore.getCacheTokenScriptSignatureVerificationType(forXmlString: xmlString)
+    }
+
+    ///The implementation assumes that we never verifies the signature files in the official store when there's an override available
+    func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
+        if let xml = overridesStore[contract], xml == xmlString {
+            overridesStore.writeCacheTokenScriptSignatureVerificationType(verificationType, forContract: contract, forXmlString: xmlString)
+            return
+        }
+        if let xml = officialStore[contract], xml == xmlString {
+            officialStore.writeCacheTokenScriptSignatureVerificationType(verificationType, forContract: contract, forXmlString: xmlString)
+            return
         }
     }
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
@@ -48,4 +48,12 @@ class AssetDefinitionInMemoryBackingStore: AssetDefinitionBackingStore {
     func hasOutdatedTokenScript(forContract contract: AlphaWallet.Address) -> Bool {
         return false
     }
+
+    func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType? {
+        return nil
+    }
+
+    func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
+        //do nothing
+    }
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -193,6 +193,14 @@ class AssetDefinitionStore {
     func invalidateSignatureStatus(forContract contract: AlphaWallet.Address) {
         subscribers.forEach { $0(contract) }
     }
+
+    func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType? {
+        return backingStore.getCacheTokenScriptSignatureVerificationType(forXmlString: xmlString)
+    }
+
+    func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
+        return backingStore.writeCacheTokenScriptSignatureVerificationType(verificationType, forContract: contract, forXmlString: xmlString)
+    }
 }
 
 extension AssetDefinitionStore: AssetDefinitionBackingStoreDelegate {

--- a/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
+++ b/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
@@ -13,6 +13,7 @@ struct TokenScriptFileIndices: Codable {
     }
 
     var fileHashes = [FileName: FileContentsHash]()
+    var signatureVerificationTypes = [FileContentsHash: TokenScriptSignatureVerificationType]()
     var contractsToFileNames = [AlphaWallet.Address: [FileName]]()
     var contractsToEntities = [FileName: [Entity]]()
     var badTokenScriptFileNames = [FileName]()
@@ -88,6 +89,13 @@ struct TokenScriptFileIndices: Codable {
     static func load(fromUrl url: URL) -> TokenScriptFileIndices? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         return try? JSONDecoder().decode(TokenScriptFileIndices.self, from: data)
+    }
+
+    mutating func copySignatureVerificationTypes(_ oldVerificationTypes: [FileContentsHash: TokenScriptSignatureVerificationType]) {
+        signatureVerificationTypes = .init()
+        for eachHash in fileHashes.values {
+            signatureVerificationTypes[eachHash] = oldVerificationTypes[eachHash]
+        }
     }
 }
 

--- a/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
+++ b/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
@@ -30,7 +30,7 @@ struct TokenScriptFileIndices: Codable {
     }
 
     mutating func trackHash(forFile fileName: FileName, contents: String) {
-        fileHashes[fileName] = contents.djb2hash
+        fileHashes[fileName] = hash(contents: contents)
     }
 
     mutating func removeHash(forFile fileName: FileName) {


### PR DESCRIPTION
So the cached status is available even if the network is slow or totally offline. Caching uses file contents hash as the key so it should be good until we add the ability to revoke certs (which we can't until we support other kinds of methods of signing).

Addresses part of #1464 

One important flow to test for is:

1. Drop a TokenScript override file in
2. Tap to open the token the TokenScript file is for
3. Wait till signature is verified
4. Switch off network
5. Launch app and open token to check cached signature is available offline
6. Switch on network
7. Change the TokenScript file so that the signature is wrong
8. Verify that the status shows that the signature is invalid
9. Replace with old TokenScript file (which has a correct signature)
10. Verify signature is shown as valid.

In case the caching breaks the proper signature verification checks.