### PR TITLE
Preserve value when switching between crypto native and fiat amounts

### DIFF
--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -141,9 +141,10 @@ class AmountTextField: UIControl {
 
     @objc func fiatAction(button: UIButton) {
         guard cryptoToDollarRate != nil else { return }
+        let oldAlternateAmount = convertToAlternateAmount()
         currentPair = currentPair.swapPair()
         updateFiatButtonTitle()
-        textField.text = nil
+        textField.text = oldAlternateAmount
         computeAlternateAmount()
         activateAmountView()
         delegate?.changeType(in: self)

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -141,9 +141,7 @@ class AmountTextField: UIControl {
 
     @objc func fiatAction(button: UIButton) {
         guard cryptoToDollarRate != nil else { return }
-        let swappedPair = currentPair.swapPair()
-        //New pair for future calculation we should swap pair each time we press fiat button.
-        currentPair = swappedPair
+        currentPair = currentPair.swapPair()
         updateFiatButtonTitle()
         textField.text = nil
         computeAlternateAmount()


### PR DESCRIPTION
Fixes #1536 

Before this PR:

1. Go to send Ether
2. Enter 1 ETH
3. Tap USD
4. Textbox is cleared

After this PR:

4. Textbox shows 180 (the current value of 1 ETH)

I can rebase after #1535 if there are conflicts.