### PR TITLE
Fix: text and button overlap on smaller devices in screen prompting to elevate key security

### DIFF
--- a/AlphaWallet/Wallet/ViewControllers/ElevateWalletSecurityViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ElevateWalletSecurityViewController.swift
@@ -45,7 +45,7 @@ class ElevateWalletSecurityViewController: UIViewController {
             subtitleLabel,
             UIView.spacer(height: 40),
             imageView,
-            UIView.spacer(height: 40),
+            UIView.spacer(height: ScreenChecker().isNarrowScreen ? 15 : 40),
             descriptionLabel,
         ].asStackView(axis: .vertical)
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
@@ -51,7 +51,11 @@ struct ElevateWalletSecurityViewModel {
     }
 
     var descriptionFont: UIFont {
-        return Fonts.regular(size: 20)!
+        if ScreenChecker().isNarrowScreen {
+            return Fonts.regular(size: 16)!
+        } else {
+            return Fonts.regular(size: 20)!
+        }
     }
 
     var cancelLockingButtonFont: UIFont {


### PR DESCRIPTION
Before | After
-|-
<img src="https://user-images.githubusercontent.com/56189/69911280-0ca26880-1454-11ea-9d89-e29329ecde2f.png" width=200> | <img src="https://user-images.githubusercontent.com/56189/69911281-0ca26880-1454-11ea-935b-2ebb4774beda.png" width=200>
