### PR TITLE
Fetch tokenscript file for contracts auto detected from transactions immediately instead of waiting until app is launched again

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -114,7 +114,7 @@ class InCoordinator: NSObject, Coordinator {
 
     private func createTransactionsStorage(server: RPCServer) -> TransactionsStorage {
         let realm = self.realm(forAccount: wallet)
-        return TransactionsStorage(realm: realm, server: server)
+        return TransactionsStorage(realm: realm, server: server, delegate: self)
     }
 
     private func fetchCryptoPrice(forServer server: RPCServer) {
@@ -665,7 +665,7 @@ extension InCoordinator: SettingsCoordinatorDelegate {
     func delete(account: Wallet, in coordinator: SettingsCoordinator) {
         let realm = self.realm(forAccount: account)
         for each in RPCServer.allCases {
-            let transactionsStorage = TransactionsStorage(realm: realm, server: each)
+            let transactionsStorage = TransactionsStorage(realm: realm, server: each, delegate: nil)
             transactionsStorage.deleteAll()
         }
     }
@@ -736,6 +736,14 @@ extension InCoordinator: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         if isViewControllerDappBrowserTab(viewController) {
             dappBrowserCoordinator?.didShow()
+        }
+    }
+}
+
+extension InCoordinator: TransactionsStorageDelegate {
+    func didAddTokensWith(contracts: [AlphaWallet.Address], inTransactionsStorage: TransactionsStorage) {
+        for each in contracts {
+            assetDefinitionStore.fetchXML(forContract: each)
         }
     }
 }

--- a/AlphaWallet/Models/TokenUpdate.swift
+++ b/AlphaWallet/Models/TokenUpdate.swift
@@ -8,6 +8,7 @@ struct TokenUpdate {
     let name: String
     let symbol: String
     let decimals: Int
+    let tokenType: TokenType
     var primaryKey: String {
          return TokenObject.generatePrimaryKey(fromContract: address, server: server)
     }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -78,6 +78,7 @@ public struct Constants {
     public static let artisTau1NetworkCoreAPI = "https://explorer.tau1.artis.network/api?module=account&action=txlist&address="
 
     //etherscan-compatible erc20 transaction event APIs
+    //The fetch ERC20 transactions endpoint from Etherscan returns only ERC20 token transactions but the Blockscout version also includes ERC721 transactions too (so it's likely other types that it can detect will be returned too); thus we check the token type rather than assume that they are all ERC20
     public static let mainnetEtherscanAPIErc20Events = "https://api.etherscan.io/api?module=account&action=tokentx&address="
     public static let ropstenEtherscanAPIErc20Events = "https://ropsten.etherscan.io/api?module=account&action=tokentx&address="
     public static let kovanEtherscanAPIErc20Events = "https://api-kovan.etherscan.io/api?module=account&action=tokentx&address="

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -360,7 +360,7 @@ class SingleChainTokenCoordinator: Coordinator {
     private func createTransactionsStore() -> TransactionsStorage? {
         guard let wallet = keystore.recentlyUsedWallet else { return nil }
         let realm = self.realm(forAccount: wallet)
-        return TransactionsStorage(realm: realm, server: session.server)
+        return TransactionsStorage(realm: realm, server: session.server, delegate: self)
     }
 
     private func realm(forAccount account: Wallet) -> Realm {
@@ -559,6 +559,14 @@ extension SingleChainTokenCoordinator: TokenInstanceActionViewControllerDelegate
 
     func shouldCloseFlow(inViewController viewController: TokenInstanceActionViewController) {
         viewController.navigationController?.popViewController(animated: true)
+    }
+}
+
+extension SingleChainTokenCoordinator: TransactionsStorageDelegate {
+    func didAddTokensWith(contracts: [AlphaWallet.Address], inTransactionsStorage: TransactionsStorage) {
+        for each in contracts {
+            assetDefinitionStore.fetchXML(forContract: each)
+        }
     }
 }
 

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -188,6 +188,7 @@ class TokensDataStore {
                 "name": token.name,
                 "symbol": token.symbol,
                 "decimals": token.decimals,
+                "rawType": token.tokenType.rawValue,
             ]
             realm.create(TokenObject.self, value: update, update: true)
         }

--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -1,13 +1,20 @@
 import Foundation
 import RealmSwift
 
+protocol TransactionsStorageDelegate: class {
+    func didAddTokensWith(contracts: [AlphaWallet.Address], inTransactionsStorage: TransactionsStorage)
+}
+
 class TransactionsStorage {
-    let realm: Realm
+    private let realm: Realm
+    private let delegate: TransactionsStorageDelegate?
+
     let server: RPCServer
 
-    init(realm: Realm, server: RPCServer) {
+    init(realm: Realm, server: RPCServer, delegate: TransactionsStorageDelegate?) {
         self.realm = realm
         self.server = server
+        self.delegate = delegate
     }
 
     var count: Int {
@@ -40,6 +47,7 @@ class TransactionsStorage {
 
     private func addTokensWithContractAddresses(fromTransactions transactions: [Transaction], contractsAndTokenTypes: [AlphaWallet.Address: TokenType]) {
         let tokens = self.tokens(from: transactions, contractsAndTokenTypes: contractsAndTokenTypes)
+        delegate?.didAddTokensWith(contracts: Array(Set(tokens.map { $0.address})), inTransactionsStorage: self)
         if !tokens.isEmpty {
             TokensDataStore.update(in: realm, tokens: tokens)
         }

--- a/AlphaWalletTests/Factories/FakeTransactionsStorage.swift
+++ b/AlphaWalletTests/Factories/FakeTransactionsStorage.swift
@@ -7,6 +7,6 @@ import RealmSwift
 class FakeTransactionsStorage: TransactionsStorage {
     convenience init() {
         let realm = try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: "MyInMemoryRealm"))
-        self.init(realm: realm, server: .main)
+        self.init(realm: realm, server: .main, delegate: nil)
     }
 }


### PR DESCRIPTION
Dependent on merging #1622 first. Left that PR's commit in so it's easier to merge since they touch the same files.