### PR TITLE
Fix Open on link for ERC721 tokens sourced from OpenSea don't do anything when tapped

### DIFF
--- a/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
+++ b/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
@@ -89,18 +89,11 @@ class BaseTokenCardTableViewCell: UITableViewCell {
         rowView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(rowView)
 
-        //Needs to for expanded view to be laid out with correct height, but cell might be too short
-        let getExpandedHeightCorrectConstraint = rowView.bottomAnchor.constraint(greaterThanOrEqualTo: contentView.bottomAnchor, constant: -GroupedTable.Metric.cellSeparatorHeight)
-        //Gets cell height correct, compensating the constraint above
-        let getCellHeightCorrectConstraint = rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -GroupedTable.Metric.cellSeparatorHeight)
-        getCellHeightCorrectConstraint.priority = .fittingSizeLevel
-
         NSLayoutConstraint.activate([
             rowView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             rowView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             rowView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: GroupedTable.Metric.cellSpacing + GroupedTable.Metric.cellSeparatorHeight),
-            getExpandedHeightCorrectConstraint,
-            getCellHeightCorrectConstraint,
+            rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -GroupedTable.Metric.cellSeparatorHeight)
         ])
     }
 }

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -68,6 +68,9 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 			detailsRowStack?.isHidden = !areDetailsVisible
 		}
 	}
+	var additionalHeightToCompensateForAutoLayout: CGFloat {
+		return 0
+	}
 
 	init(server: RPCServer, tokenView: TokenView, showCheckbox: Bool = false, assetDefinitionStore: AssetDefinitionStore) {
 		self.server = server

--- a/AlphaWallet/UI/Views/TokenCardRowViewProtocol.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowViewProtocol.swift
@@ -9,6 +9,7 @@ protocol TokenCardRowViewProtocol {
     var tokenView: TokenView { get set }
     var showCheckbox: Bool { get set }
     var areDetailsVisible: Bool { get set }
+    var additionalHeightToCompensateForAutoLayout: CGFloat { get }
 
     func configure(tokenHolder: TokenHolder, tokenView: TokenView, areDetailsVisible: Bool, width: CGFloat, assetDefinitionStore: AssetDefinitionStore)
 }


### PR DESCRIPTION
Fixes #1544 

The problem is that the cell height isn't calculated correctly, so the link (button) is outside of its ancestor views so it doesn't get hit-tested.

Unfortunately, it's one of the cases where it's hard (or impossible) to get Auto Layout to work — complicated cell with cell-stackview-multilineLabel. At least I couldn't. Solution is a bit hackish.