### PR TITLE
Refresh every TokenScript file on disk that were downloaded from the repo server upon app startup

### DIFF
--- a/AlphaWallet/TokenScriptClient/Coordinators/FetchAssetDefinitionsCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/FetchAssetDefinitionsCoordinator.swift
@@ -7,12 +7,7 @@ class FetchAssetDefinitionsCoordinator: Coordinator {
     private let assetDefinitionStore: AssetDefinitionStore
     private let tokensDataStores: ServerDictionary<TokensDataStore>
 
-    init(assetDefinitionStore: AssetDefinitionStore, tokensDataStores: ServerDictionary<TokensDataStore>) {
-        self.assetDefinitionStore = assetDefinitionStore
-        self.tokensDataStores = tokensDataStores
-    }
-
-    func start() {
+    private var contractsInDatabase: [AlphaWallet.Address] {
         var contracts = [AlphaWallet.Address]()
         for each in tokensDataStores.values {
             contracts.append(contentsOf: each.enabledObject.filter {
@@ -24,6 +19,21 @@ class FetchAssetDefinitionsCoordinator: Coordinator {
                 }
             }.map { $0.contractAddress })
         }
+        return contracts
+    }
+
+    private var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
+        return assetDefinitionStore.contractsWithTokenScriptFileFromOfficialRepo
+    }
+
+    init(assetDefinitionStore: AssetDefinitionStore, tokensDataStores: ServerDictionary<TokensDataStore>) {
+        self.assetDefinitionStore = assetDefinitionStore
+        self.tokensDataStores = tokensDataStores
+    }
+
+    func start() {
+        let contracts = Array(Set(contractsInDatabase + contractsWithTokenScriptFileFromOfficialRepo))
         assetDefinitionStore.fetchXMLs(forContracts: contracts)
     }
+
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
@@ -6,6 +6,7 @@ protocol AssetDefinitionBackingStore {
     var delegate: AssetDefinitionBackingStoreDelegate? { get set }
     var badTokenScriptFileNames: [TokenScriptFileIndices.FileName] { get }
     var conflictingTokenScriptFileNames: (official: [TokenScriptFileIndices.FileName], overrides: [TokenScriptFileIndices.FileName], all: [TokenScriptFileIndices.FileName]) { get }
+    var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] { get }
 
     subscript(contract: AlphaWallet.Address) -> String? { get set }
     func lastModifiedDateOfCachedAssetDefinitionFile(forContract contract: AlphaWallet.Address) -> Date?

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStore.swift
@@ -36,6 +36,11 @@ class AssetDefinitionDiskBackingStore: AssetDefinitionBackingStore {
         }
     }
 
+    var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
+        guard let urls = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else { return .init() }
+        return urls.compactMap { AlphaWallet.Address(string: $0.deletingPathExtension().lastPathComponent) }
+    }
+
     init(directoryName: String = officialDirectoryName) {
         self.assetDefinitionsDirectoryName = directoryName
         self.isOfficial = assetDefinitionsDirectoryName == AssetDefinitionDiskBackingStore.officialDirectoryName

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
@@ -19,6 +19,10 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
         return (official: official, overrides: overrides, all: official + overrides)
     }
 
+    var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
+        return officialStore.contractsWithTokenScriptFileFromOfficialRepo
+    }
+
     init(overridesStore: AssetDefinitionBackingStore? = nil) {
         if let overridesStore = overridesStore {
             self.overridesStore = overridesStore

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionInMemoryBackingStore.swift
@@ -13,6 +13,10 @@ class AssetDefinitionInMemoryBackingStore: AssetDefinitionBackingStore {
         return (official: [], overrides: [], all: [])
     }
 
+    var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
+        return .init()
+    }
+
     subscript(contract: AlphaWallet.Address) -> String? {
         get {
             return xmls[contract]

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -44,6 +44,10 @@ class AssetDefinitionStore {
         return backingStore.conflictingTokenScriptFileNames
     }
 
+    var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
+        return backingStore.contractsWithTokenScriptFileFromOfficialRepo
+    }
+
     //TODO move
     static var standardTokenScriptStyles: String {
         return """


### PR DESCRIPTION
TokenScript files on disk, from official repos that have filenames for tokens that are not in the Realm database don't get refreshed so they will cause conflicts when a copy of the same TokenScript file is updated for another token (which is in the Realm database).

e.g. TokenScript file A is on the repo server which works for holding contracts 0xC1 and 0xC2. For some reason [1], A is written locally as 0xC1.tsml and 0xC2.tsml. Only 0xC1 is in the database. Before this commit, Only 0xC1.tsml will be refreshed. So if A changes, 0xC1.tsml and 0xC2.tsml will be different and cause a conflict.

This PR changes it so that every TokenScript file is refreshed.