### PR TITLE
Remove hardcoded app store URL for the app as we can use SKStoreReviewController because of our min deployment target setting

### DIFF
--- a/AlphaWallet/Settings/Coordinators/HelpUsCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/HelpUsCoordinator.swift
@@ -30,9 +30,7 @@ class HelpUsCoordinator: Coordinator {
     }
 
     func rateUs() {
-        if #available(iOS 10.3, *) { SKStoreReviewController.requestReview() } else {
-            UIApplication.shared.open(URL(string: Constants.appstoreURL)!, options: [:])
-        }
+        SKStoreReviewController.requestReview()
         appTracker.completedRating = true
     }
 

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -39,7 +39,6 @@ public struct Constants {
     public static let twitterUsername = "AlphaWallet"
     public static let redditGroupName = "r/AlphaWallet/"
     public static let facebookUsername = "AlphaWallet"
-    public static let appstoreURL = "itms-apps://itunes.apple.com/app/id1358230430"
 
     // support
     public static let supportEmail = "feedback+ios@alphawallet.com"


### PR DESCRIPTION
Very old versions of the app supported iOS 10 which did not have access to `SKStoreReviewController`. No longer a constraint.