### PR TITLE
Fix: crash when scrolling assets because collection view is silently loaded by iOS with the wrong/non-existent items

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -450,7 +450,13 @@ extension TokensViewController: WalletFilterViewDelegate {
 
 extension TokensViewController: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.numberOfItems()
+        //Defensive check to make sure we don't return the wrong count. iOS might decide to load (the first time especially) the collection view at some point even if we don't switch to it, thus getting the wrong count and then at some point asking for a cell for those non-existent rows/items. E.g 10 tokens total, only 3 are collectibles and asked for the 6th cell
+        switch viewModel.filter {
+        case .collectiblesOnly:
+            return viewModel.numberOfItems()
+        case .all, .currencyOnly, .assetsOnly, .keyword:
+            return 0
+        }
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
Fixes #1651 

Before the PR:

1. App is launched
2. ALL tab is selected
3. Tap ASSETS tab and scroll to hide/reveal new rows
4. iOS might decide to load (the first time especially) the collection view at some point even if we don't switch to it, thus getting the wrong count
5. At some point, iOS ask for a cell(s) for those non-existent rows/items

E.g 10 tokens total (ALL), only 3 are collectibles and asked for the 6th cell

This PR adds a defensive check to make sure we only return a non-zero count for collectibles when we are actually at the collectibles tab