### PR TITLE
Fix: crash when scrolling TokenScript views

### DIFF
--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -68,6 +68,11 @@ class TokenInstanceWebView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        //Necessary to prevent crash when scrolling a table with several cells containing this class
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
+    }
+
     //Implementation: String concatentation is slow, but it's not obvious at all
     func update(withTokenHolder tokenHolder: TokenHolder, isFungible: Bool, isFirstUpdate: Bool = true) {
         var token = [AttributeId: String]()


### PR DESCRIPTION
Before applying this PR, the screen with a list of TokenScript views will crash while scrolling if there are more rows than the screen can fit.