### PR TITLE
Fix: Detection of spawnable meetup contract for display

### DIFF
--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
@@ -338,7 +338,7 @@ struct ImportMagicTokenViewControllerViewModel {
             if let tokenHolder = tokenHolder, tokenHolder.isSpawnableMeetupContract {
                 //Not the best check, but we assume that even if the data is just partially available, we can show something
                 //TODO get rid of this. Do we even use "building" as spawable check anymore? Testing `is String` is wrong anyway. But probably harmless for now
-                if case .some(.subscribable(let subscribable)) = tokenHolder.values["building"]?.value, subscribable.value is String {
+                if case .some(.subscribable(let subscribable)) = tokenHolder.values["building"]?.value, subscribable.value?.stringValue != nil {
                     return false
                 } else {
                     return true


### PR DESCRIPTION
We can probably remove this stop-gap code if we don't use it anymore. But anyway a fix while it's still there.