### PR TITLE
Fix: crash due to infinite recursion when dapp browser's selected network is not in enabled list

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -82,7 +82,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
                 return selected
             } else {
                 let fallback = enabled[0]
-                server = fallback
+                Config.setChainId(fallback.chainID)
                 return fallback
             }
         }


### PR DESCRIPTION
Happens if we disable the server that is dapp browser's current selection