### PR TITLE
Fix: Must only return the last modified date for a file if it's for the current schema version otherwise, a file using the old schema might have a more recent timestamp (because it was recently downloaded) than a newer version on the server (which was not yet made available by the time the user downloaded the version with the old schema)

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -176,10 +176,12 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
         tokenScriptFileIndices.write(toUrl: indicesFileUrl)
     }
 
+    //Must only return the last modified date for a file if it's for the current schema version otherwise, a file using the old schema might have a more recent timestamp (because it was recently downloaded) than a newer version on the server (which was not yet made available by the time the user downloaded the version with the old schema)
     func lastModifiedDateOfCachedAssetDefinitionFile(forContract contract: AlphaWallet.Address) -> Date? {
         assert(isOfficial)
         let path = localURLOfXML(for: contract)
         guard let lastModified = try? path.resourceValues(forKeys: [.contentModificationDateKey]) else { return nil }
+        guard XMLHandler.isTokenScriptSupportedSchemaVersion(path) else { return nil }
         return lastModified.contentModificationDate
     }
 

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -718,6 +718,19 @@ public class XMLHandler {
         }
     }
 
+    static func isTokenScriptSupportedSchemaVersion(_ url: URL) -> Bool {
+        switch XMLHandler.checkTokenScriptSchema(forPath: url) {
+        case .supportedTokenScriptVersion:
+            return true
+        case .unsupportedTokenScriptVersion:
+            return false
+        case .unknownXml:
+            return false
+        case .others:
+            return false
+        }
+    }
+
     static func checkTokenScriptSchema(_ contents: String) -> TokenScriptSchema {
         //It's fine to have a file that is empty. A CSS file for example. But we should expect the input to be XML
         if let xml = try? Kanna.XML(xml: contents, encoding: .utf8) {


### PR DESCRIPTION
Fixes #1527 

This PR fixes this problem:

1. `2019/10` TokenScript files made available on repo server with timestamp `T`
2. User runs app which works with `2019/05` and downloads TokenScript files using 2019/05, writing to disk with timestamp `T+1`
3. User upgrades to app using `2019/10`
4. App asks repo server for `2019/10` version of the files, sending last modified timestamp of `2019/05` as `T+1`, so server tells app that app already has the latest version