### PR TITLE
Always support decimal comma as decimal separator in addition to what is specified by locale when entering amounts

### DIFF
--- a/AlphaWallet/Foundation/EtherNumberFormatter.swift
+++ b/AlphaWallet/Foundation/EtherNumberFormatter.swift
@@ -1,9 +1,11 @@
 // Copyright SIX DAY LLC. All rights reserved.
-
 import BigInt
 import Foundation
 
 final class EtherNumberFormatter {
+    /// We always allow users to use "." as the decimal separator even if the locale might specify a different separator, eg. a decimal comma like Spain. If user sets their locale to one that uses a decimal comma, eg. Spain, the `.decimalPad` will still show "." instead of "," so the user wouldn't be able enter the "," that the locale expects using the keypad.
+    static let decimalPoint = "."
+
     /// Formatter that preserves full precision.
     static let full = EtherNumberFormatter()
 
@@ -50,7 +52,7 @@ final class EtherNumberFormatter {
     ///   - decimals: decimal places used for scaling values.
     /// - Returns: `BigInt` represenation.
     func number(from string: String, decimals: Int) -> BigInt? {
-        guard let index = string.index(where: { String($0) == decimalSeparator }) else {
+        guard let index = string.index(where: { String($0) == decimalSeparator }) ?? string.index(where: { String($0) == EtherNumberFormatter.decimalPoint }) else {
             // No fractional part
             return BigInt(string).flatMap({ $0 * BigInt(10).power(decimals) })
         }

--- a/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/EnterSellTokensCardPriceQuantityViewController.swift
@@ -225,7 +225,8 @@ class EnterSellTokensCardPriceQuantityViewController: UIViewController, TokenVer
         }
 
         let noPrice: Bool
-        if let price = Double(pricePerTokenField.ethCost) {
+        //We must use `Ether(string:)` because the input string might not always use a decimal point as the decimal separator. It might use a decimal comma. E.g. "1.2" or "1,2" depending on locale
+        if let price = Double(Ether(string: pricePerTokenField.ethCost)?.unformattedDescription ?? "") {
             noPrice = price.isZero
         } else {
             noPrice = true

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -77,8 +77,8 @@ class AmountTextField: UIControl {
     weak var delegate: AmountTextFieldDelegate?
 
     private var allowedCharacters: String = {
-        let decimalSeparator = Locale.current.decimalSeparator ?? "."
-        return "0123456789" + decimalSeparator
+        let decimalSeparator = Locale.current.decimalSeparator ?? ""
+        return "0123456789" + decimalSeparator + EtherNumberFormatter.decimalPoint
     }()
     lazy var decimalFormatter: DecimalFormatter = {
         return DecimalFormatter()


### PR DESCRIPTION
Fixes #1599 

There are a few ways to change the locale or preferred language for the app:

1. Change the locale in Settings.app
2. Change the preferred language in Settings.app
3. Change the preferred language in Settings.app for AlphaWallet only (iOS 13 and newer)
4. Change the language in AlphaWallet Settings tab

When the user sets the in-app locale (method 4) to one that uses a decimal comma (E.g. Spanish), the `.decimalPad` keyboard still (only) shows decimal point. The `.decimalPad` keyboard only switches to the decimal comma correctly with methods 1, 2 and 3.

This PR changes it so that we always consider the decimal point as the one defined by the locale.