### PR TITLE
Fix: inject token data into action view is broken

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -25,6 +25,7 @@ class TokenInstanceActionViewController: UIViewController, TokenVerifiableStatus
         let webView = TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
         webView.isWebViewInteractionEnabled = true
         webView.delegate = self
+        webView.isStandalone = true
         return webView
     }()
 

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -37,6 +37,11 @@ class TokenInstanceWebView: UIView {
     }
     weak var delegate: TokenInstanceWebViewDelegate?
     var shouldOnlyRenderIfHeightIsCached = false
+    //HACK: Flag necessary to inject token values somewhat reliably in at least 2 distinct cases:
+    //A. TokenScript views in token cards (ie. view iconified)
+    //B. Action views
+    //TODO improve further. It's not reliable enough
+    var isStandalone = false
 
     init(server: RPCServer, walletAddress: AlphaWallet.Address, assetDefinitionStore: AssetDefinitionStore) {
         self.server = server
@@ -117,8 +122,12 @@ class TokenInstanceWebView: UIView {
                          const oldTokens = web3.tokens.data
                          """ + string
 
-        //Important to inject JavaScript differently depending on whether this is the first time it's loaded because the HTML document may not be ready yet. Seems like it is necessary for `afterDocumentIsLoaded` to always be true here in order to avoid `Can't find variable: web3` errors
-        inject(javaScript: javaScript, afterDocumentIsLoaded: true)
+        //Important to inject JavaScript differently depending on whether this is the first time it's loaded because the HTML document may not be ready yet. Seems like it is necessary for `afterDocumentIsLoaded` to always be true here in order to avoid `Can't find variable: web3` errors when used for token cards
+        if isStandalone {
+            inject(javaScript: javaScript, afterDocumentIsLoaded: isFirstUpdate)
+        } else {
+            inject(javaScript: javaScript, afterDocumentIsLoaded: true)
+        }
     }
 
     private func implicitAttributes(tokenHolder: TokenHolder, isFungible: Bool) -> [String: AssetInternalValue] {


### PR DESCRIPTION
Fixes #1646 

TokenScript views continues to be a hairy part of the app. There are 2 different types of screens where the behavior/needs of WKWebview are a bit different in our app:

A. When displaying view-iconified in token card screens and MagicLink creation screen and when importing a MagicLink
B. When displaying an action view

They seem to require slightly different ways to injecting JavaScript into the webviews. (B) also requires reading from user-entry which is done via injecting JavaScript too.

(A) is harder to get rid because we require good performance out of it, whereas (B) seems to be simpler to get right (though broken by a recent PR to optimise for A).

So I imagine we'll just have to remember testing at least these 2 types occasionally.