### PR TITLE
Fix: when displaying token in import MagicLink UI, the section attribute is displayed wrongly

### DIFF
--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
@@ -143,7 +143,7 @@ struct ImportMagicTokenViewControllerViewModel {
     var match: String {
         guard let tokenHolder = tokenHolder else { return "" }
         if tokenHolder.values["section"] != nil {
-            if let section = tokenHolder.values["section"] {
+            if let section = tokenHolder.values["section"]?.stringValue {
                 return "S\(section)"
             } else {
                 return "S0"


### PR DESCRIPTION
Fixes #1474 

(Would not have happened if this had a snapshot test)

Before PR|After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/65658663-3e194500-e05b-11e9-8309-1c8425246289.jpg" width=200> | <img src="https://user-images.githubusercontent.com/56189/65658751-951f1a00-e05b-11e9-8615-ff80f4dd0f84.png" width=200>