### PR TITLE
Fix tokenscript view cells height for heavy tokenscript views

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
@@ -227,7 +227,8 @@ extension TokenInstanceViewController: UITableViewDelegate, UITableViewDataSourc
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         configure(cell: cellForSizing)
-        let size = cellForSizing.systemLayoutSizeFitting(UIView.layoutFittingExpandedSize)
+        //Have to be careful that height is calculated correctly for OpenSea-backed tokens (both expanded and minimized) as well as TokenScript views
+        let size = cellForSizing.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         if let rowView = cellForSizing.rowView {
             return size.height + rowView.additionalHeightToCompensateForAutoLayout
         } else {


### PR DESCRIPTION
Fixes #1597 

Also fixes the height in the screen. Before this PR, while it's not obvious until the user attempt to scroll it, the scroll view is very tall:

<img src="https://user-images.githubusercontent.com/56189/70025974-78620e00-15d9-11ea-9ab8-fc6c9e99149f.png" width=200>

Performance is quite poor when selecting/de-selecting, so probably have to optimise further later