### PR TITLE
Fix malicious takeover previously owned ens names

### DIFF
--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -115,6 +115,7 @@ public struct Constants {
     static let ENSRegistrarAddress = AlphaWallet.Address(string: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e")!
     static let ENSRegistrarRopsten = ENSRegistrarAddress
     static let ENSRegistrarRinkeby = ENSRegistrarAddress
+    static let ENSRegistrarGoerli = ENSRegistrarAddress
     static let ENSRegistrarXDAI = AlphaWallet.Address(string: "0x17734f3709486b1d7015f941c069cebf8017a833")!
 
     //Misc

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -112,9 +112,9 @@ public struct Constants {
     public static let katContractAddress = "0x06012c8cf97bead5deae237070f9587f8e7a266d"
 
     //ENS
-    static let ENSRegistrarAddress = AlphaWallet.Address(string: "0x314159265dD8dbb310642f98f50C066173C1259b")!
-    static let ENSRegistrarRopsten = AlphaWallet.Address(string: "0x112234455c3a32fd11230c42e7bccd4a84e02010")!
-    static let ENSRegistrarRinkeby = AlphaWallet.Address(string: "0xe7410170f87102df0055eb195163a03b7f2bff4a")!
+    static let ENSRegistrarAddress = AlphaWallet.Address(string: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e")!
+    static let ENSRegistrarRopsten = ENSRegistrarAddress
+    static let ENSRegistrarRinkeby = ENSRegistrarAddress
     static let ENSRegistrarXDAI = AlphaWallet.Address(string: "0x17734f3709486b1d7015f941c069cebf8017a833")!
 
     //Misc

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -289,8 +289,9 @@ enum RPCServer: Hashable, CaseIterable {
         case .main: return Constants.ENSRegistrarAddress
         case .ropsten: return Constants.ENSRegistrarRopsten
         case .rinkeby: return Constants.ENSRegistrarRinkeby
+        case .goerli: return Constants.ENSRegistrarGoerli
         case .xDai: return Constants.ENSRegistrarXDAI
-        case .kovan, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .custom:
+        case .kovan, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .custom:
             return Constants.ENSRegistrarAddress
         }
     }


### PR DESCRIPTION
This PR handles the change required by https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a

Replaces #1682 

* Update all the registrar contracts to be the same
    * https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
    * https://ropsten.etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
    * https://rinkeby.etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e
* Adds registrar contract for Goerli, which is the same address too
    * https://goerli.etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e