### PR TITLE
Fix: default tokens shows balance of 0 momentarily shortly after startup

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -264,13 +264,15 @@ class SingleChainTokenCoordinator: Coordinator {
                 strongSelf.storage.addCustom(token: token)
                 completion()
             case .fungibleTokenComplete(let name, let symbol, let decimals):
+                //We re-use the existing balance value to avoid the Wallets tab showing that token (if it already exist) as balance = 0 momentarily
+                let value = strongSelf.storage.enabledObject.first(where: { $0.contractAddress == contract })?.value ?? "0"
                 let token = TokenObject(
                         contract: contract,
                         server: strongSelf.session.server,
                         name: name,
                         symbol: symbol,
                         decimals: Int(decimals),
-                        value: "0",
+                        value: value,
                         type: .erc20
                 )
                 strongSelf.storage.add(tokens: [token])


### PR DESCRIPTION
Before the PR:

1. We know a fungible token (eg. Discover) has a balance of X and the local database stores it as such
2. App is launched again (killed or out of memory previously)
3. App adds default tokens and it shows up as balance = 0 briefly
4. Balance goes to X (or whatever is the current value)

After PR:

1. We know a fungible token (eg. Discover) has a balance of X and the local database stores it as such
2. App is launched again (killed or out of memory previously)
3. App adds default tokens and it shows up as balance = X
4. Balance remains as X or updates to the current value if it's changed.

