### PR TITLE
Fix: DAI token symbol is shown with a missing trailing parenthesis in the Wallet tab

### DIFF
--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -98,7 +98,14 @@ class TokenObject: Object {
         if compositeName.isEmpty {
             return symbol
         } else {
-            return "\(compositeName) (\(symbol))"
+            let daiSymbol = "DAI\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}"
+            //We could have just trimmed away all trailing \0, but this is faster and safer since only DAI seems to have this problem
+            if daiSymbol == symbol {
+                return "\(compositeName) (DAI)"
+            } else {
+                return "\(compositeName) (\(symbol))"
+            }
+
         }
     }
 


### PR DESCRIPTION
Fixes #1443, #1540 

Before this PR, this is shown in the wallet tab:

"0x0255 DAI (DAI"

With this PR:

"0x0255 DAI (DAI)".

Interestingly, this is because the DAI contract returns both the name and symbol padded with trailing `\0` characters so they are both 32 characters long.