### PR TITLE
Fix: Tokenscript views flash when tapped in token instance screen (the one with redeem/transfer/sell buttons)

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
@@ -228,8 +228,14 @@ extension TokenInstanceViewController: UITableViewDelegate, UITableViewDataSourc
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        viewModel.toggleSelection(for: indexPath)
-        configure()
+        //We don't allow user to toggle (despite it not doing anything) for non-opensea-backed tokens because it will cause TokenScript views to flash as they have to be re-rendered
+        switch OpenSeaBackedNonFungibleTokenHandling(token: viewModel.token, assetDefinitionStore: assetDefinitionStore, tokenViewType: .viewIconified) {
+        case .backedByOpenSea:
+            viewModel.toggleSelection(for: indexPath)
+            configure()
+        case .notBackedByOpenSea:
+            break
+        }
     }
 }
 


### PR DESCRIPTION
In this screen:

<img src="https://user-images.githubusercontent.com/56189/69606447-c3ba7080-105d-11ea-82a2-53c2917cc71e.png" width=200>