### PR TITLE
Speed up launch

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
+++ b/AlphaWallet/TokenScriptClient/Models/TokenScriptFileIndices.swift
@@ -83,7 +83,8 @@ struct TokenScriptFileIndices: Codable {
     }
 
     func hash(contents: String) -> FileContentsHash {
-        return contents.djb2hash
+        //The value returned by `hashValue` might be subject to change and 2 strings that has the same `hasValue` *might* not be identical, but should be good enough for now. It is much faster than other commonly available hashes and we need it to be very fast because it is called once for each file upon startup
+        return contents.hashValue
     }
 
     static func load(fromUrl url: URL) -> TokenScriptFileIndices? {
@@ -95,17 +96,6 @@ struct TokenScriptFileIndices: Codable {
         signatureVerificationTypes = .init()
         for eachHash in fileHashes.values {
             signatureVerificationTypes[eachHash] = oldVerificationTypes[eachHash]
-        }
-    }
-}
-
-extension String {
-    //https://useyourloaf.com/blog/swift-hashable/
-    //http://www.cse.yorku.ca/~oz/hash.html
-    fileprivate var djb2hash: TokenScriptFileIndices.FileContentsHash {
-        let unicodeScalars = self.unicodeScalars.map { $0.value }
-        return unicodeScalars.reduce(5381) {
-            ($0 << 5) &+ $0 &+ Int($1)
         }
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -65,19 +65,12 @@ class SingleChainTokenCoordinator: Coordinator {
             DispatchQueue.main.async { [weak self] in
                 self?.autoDetectTransactedTokens()
                 self?.autoDetectPartnerTokens()
-                self?.refreshUponAssetDefinitionChanges()
             }
         }
     }
 
     func isServer(_ server: RPCServer) -> Bool {
         return session.server == server
-    }
-
-    private func refreshUponAssetDefinitionChanges() {
-        assetDefinitionStore.subscribe { [weak self] _ in
-            self?.storage.fetchTokenNamesForNonFungibleTokensIfEmpty()
-        }
     }
 
     ///Implementation: We refresh once only, after all the auto detected tokens' data have been pulled because each refresh pulls every tokens' (including those that already exist before the this auto detection) price as well as balance, placing heavy and redundant load on the device. After a timeout, we refresh once just in case it took too long, so user at least gets the chance to see some auto detected tokens

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -165,7 +165,7 @@ class TokenInstanceWebView: UIView {
 
     func loadHtml(_ html: String) {
         webView.loadHTMLString(html, baseURL: nil)
-        let hash = html.djb2hash
+        let hash = html.hashForCachingHeight
         hashOfCurrentHtml = hash
         if let cachedHeight = TokenInstanceWebView.htmlHeightCache[hash] {
             guard heightConstraint.constant != cachedHeight else { return }
@@ -379,12 +379,7 @@ func wrapWithHtmlViewport(_ html: String) -> String {
 }
 
 extension String {
-    //https://useyourloaf.com/blog/swift-hashable/
-    //http://www.cse.yorku.ca/~oz/hash.html
-    fileprivate var djb2hash: Int {
-        let unicodeScalars = self.unicodeScalars.map { $0.value }
-        return unicodeScalars.reduce(5381) {
-            ($0 << 5) &+ $0 &+ Int($1)
-        }
+    fileprivate var hashForCachingHeight: Int {
+        return hashValue
     }
 }


### PR DESCRIPTION
Closes #1639, #1643 

This PR fixes 2 reasons leading to slower app launch:

* Upon launch, every TokenScript file's content is hashed. The hashing function we used is slow. Even with ~20 TokenScript files, there is noticeable slowdown. Switched to a faster hash function
* A fixed which scan every TokenScript and conditionally process it once for every holding contract they are for is ran at launch. This was for an old database migration and looks like it is no longer necessary.