### PR TITLE
Fix: Done button is not visible in transfer NFT notification dialog

### DIFF
--- a/AlphaWallet/Market/ViewModels/StatusViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/StatusViewControllerViewModel.swift
@@ -1,5 +1,4 @@
 // Copyright © 2018 Stormbird PTE. LTD.
-
 import UIKit
 
 struct StatusViewControllerViewModel {
@@ -41,7 +40,7 @@ struct StatusViewControllerViewModel {
 		return Colors.appWhite
 	}
 	var actionButtonBackgroundColor: UIColor {
-		return Colors.appBackground
+		return Colors.appActionButtonGreen
 	}
 	var actionButtonTitleFont: UIFont {
 		return Fonts.regular(size: 20)!


### PR DESCRIPTION
This PR fixes this:

<img src="https://user-images.githubusercontent.com/56189/69393212-80859800-0d13-11ea-9b27-654ee319d1d3.jpg" width=200>
