### PR TITLE
Fix: ignore UEFA ticket token from OpenSea results, so that token type is not wrongly overridden as `.erc721`. It should be `.erc721ForTickets` instead

### DIFF
--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -166,12 +166,14 @@ class OpenSea {
                             completion(results)
                         }
                     } else {
+                        //Ignore UEFA from OpenSea, otherwise the token type would be saved wrongly as `.erc721` instead of `.erc721ForTickets`
+                        let excludingUefa = sum.filter { !$0.key.isUEFATicketContract }
                         var tokenIdCount = 0
-                        for (_, tokenIds) in sum {
+                        for (_, tokenIds) in excludingUefa {
                             tokenIdCount += tokenIds.count
                         }
                         strongSelf.cachePromise(withTokenIdCount: tokenIdCount, forOwner: owner)
-                        completion(.success(sum))
+                        completion(.success(excludingUefa))
                     }
                 }
             }


### PR DESCRIPTION
Also means symbol will be displayed correctly.

(Still refers to `UEFA` in the codebase, but oh well)