### PR TITLE
Mitigate user losing access to wallets when app starts up and NSUserDefaults is not accessible

### DIFF
--- a/AlphaWalletTests/Coordinators/AppCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/AppCoordinatorTests.swift
@@ -12,7 +12,6 @@ class AppCoordinatorTests: XCTestCase {
         )
         
         coordinator.start()
-
         XCTAssertTrue(coordinator.navigationController.viewControllers[0] is WelcomeViewController)
     }
     


### PR DESCRIPTION
Might fix #1589

Before this PR, if NSUSerDefaults is not accessible (then it's an iOS bug) upon startup, the app will think the user has no wallets and ask them to create/import a wallet. It seems random and hard to reproduce. Adds a defensive check to make sure user does not have existing Realm databases for wallets and delays launch if that happens. It can cause #1589, but not sure if it is the only possible cause.

If it does happens, the effects of applying this PR is the app will wait until NSUserDefaults is available or if it doesn't either apply to be hung or iOS/user might kill the app. That way, the user will be able to launch the app again and access their wallets

If there is another cause for #1589, this PR will not make it worse.