### PR TITLE
filters zero balance tokens from balances array

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/GetERC721ForTicketsBalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetERC721ForTicketsBalanceCoordinator.swift
@@ -23,7 +23,7 @@ class GetERC721ForTicketsBalanceCoordinator {
 
     private func adapt(_ values: Any?) -> [String] {
         guard let array = values as? [BigUInt] else { return [] }
-        return array.map { each in
+        return array.filter({ $0 != BigUInt(0) }).map { each in
             let value = each.serialize().hex()
             return "0x\(value)"
         }


### PR DESCRIPTION
If you have a zeroed out array value it will still add to your balance and give you a falsely high number, this PR prevents this for erc721 tickets 