### PR TITLE
Fix: App crash with Xcode 11 due to Realm

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ target 'AlphaWallet' do
   pod 'KeychainSwift', :git=>'https://github.com/AlphaWallet/keychain-swift.git', :branch=>'alphawallet'
   pod 'SwiftLint'
   pod 'SeedStackViewController'
-  pod 'RealmSwift', '~> 3.9'
+  pod 'RealmSwift', '~> 3.18'
   pod 'Moya', '~> 10.0.1'
   pod 'JavaScriptKit'
   pod 'CryptoSwift'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,11 +49,11 @@ PODS:
   - R.swift (4.0.0):
     - R.swift.Library (~> 4.0.0)
   - R.swift.Library (4.0.0)
-  - Realm (3.9.0):
-    - Realm/Headers (= 3.9.0)
-  - Realm/Headers (3.9.0)
-  - RealmSwift (3.9.0):
-    - Realm (= 3.9.0)
+  - Realm (3.21.0):
+    - Realm/Headers (= 3.21.0)
+  - Realm/Headers (3.21.0)
+  - RealmSwift (3.21.0):
+    - Realm (= 3.21.0)
   - Result (3.2.4)
   - SAMKeychain (1.5.3)
   - secp256k1_ios (0.1.3)
@@ -102,7 +102,7 @@ DEPENDENCIES:
   - PromiseKit/CorePromise
   - QRCodeReaderViewController (from `https://github.com/AlphaWallet/QRCodeReaderViewController.git`, branch `alphawallet`)
   - R.swift
-  - RealmSwift (~> 3.9)
+  - RealmSwift (~> 3.18)
   - SAMKeychain
   - SeedStackViewController
   - StatefulViewController
@@ -230,8 +230,8 @@ SPEC CHECKSUMS:
   QRCodeReaderViewController: e8f27d035b3e72b1d4b1c61ff66458287e3be0ff
   R.swift: d6a5ec2f55a8441dc0ed9f1f8b37d7d11ae85c66
   R.swift.Library: c3af34921024333546e23b70e70d0b4e0cffca75
-  Realm: 3d36f208bf3aff8335dc3298742140182bde4edb
-  RealmSwift: aa4d11917bfcfaa3ed51f219102a487ecd895447
+  Realm: 38e9dcb19104b58407167d99f70d4995f7c16023
+  RealmSwift: 3183cc1ad48378fbcd634311b22c0e6c44021152
   Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
   SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   secp256k1_ios: ac9ef04e761f43c58012b28548afa91493761f17
@@ -248,6 +248,6 @@ SPEC CHECKSUMS:
   TrustWalletCore: dd8c81d5958f1eb737abea1e14675efcc6a104aa
   web3swift: 1597d4997976d21325882db4c523f1dfd5459406
 
-PODFILE CHECKSUM: 69e100f8eef27d4c00bf165c55fa17e32ca9fa06
+PODFILE CHECKSUM: 5c0d3182259431476116a136cb40db573ac7262a
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Fixes #1485

Now runs without crashing with Xcode 11.

Still shouldn't build with Xcode11 for TestFlight/submission because we still need to fix update the view controller presentation styles so they don't look like:

<img src="https://user-images.githubusercontent.com/56189/71347219-d5336180-25a4-11ea-8f19-5f15ba43d1f4.png" width=200>
