### PR TITLE
Fix: Detection for ERC721 for tickets fires completion handler twice

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/GetIsERC721ForTicketsContractCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetIsERC721ForTicketsContractCoordinator.swift
@@ -18,6 +18,5 @@ class GetIsERC721ForTicketsContractCoordinator {
                 completion(.success(false))
             }
         }
-        completion(.success(false))
     }
 }


### PR DESCRIPTION
The first time saying that it's a normal ERC721 token. Causing the token in wallet tab to briefly show the balance as 0 before showing the correct balance