### PR TITLE
Fix TokenScript view cells height detection and remove margins

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -279,4 +279,8 @@ extension TokenInstanceActionViewController: TokenInstanceWebViewDelegate {
         }
         delegate?.shouldCloseFlow(inViewController: self)
     }
+
+    func heightChangedFor(tokenInstanceWebView: TokenInstanceWebView) {
+        //no-op. Auto layout handles it
+    }
 }

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -318,7 +318,11 @@ extension TokensCardViewController: UITableViewDelegate, UITableViewDataSource {
         case .backedByOpenSea:
             rowView = OpenSeaNonFungibleTokenCardRowView(tokenView: .viewIconified, showCheckbox: cell.showCheckbox())
         case .notBackedByOpenSea:
-            rowView = TokenCardRowView(server: .main, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
+            rowView = {
+                let rowView = TokenCardRowView(server: .main, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
+                rowView.delegate = self
+                return rowView
+            }()
         }
         cell.delegate = self
         cell.rowView = rowView
@@ -386,5 +390,15 @@ extension TokensCardViewController: UIViewControllerPreviewingDelegate {
 extension TokensCardViewController: TokenCardsViewControllerHeaderDelegate {
     func didPressViewContractWebPage(inHeaderView: TokenCardsViewControllerHeader) {
         showContractWebPage()
+    }
+}
+
+extension TokensCardViewController: TokenCardRowViewDelegate {
+    func heightChangedFor(tokenCardRowView: TokenCardRowView) {
+        //Important to not reload the cell because that will trigger an infinite recursion as the height will be calculated again and this func fired again
+        UIView.setAnimationsEnabled(false)
+        tableView.beginUpdates()
+        tableView.endUpdates()
+        UIView.setAnimationsEnabled(true)
     }
 }

--- a/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
+++ b/AlphaWallet/Tokens/Views/BaseTokenCardTableViewCell.swift
@@ -88,12 +88,14 @@ class BaseTokenCardTableViewCell: UITableViewCell {
 
         rowView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(rowView)
+        var rowHeightConstraint = rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -GroupedTable.Metric.cellSeparatorHeight)
+        rowHeightConstraint.priority = .defaultHigh
 
         NSLayoutConstraint.activate([
             rowView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             rowView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             rowView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: GroupedTable.Metric.cellSpacing + GroupedTable.Metric.cellSeparatorHeight),
-            rowView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -GroupedTable.Metric.cellSeparatorHeight)
+            rowHeightConstraint
         ])
     }
 }

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -10,6 +10,7 @@ protocol TokenInstanceWebViewDelegate: class {
     //TODO not good. But quick and dirty to ship
     func navigationControllerFor(tokenInstanceWebView: TokenInstanceWebView) -> UINavigationController?
     func shouldClose(tokenInstanceWebView: TokenInstanceWebView)
+    func heightChangedFor(tokenInstanceWebView: TokenInstanceWebView)
 }
 
 
@@ -168,6 +169,7 @@ class TokenInstanceWebView: UIView {
 
     private func makeIntroductionWebViewFullHeight() {
         heightConstraint.constant = webView.scrollView.contentSize.height
+        delegate?.heightChangedFor(tokenInstanceWebView: self)
     }
 }
 

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -52,6 +52,12 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 		return webView
 	}()
 
+    //These are necessary because non-TokenScript views have margins whereas TokenScript views doesn't
+	private var constraintsWithLeadingMarginsThatDependsOnWhetherTokenScriptIsUsed: [NSLayoutConstraint] = []
+	private var constraintsWithTrailingMarginsThatDependsOnWhetherTokenScriptIsUsed: [NSLayoutConstraint] = []
+	private var constraintsWithTopMarginsThatDependsOnWhetherTokenScriptIsUsed: [NSLayoutConstraint] = []
+	private var constraintsWithBottomMarginsThatDependsOnWhetherTokenScriptIsUsed: [NSLayoutConstraint] = []
+
 	var delegate: TokenCardRowViewDelegate?
 	let background = UIView()
 	var checkboxImageView = UIImageView(image: R.image.ticket_bundle_unchecked())
@@ -122,9 +128,25 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 
 		nativelyRenderedAttributeViews = [stateLabel, row0, row1, spaceAboveBottomRowStack, row3, detailsRowStack!]
 
+		constraintsWithLeadingMarginsThatDependsOnWhetherTokenScriptIsUsed = [
+			stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor),
+		]
+		constraintsWithTrailingMarginsThatDependsOnWhetherTokenScriptIsUsed = [
+			background.trailingAnchor.constraint(equalTo: trailingAnchor),
+			stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor),
+		]
+
+		constraintsWithTopMarginsThatDependsOnWhetherTokenScriptIsUsed = [
+			background.topAnchor.constraint(equalTo: topAnchor),
+			stackView.topAnchor.constraint(equalTo: background.topAnchor),
+		]
+		constraintsWithBottomMarginsThatDependsOnWhetherTokenScriptIsUsed = [
+			background.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+			stackView.bottomAnchor.constraint(lessThanOrEqualTo: background.bottomAnchor),
+		]
+
 		// TODO extract constant. Maybe StyleLayout.sideMargin
 		let xMargin  = CGFloat(7)
-		let yMargin  = CGFloat(5)
 		checkboxRelatedConstraintsWhenShown.append(checkboxImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xMargin))
 		checkboxRelatedConstraintsWhenShown.append(checkboxImageView.centerYAnchor.constraint(equalTo: centerYAnchor))
 		checkboxRelatedConstraintsWhenShown.append(background.leadingAnchor.constraint(equalTo: checkboxImageView.trailingAnchor, constant: xMargin))
