### PR TITLE
Fix: symbol in amount textfield moves around when tapped. Happens when building with older Xcode and running on new iOS versions

### DIFF
--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -155,6 +155,8 @@ class AmountTextField: UIControl {
         switch currentPair.left {
         case .cryptoCurrency(let symbol), .usd(let symbol):
             fiatButton.setTitle(symbol, for: .normal)
+            //Have to re-create `rightView`, otherwise building with older Xcode and deploying on newer iOS version causes the `rightView` to move around when tapped. Specifically reproducible by building with Xcode 10.3 and running on iOS 13.3
+            textField.rightView = makeAmountRightView()
         }
     }
 


### PR DESCRIPTION
This PR fixes a display issue which happens when building with an older Xcode and running on a newer iOS versions. Specifically building with Xcode 10.x (which is for iOS 12) and running iOS 13.x. When the symbol in the amount textbox is tapped, the symbol grows a mind of its own and moves to the left of the textbox and the amount entered might be covered.

Before PR|After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/72231752-1e9d2c80-35f8-11ea-944e-1f115f115dc6.png" width=200>|<img src="https://user-images.githubusercontent.com/56189/72231755-1f35c300-35f8-11ea-921c-770a6e8e6553.png" width=200>