### PR TITLE
Fix: cancel button is not visible in the dapp browser navigation bar while editing URL

### DIFF
--- a/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
+++ b/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
@@ -110,6 +110,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
         forwardButton.setImage(R.image.toolbarForward(), for: .normal)
         forwardButton.addTarget(self, action: #selector(goForwardAction), for: .touchUpInside)
 
+        cancelEditingButton.setTitleColor(Colors.navigationTitleColor, for: .normal)
         //compression and hugging priority required to make cancel button appear reliably yet not be too wide
         cancelEditingButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         cancelEditingButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)


### PR DESCRIPTION
With this PR, the cancel button becomes visible like this:

<img src="https://user-images.githubusercontent.com/56189/69473617-65895580-0df1-11ea-9351-e598dddfd7fa.png" width=200>