@@ -136,7 +158,9 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 			checkboxRelatedConstraintsWhenShown.append(checkboxImageView.widthAnchor.constraint(equalToConstant: 28))
 			checkboxRelatedConstraintsWhenShown.append(checkboxImageView.heightAnchor.constraint(equalToConstant: 28))
 		}
-		checkboxRelatedConstraintsWhenHidden.append(background.leadingAnchor.constraint(equalTo: leadingAnchor, constant: xMargin))
+		let c1 = background.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0)
+        constraintsWithLeadingMarginsThatDependsOnWhetherTokenScriptIsUsed.append(c1)
+		checkboxRelatedConstraintsWhenHidden.append(c1)
 		if showCheckbox {
 			NSLayoutConstraint.activate(checkboxRelatedConstraintsWhenShown)
 		} else {
@@ -144,16 +168,12 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 		}
 
 		NSLayoutConstraint.activate([
-			stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 21),
-			stackView.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -21),
-			stackView.topAnchor.constraint(equalTo: background.topAnchor, constant: 16),
-			stackView.bottomAnchor.constraint(lessThanOrEqualTo: background.bottomAnchor, constant: -16),
-
 			detailsRowStack!.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
-			background.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -xMargin),
-			background.topAnchor.constraint(equalTo: topAnchor, constant: yMargin),
-			background.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -yMargin),
+			constraintsWithLeadingMarginsThatDependsOnWhetherTokenScriptIsUsed,
+			constraintsWithTrailingMarginsThatDependsOnWhetherTokenScriptIsUsed,
+			constraintsWithTopMarginsThatDependsOnWhetherTokenScriptIsUsed,
+			constraintsWithBottomMarginsThatDependsOnWhetherTokenScriptIsUsed,
 
 			tokenScriptRendererView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
@@ -264,6 +284,35 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 			//TODO we can't change it here. Because it is set (correctly) earlier. Fix this inconsistency
 //			canDetailsBeVisible = true
 			tokenScriptRendererView.isHidden = true
+		}
+
+		for each in constraintsWithLeadingMarginsThatDependsOnWhetherTokenScriptIsUsed {
+			if viewModel.hasTokenScriptHtml {
+				each.constant = 0
+			} else {
+				each.constant = 7
+			}
+		}
+		for each in constraintsWithTrailingMarginsThatDependsOnWhetherTokenScriptIsUsed {
+			if viewModel.hasTokenScriptHtml {
+				each.constant = 0
+			} else {
+				each.constant = -7
+			}
+		}
+		for each in constraintsWithTopMarginsThatDependsOnWhetherTokenScriptIsUsed {
+			if viewModel.hasTokenScriptHtml {
+				each.constant = 0
+			} else {
+				each.constant = 5
+			}
+		}
+		for each in constraintsWithBottomMarginsThatDependsOnWhetherTokenScriptIsUsed {
+			if viewModel.hasTokenScriptHtml {
+				each.constant = 0
+			} else {
+				each.constant = -5
+			}
 		}
 
 		adjustmentsToHandleWhenCategoryLabelTextIsTooLong()

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -3,6 +3,10 @@
 import UIKit
 import WebKit
 
+protocol TokenCardRowViewDelegate {
+    func heightChangedFor(tokenCardRowView: TokenCardRowView)
+}
+
 class TokenCardRowView: UIView, TokenCardRowViewProtocol {
     private let server: RPCServer
 	private let assetDefinitionStore: AssetDefinitionStore
@@ -43,9 +47,12 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 		//TODO pass in keystore or wallet address instead
 		let walletAddress = EtherKeystore.current!.address
 		//TODO this can't sign personal message because we didn't set a delegate, but we don't need it also
-		return TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
+		let webView = TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
+		webView.delegate = self
+		return webView
 	}()
 
+	var delegate: TokenCardRowViewDelegate?
 	let background = UIView()
 	var checkboxImageView = UIImageView(image: R.image.ticket_bundle_unchecked())
 	var stateLabel = UILabel()
@@ -271,5 +278,19 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 extension TokenCardRowView: TokenRowView {
 	func configure(tokenHolder: TokenHolder) {
 		configure(viewModel: TokenCardRowViewModel(tokenHolder: tokenHolder, tokenView: tokenView, assetDefinitionStore: assetDefinitionStore))
+	}
+}
+
+extension TokenCardRowView: TokenInstanceWebViewDelegate {
+	func navigationControllerFor(tokenInstanceWebView: TokenInstanceWebView) -> UINavigationController? {
+		return nil
+	}
+
+	func shouldClose(tokenInstanceWebView: TokenInstanceWebView) {
+        //no-op
+	}
+
+	func heightChangedFor(tokenInstanceWebView: TokenInstanceWebView) {
+        delegate?.heightChangedFor(tokenCardRowView: self)
 	}
 }


### PR DESCRIPTION
Closes #1594 with:

* Fix TokenScript view cells height detection
* Remove margins around TokenScript views

Expect to affect only TokenScript-rendered views. The effect on margins:

|Before|After|
-|-
<img src="https://user-images.githubusercontent.com/56189/69932738-39638800-1507-11ea-8f94-85ccb9389db6.png" width=200>|<img src="https://user-images.githubusercontent.com/56189/69932736-39638800-1507-11ea-9e4e-0bb452324169.png" width=200>