### PR TITLE
Add defensive check when creating and importing wallets with seed

### DIFF
--- a/AlphaWallet/KeyManagement/EtherKeystore.swift
+++ b/AlphaWallet/KeyManagement/EtherKeystore.swift
@@ -220,6 +220,8 @@ open class EtherKeystore: Keystore {
             return .success(Wallet(type: .real(.init(address: address))))
         case .mnemonic(let mnemonic, _):
             let mnemonicString = mnemonic.joined(separator: " ")
+            let mnemonicIsGood = doesSeedMatchWalletAddress(mnemonic: mnemonicString)
+            guard mnemonicIsGood else { return .failure(.failedToCreateWallet) }
             let wallet = HDWallet(mnemonic: mnemonicString, passphrase: emptyPassphrase)
             let privateKey = derivePrivateKeyOfAccount0(fromHdWallet: wallet)
             let address = AlphaWallet.Address(fromPrivateKey: privateKey)


### PR DESCRIPTION
Would have prevented #1565 and help to catch if in the future our seed generation is somehow broken.

With this PR, when importing a seed phrase or generating a new one, we'll double check that the address is what we think it will be and also sign a test message and ecrecover just to be sure.