### PR TITLE
Fix: incorrectly treating ethereum: as TokenScript file drops

### DIFF
--- a/AlphaWallet/TokenScriptClient/Coordinators/AssetDefinitionStoreCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/AssetDefinitionStoreCoordinator.swift
@@ -149,11 +149,12 @@ class AssetDefinitionStoreCoordinator: Coordinator {
                         delegate?.addedTokenScript(forContract: contract, forServer: server)
                     }
                 }
+                return true
             }
         } catch {
             NSLog("Error moving asset definition file from \(url.path) to: \(destinationFileName.path): \(error)")
         }
-        return true
+        return false
     }
 
     private func watchDirectoryContents(changeHandler: @escaping () -> Void) {


### PR DESCRIPTION
Before this PR, scanning `ethereum:` links might fail because the TokenScript client thinks it's a link to a new TokenScript override file