### PR TITLE
Fix TokenScript files marked wrongly as having conflicts

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
@@ -16,6 +16,7 @@ protocol AssetDefinitionBackingStore {
     func hasOutdatedTokenScript(forContract contract: AlphaWallet.Address) -> Bool
     func getCacheTokenScriptSignatureVerificationType(forXmlString xmlString: String) -> TokenScriptSignatureVerificationType?
     func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String)
+    func deleteFileDownloadedFromOfficialRepoFor(contract: AlphaWallet.Address)
 }
 
 protocol AssetDefinitionBackingStoreDelegate: class {

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -258,10 +258,18 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
                 }
             }
         }
-        for each in Array(Set(contractsAffected)) {
-            changeHandler(each)
-        }
+        purgeCacheFor(contracts: contractsAffected, changeHandler: changeHandler)
         writeIndicesToDisk()
         delegate?.badTokenScriptFilesChanged(in: self)
+    }
+
+    private func purgeCacheFor(contracts: [AlphaWallet.Address], changeHandler: @escaping (AlphaWallet.Address) -> Void) {
+        //Import to clear the signature cache (which includes conflicts) because a file which was in conflict with another earlier might no longer be
+        //TODO clear the cache more intelligently rather than purge it entirely. It might be hard or impossible to know which other contracts are affected
+        tokenScriptFileIndices.signatureVerificationTypes = .init()
+        for each in Array(Set(contracts)) {
+            XMLHandler.invalidate(forContract: each)
+            changeHandler(each)
+        }
     }
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -176,6 +176,29 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
         tokenScriptFileIndices.write(toUrl: indicesFileUrl)
     }
 
+    //When we remove a contract from our database, we must remove the TokenScript file (from the standard repo) that is named after it because this file wouldn't be pulled from the server anymore. If the TokenScript file applies to more than 1 contract, having the outdated file around will mean 2 copies of the same file — with 1 outdated, 1 up-to-date, causing TokenScript client to see a conflict
+    func deleteFileDownloadedFromOfficialRepoFor(contract: AlphaWallet.Address) {
+        guard isOfficial else { return }
+        let filename = self.filename(fromContract: contract)
+        let url = directory.appendingPathComponent(filename)
+        try? FileManager.default.removeItem(at: url)
+        tokenScriptFileIndices.removeHash(forFile: filename)
+
+        var contractsToFileNames = tokenScriptFileIndices.contractsToFileNames
+        for (eachContract, eachFilenames) in tokenScriptFileIndices.contractsToFileNames {
+            if eachFilenames.contains(filename) {
+                var updatedFilenames = eachFilenames
+                updatedFilenames.removeAll { $0 == filename }
+                contractsToFileNames[eachContract] = updatedFilenames
+            }
+        }
+        tokenScriptFileIndices.contractsToFileNames = contractsToFileNames
+        tokenScriptFileIndices.contractsToEntities[filename] = nil
+        tokenScriptFileIndices.removeBadTokenScriptFileName(filename)
+        tokenScriptFileIndices.removeOldTokenScriptFileName(filename)
+        writeIndicesToDisk()
+    }
+
     //Must only return the last modified date for a file if it's for the current schema version otherwise, a file using the old schema might have a more recent timestamp (because it was recently downloaded) than a newer version on the server (which was not yet made available by the time the user downloaded the version with the old schema)
     func lastModifiedDateOfCachedAssetDefinitionFile(forContract contract: AlphaWallet.Address) -> Date? {
         assert(isOfficial)

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
@@ -107,6 +107,10 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
             return
         }
     }
+
+    func deleteFileDownloadedFromOfficialRepoFor(contract: AlphaWallet.Address) {
+        officialStore.deleteFileDownloadedFromOfficialRepoFor(contract: contract)
+    }
 }
 
 extension AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStoreDelegate {

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
@@ -56,4 +56,8 @@ class AssetDefinitionInMemoryBackingStore: AssetDefinitionBackingStore {
     func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
         //do nothing
     }
+
+    func deleteFileDownloadedFromOfficialRepoFor(contract: AlphaWallet.Address) {
+        xmls[contract] = nil
+    }
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -201,6 +201,11 @@ class AssetDefinitionStore {
     func writeCacheTokenScriptSignatureVerificationType(_ verificationType: TokenScriptSignatureVerificationType, forContract contract: AlphaWallet.Address, forXmlString xmlString: String) {
         return backingStore.writeCacheTokenScriptSignatureVerificationType(verificationType, forContract: contract, forXmlString: xmlString)
     }
+
+    func contractDeleted(_ contract: AlphaWallet.Address) {
+        XMLHandler.invalidate(forContract: contract)
+        backingStore.deleteFileDownloadedFromOfficialRepoFor(contract: contract)
+    }
 }
 
 extension AssetDefinitionStore: AssetDefinitionBackingStoreDelegate {

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -395,6 +395,7 @@ class SingleChainTokenCoordinator: Coordinator {
     }
 
     func delete(token: TokenObject) {
+        assetDefinitionStore.contractDeleted(token.contractAddress)
         storage.add(hiddenContracts: [HiddenContract(contractAddress: token.contractAddress, server: session.server)])
         storage.delete(tokens: [token])
         delegate?.tokensDidChange(inCoordinator: self)


### PR DESCRIPTION
Fixes #1595 

This PR fixes 3 bugs:

1. When a TokenScript file signature is validated, it is cached. This cache also stores if the file has a conflict with another. If A and B has a conflict and then A is updated, the cache still says that A and B has a conflict
2. When a TokenScript file from the repo server covers contracts `0x1` and `0x2`, it is downloaded and stored as the files `0x1.tsml` and `0x2.tsml` with identical content. When `0x1` is deleted by the user and the app checks for updated TokenScript files, only `0x2.tsml` is fetched and written to disk, so there is a conflict between `0x1.tsml` and `0x2.tsml` (the former being outdated)
3. When a TokenScript file from the repo server covers contracts `0x1` and `0x2`, it is downloaded and stored as the files `0x1.tsml` and `0x2.tsml` with identical content. When the app checks for updated TokenScript files, `0x1.tsml` is downloaded and connectivity lost, `0x2.tsml` would not be downloaded. Then the TokenScript client will think `0x1.tsml` and `0x2.tsml` has a conflict. Rightfully so. But upon restart, it will still think they are in conflict because of (1)