### PR TITLE
Display ERC 20 token name from TokenScript file instead of the contract in the send screen (like in the Wallet tab), if the file is available

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -153,7 +153,8 @@ class TokenViewController: UIViewController {
         case .ERC20Token(let token, _, _):
             let viewModel = BalanceTokenViewModel(token: token)
             let amount = viewModel.amountShort
-            headerViewModel.title = "\(amount) \(viewModel.name) (\(viewModel.symbol))"
+            //Note that if we want to display the token name directly from token.name, we have to be careful that DAI token's name has trailing \0
+            headerViewModel.title = "\(amount) \(token.titleInPluralForm(withAssetDefinitionStore: assetDefinitionStore))"
             let etherToken = TokensDataStore.etherToken(forServer: session.server)
             let ticker = tokensDataStore.coinTicker(for: etherToken)
             headerViewModel.ticker = ticker

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -254,7 +254,8 @@ class SendViewController: UIViewController, CanScanQRCode {
         case .ERC20Token(let token, _, _):
             let viewModel = BalanceTokenViewModel(token: token)
             let amount = viewModel.amountShort
-            headerViewModel.title = "\(amount) \(viewModel.name) (\(viewModel.symbol))"
+            //Note that if we want to display the token name directly from token.name, we have to be careful that DAI token's name has trailing \0
+            headerViewModel.title = "\(amount) \(token.titleInPluralForm(withAssetDefinitionStore: assetDefinitionStore))"
             let etherToken = TokensDataStore.etherToken(forServer: session.server)
             let ticker = storage.coinTicker(for: etherToken)
             headerViewModel.ticker = ticker


### PR DESCRIPTION
Fixes #1472 

Before this PR, for an ERC 20 token with TokenScript file (example DAI):

* Wallet tab displays token name from TokenScript file
* Send screen displays token name returned by the contract