### PR TITLE
Fix: override TokenScript file with new schema is ignored if there's an official version with an old schema

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
@@ -68,12 +68,10 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
     }
 
     func hasOutdatedTokenScript(forContract contract: AlphaWallet.Address) -> Bool {
-        let official = officialStore.hasOutdatedTokenScript(forContract: contract)
-        let overrides = overridesStore.hasOutdatedTokenScript(forContract: contract)
-        if overrides {
-            return true
+        if overridesStore[contract] != nil {
+            return overridesStore.hasOutdatedTokenScript(forContract: contract)
         } else {
-            return official
+            return officialStore.hasOutdatedTokenScript(forContract: contract)
         }
     }
 


### PR DESCRIPTION
Fixes #1496 