### PR TITLE
Add and use API key for Etherscan

### DIFF
--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -70,7 +70,17 @@ extension AlphaWalletService: TargetType {
         switch self {
         case .getTransactions(_, let server, let address, let startBlock, let endBlock, let sortOrder):
             switch server {
-            case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .artis_tau1:
+            case .main, .kovan, .ropsten, .rinkeby, .goerli:
+                return .requestParameters(parameters: [
+                    "module": "account",
+                    "action": "txlist",
+                    "address": address,
+                    "startblock": startBlock,
+                    "endblock": endBlock,
+                    "sort": sortOrder.rawValue,
+                    "apikey": Constants.Credentials.etherscanKey,
+                ], encoding: URLEncoding())
+            case .classic, .callisto, .custom, .poa, .sokol, .xDai, .artis_sigma1, .artis_tau1:
                 return .requestParameters(parameters: [
                     "module": "account",
                     "action": "txlist",

--- a/AlphaWallet/Settings/Types/Constants+Credentials.swift
+++ b/AlphaWallet/Settings/Types/Constants+Credentials.swift
@@ -5,5 +5,6 @@ import Foundation
 extension Constants {
     enum Credentials {
         static let infuraKey = "da3717f25f824cc1baa32d812386d93f"
+        static let etherscanKey = "1PX7RG8H4HTDY8X55YRMCAKPZK476M23ZR"
     }
 }

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -122,11 +122,11 @@ enum RPCServer: Hashable, CaseIterable {
     }
 
     func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address) -> URL? {
-        return getEtherscanURL.flatMap { URL(string: $0 + address.eip55String) }
+        return getEtherscanURL.flatMap { URL(string: "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)") }
     }
 
     func etherscanAPIURLForERC20TxList(for address: AlphaWallet.Address) -> URL? {
-        return getEtherscanURLERC20Events.flatMap { URL(string: $0 + address.eip55String) }
+        return getEtherscanURLERC20Events.flatMap { URL(string: "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)") }
     }
 
     func etherscanContractDetailsWebPageURL(for address: AlphaWallet.Address) -> URL {

--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -29,6 +29,7 @@ class TransactionDataCoordinator: Coordinator {
     private let fetchLatestTransactionsQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.name = "Fetch Latest Transactions"
+        //A limit is important for many reasons. One of which is Etherscan has a rate limit of 5 calls/sec/IP address according to https://etherscan.io/apis
         queue.maxConcurrentOperationCount = 3
         return queue
     }()


### PR DESCRIPTION
Closes #1677 

This PR 

* adds an Etherscan API key
* uses it for access
* use the same approach to manage the key described in #1583 

Since the deadline to use an API key is Feb 15, a build will have to go live before then for transaction history and auto detection of ERC20 tokens from transactions