### PR TITLE
Fix: navigation bar and status bar color is wrong (black) for Wallet tab when search bar is visible in iOS 13.1

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -187,6 +187,7 @@ class TokensViewController: UIViewController {
         super.viewWillAppear(animated)
         navigationController?.applyTintAdjustment()
         fetch()
+        fixNavigationBarAndStatusBarBackgroundColorForiOS13Dot1()
     }
 
     @objc func pullToRefresh() {
@@ -554,6 +555,10 @@ extension TokensViewController {
         let v = UIView()
         v.backgroundColor = Colors.appBackground
         tableView.backgroundView = v
+    }
+
+    private func fixNavigationBarAndStatusBarBackgroundColorForiOS13Dot1() {
+        view.superview?.backgroundColor = Colors.appBackground
     }
 
     private func setupFilteringWithKeyword() {


### PR DESCRIPTION
Fixes #1423 

Issue might only be for iOS 13.1 beta (but it has happened for all 4 betas) and iOS 13.1 public release is imminent.

Hackish, but seems safe for other OS versions. 