### PR TITLE
Fix: Tokens auto-detected from transactions shouldn't always be treated as ERC20 because BlockScout returns ERC721 too

### DIFF
--- a/AlphaWallet/Models/TokenUpdate.swift
+++ b/AlphaWallet/Models/TokenUpdate.swift
@@ -8,6 +8,7 @@ struct TokenUpdate {
     let name: String
     let symbol: String
     let decimals: Int
+    let tokenType: TokenType
     var primaryKey: String {
          return TokenObject.generatePrimaryKey(fromContract: address, server: server)
     }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -78,6 +78,7 @@ public struct Constants {
     public static let artisTau1NetworkCoreAPI = "https://explorer.tau1.artis.network/api?module=account&action=txlist&address="
 
     //etherscan-compatible erc20 transaction event APIs
+    //The fetch ERC20 transactions endpoint from Etherscan returns only ERC20 token transactions but the Blockscout version also includes ERC721 transactions too (so it's likely other types that it can detect will be returned too); thus we check the token type rather than assume that they are all ERC20
     public static let mainnetEtherscanAPIErc20Events = "https://api.etherscan.io/api?module=account&action=tokentx&address="
     public static let ropstenEtherscanAPIErc20Events = "https://ropsten.etherscan.io/api?module=account&action=tokentx&address="
     public static let kovanEtherscanAPIErc20Events = "https://api-kovan.etherscan.io/api?module=account&action=tokentx&address="

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -188,6 +188,7 @@ class TokensDataStore {
                 "name": token.name,
                 "symbol": token.symbol,
                 "decimals": token.decimals,
+                "rawType": token.tokenType.rawValue,
             ]
             realm.create(TokenObject.self, value: update, update: true)
         }


### PR DESCRIPTION
Especially relevant for ERC721 tickets that are auto-detected.

E.g. Blockscout output: https://blockscout.com/poa/dai/api?module=account&action=tokentx&address=0x08d0d733b65321a1e28bd8b6045e59aa11f6bbe3

Not sure if this affects Android @James-Sangalli @JamesSmartCell 