### PR TITLE
Make seed phrase display scrollable and avoid blocking the Clear button in Verify seed phrase screen

### DIFF
--- a/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
@@ -103,7 +103,10 @@ class ShowSeedPhraseViewController: UIViewController {
         footerBar.addSubview(buttonsBar)
 
         NSLayoutConstraint.activate([
-            stackView.anchorsConstraint(to: view, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 20)),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            stackView.topAnchor.constraint(equalTo: view.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: footerBar.topAnchor, constant: -7),
 
             buttonsBar.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor),
             buttonsBar.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor),

--- a/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
@@ -104,6 +104,7 @@ class VerifySeedPhraseViewController: UIViewController {
         self.state = .notDisplayedSeedPhrase
         super.init(nibName: nil, bundle: nil)
 
+        seedPhraseCollectionView.bounces = true
         seedPhraseCollectionView.seedPhraseDelegate = self
 
         roundedBackground.translatesAutoresizingMaskIntoConstraints = false
@@ -145,7 +146,10 @@ class VerifySeedPhraseViewController: UIViewController {
         NSLayoutConstraint.activate([
             seedPhraseTextView.heightAnchor.constraint(equalToConstant: ScreenChecker().isNarrowScreen ? 100: 140),
 
-            stackView.anchorsConstraint(to: view, edgeInsets: .init(top: 0, left: 20, bottom: 0, right: 20)),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            stackView.topAnchor.constraint(equalTo: view.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: clearChooseSeedPhraseButton.topAnchor, constant: -7),
 
             clearChooseSeedPhraseButton.leadingAnchor.constraint(equalTo: footerBar.leadingAnchor, constant: 10),
             clearChooseSeedPhraseButton.trailingAnchor.constraint(equalTo: footerBar.trailingAnchor, constant: -10),

--- a/AlphaWallet/Wallet/Views/SeedPhraseCollectionView.swift
+++ b/AlphaWallet/Wallet/Views/SeedPhraseCollectionView.swift
@@ -11,6 +11,7 @@ class SeedPhraseCollectionView: UICollectionView {
     var viewModel: SeedPhraseCollectionViewModel = .init(isSelectable: true, shouldShowSequenceNumber: true) {
         didSet {
             reloadData()
+            flashScrollIndicators()
         }
     }
     weak var seedPhraseDelegate: SeedPhraseCollectionViewDelegate?


### PR DESCRIPTION
Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/73120664-148e0d00-3fac-11ea-912b-bbd35ca708ed.png" width=200>|<img src="https://user-images.githubusercontent.com/56189/73120665-148e0d00-3fac-11ea-806e-dcd075b98dd7.png" width=200>

Similar for the previous screen which displays the seed phrase