### PR TITLE
remove blockchain name text

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -305,19 +305,6 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
-    var blockChainName: String {
-        switch self {
-        case .xDai:
-            return R.string.localizable.blockchainXDAI()
-        case .artis_sigma1:
-            return R.string.localizable.blockchainARTISSigma1()
-        case .artis_tau1:
-            return R.string.localizable.blockchainARTISTau1()
-        case .main, .rinkeby, .ropsten, .custom, .callisto, .classic, .kovan, .sokol, .poa, .goerli:
-            return R.string.localizable.blockchainEthereum()
-        }
-    }
-
     var blockChainNameColor: UIColor {
         switch self {
         case .main: return .init(red: 41, green: 134, blue: 175)

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -65,10 +65,6 @@ struct EthTokenViewCellViewModel {
         return Screen.TokenCard.Metric.blockChainTagCornerRadius
     }
 
-    var blockChainName: String {
-        return server.blockChainName
-    }
-
     var backgroundColor: UIColor {
         return Screen.TokenCard.Color.background
     }

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
@@ -52,10 +52,6 @@ struct FungibleTokenViewCellViewModel {
         return Screen.TokenCard.Metric.blockChainTagCornerRadius
     }
 
-    var blockChainName: String {
-        return server.blockChainName
-    }
-
     var backgroundColor: UIColor {
         return Screen.TokenCard.Color.background
     }

--- a/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
@@ -34,14 +34,6 @@ struct NonFungibleTokenViewCellViewModel {
         }
     }
 
-    var issuerSeparator: String {
-        if issuer.isEmpty {
-            return ""
-        } else {
-            return "|"
-        }
-    }
-
     var blockChainNameFont: UIFont {
         return Screen.TokenCard.Font.blockChainName
     }
@@ -64,10 +56,6 @@ struct NonFungibleTokenViewCellViewModel {
 
     var blockChainNameCornerRadius: CGFloat {
         return Screen.TokenCard.Metric.blockChainTagCornerRadius
-    }
-
-    var blockChainName: String {
-        return server.blockChainName
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Tokens/ViewModels/TokensCardViewControllerHeaderViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensCardViewControllerHeaderViewModel.swift
@@ -28,14 +28,6 @@ struct TokensCardViewControllerHeaderViewModel {
         }
     }
 
-    var issuerSeparator: String {
-        if issuer.isEmpty {
-            return ""
-        } else {
-            return "|"
-        }
-    }
-
     var blockChainNameFont: UIFont {
         return Screen.TokenCard.Font.blockChainName
     }
@@ -54,10 +46,6 @@ struct TokensCardViewControllerHeaderViewModel {
 
     var blockChainNameTextAlignment: NSTextAlignment {
         return .center
-    }
-
-    var blockChainName: String {
-        return server.blockChainName
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
@@ -9,7 +9,6 @@ class EthTokenViewCell: UITableViewCell {
 
     private let background = UIView()
     private let titleLabel = UILabel()
-    private let blockchainLabel = UILabel()
     private let separator = UILabel()
     private let issuerLabel = UILabel()
     private let blockChainTagLabel = UILabel()
@@ -41,7 +40,7 @@ class EthTokenViewCell: UITableViewCell {
         valueLabel.textAlignment = .center
         valueNameLabel.textAlignment = .center
 
-        let bottomRowStack = [blockchainLabel, separator, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
+        let bottomRowStack = [separator, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
         let footerValuesStack = [valuePercentageChangeValueLabel, valueChangeLabel, valueLabel].asStackView(distribution: .fillEqually, spacing: 15)
         let footerNamesStack = [valuePercentageChangePeriodLabel, valueChangeNameLabel, valueNameLabel].asStackView(distribution: .fillEqually, spacing: 15)
         let footerStackView = [
@@ -112,10 +111,6 @@ class EthTokenViewCell: UITableViewCell {
         blockChainTagLabel.textColor = viewModel.blockChainNameColor
         blockChainTagLabel.font = viewModel.blockChainNameFont
         blockChainTagLabel.text = viewModel.blockChainTag
-
-        blockchainLabel.textColor = viewModel.subtitleColor
-        blockchainLabel.font = viewModel.subtitleFont
-        blockchainLabel.text = viewModel.blockChainName
 
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont

--- a/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
@@ -9,7 +9,6 @@ class FungibleTokenViewCell: UITableViewCell {
 
     private let background = UIView()
     private let titleLabel = UILabel()
-    private let blockchainLabel = UILabel()
     private let separator = UILabel()
     private let issuerLabel = UILabel()
     private let blockChainTagLabel = UILabel()
@@ -26,7 +25,7 @@ class FungibleTokenViewCell: UITableViewCell {
         contentView.addSubview(cellSeparators.top)
         contentView.addSubview(cellSeparators.bottom)
 
-        let bottomRowStack = [blockchainLabel, separator, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
+        let bottomRowStack = [separator, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)
@@ -86,10 +85,6 @@ class FungibleTokenViewCell: UITableViewCell {
         blockChainTagLabel.textColor = viewModel.blockChainNameColor
         blockChainTagLabel.font = viewModel.blockChainNameFont
         blockChainTagLabel.text = viewModel.blockChainTag
-
-        blockchainLabel.textColor = viewModel.subtitleColor
-        blockchainLabel.font = viewModel.subtitleFont
-        blockchainLabel.text = viewModel.blockChainName
 
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont

--- a/AlphaWallet/Tokens/Views/NonFungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/NonFungibleTokenViewCell.swift
@@ -9,8 +9,6 @@ class NonFungibleTokenViewCell: UITableViewCell {
 
     private let background = UIView()
     private let titleLabel = UILabel()
-    private let blockchainLabel = UILabel()
-    private let separator = UILabel()
     private let issuerLabel = UILabel()
     private let blockChainTagLabel = UILabel()
     private let cellSeparators = (top: UIView(), bottom: UIView())
@@ -27,7 +25,7 @@ class NonFungibleTokenViewCell: UITableViewCell {
         contentView.addSubview(cellSeparators.bottom)
 
         //TODO write snapshot test to ensure separator + issueLabel is positioned correctly, in particular. Doesn't display at the right edge of the screen. Do it for every cell class used in TokensViewController
-        let bottomRowStack = [blockchainLabel, separator, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
+        let bottomRowStack = [issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)
@@ -88,17 +86,9 @@ class NonFungibleTokenViewCell: UITableViewCell {
         blockChainTagLabel.font = viewModel.blockChainNameFont
         blockChainTagLabel.text = viewModel.blockChainTag
 
-        blockchainLabel.textColor = viewModel.subtitleColor
-        blockchainLabel.font = viewModel.subtitleFont
-        blockchainLabel.text = viewModel.blockChainName
-
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont
         issuerLabel.text = viewModel.issuer
-
-        separator.textColor = viewModel.subtitleColor
-        separator.font = viewModel.subtitleFont
-        separator.text = viewModel.issuerSeparator
 
         cellSeparators.top.backgroundColor = GroupedTable.Color.cellSeparator
         cellSeparators.bottom.backgroundColor = GroupedTable.Color.cellSeparator

--- a/AlphaWallet/Tokens/Views/TokenCardsViewControllerHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokenCardsViewControllerHeader.swift
@@ -23,8 +23,6 @@ class TokenCardsViewControllerHeader: UIView {
         addSubview(background)
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        // TODO maybe we should allow the label to be pressed to open the page? Or simply drop the feature as it is not obvious to the user anyway
-        //blockChainTagLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)

--- a/AlphaWallet/Tokens/Views/TokenCardsViewControllerHeader.swift
+++ b/AlphaWallet/Tokens/Views/TokenCardsViewControllerHeader.swift
@@ -11,9 +11,6 @@ class TokenCardsViewControllerHeader: UIView {
 
     private let background = UIView()
     private let titleLabel = UILabel()
-    //TODO rename? Button now
-    private let blockchainLabel = UIButton(type: .system)
-    private let separator = UILabel()
     private let issuerLabel = UILabel()
     private let blockChainTagLabel = UILabel()
 
@@ -26,12 +23,12 @@ class TokenCardsViewControllerHeader: UIView {
         addSubview(background)
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        blockchainLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
+        // TODO maybe we should allow the label to be pressed to open the page? Or simply drop the feature as it is not obvious to the user anyway
+        //blockChainTagLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)
-        let bottomRowStack = [blockchainLabel, separator, issuerLabel, UIView.spacerWidth(flexible: true), blockChainTagLabel].asStackView(spacing: 15)
+        let bottomRowStack = [issuerLabel, UIView.spacerWidth(flexible: true), blockChainTagLabel].asStackView(spacing: 15)
         let stackView = [
             titleLabel,
             bottomRowStack
@@ -68,10 +65,6 @@ class TokenCardsViewControllerHeader: UIView {
         titleLabel.text = viewModel.title
         titleLabel.adjustsFontSizeToFitWidth = true
 
-        blockchainLabel.setTitleColor(viewModel.subtitleColor, for: .normal)
-        blockchainLabel.titleLabel?.font = viewModel.subtitleFont
-        blockchainLabel.setTitle(viewModel.blockChainName, for: .normal)
-
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont
         let issuer = viewModel.issuer
@@ -80,9 +73,6 @@ class TokenCardsViewControllerHeader: UIView {
         } else {
             issuerLabel.text = issuer
         }
-        separator.textColor = viewModel.subtitleColor
-        separator.font = viewModel.subtitleFont
-        separator.text = viewModel.issuerSeparator
 
         blockChainTagLabel.textAlignment = viewModel.blockChainNameTextAlignment
         blockChainTagLabel.cornerRadius = 7

--- a/AlphaWallet/Transactions/Views/TransactionViewCell.swift
+++ b/AlphaWallet/Transactions/Views/TransactionViewCell.swift
@@ -10,7 +10,7 @@ class TransactionViewCell: UITableViewCell {
     private let titleLabel = UILabel()
     private let amountLabel = UILabel()
     private let subTitleLabel = UILabel()
-    private let blockchainLabel = UILabel()
+    private let blockchainTagLabel = UILabel()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -35,11 +35,11 @@ class TransactionViewCell: UITableViewCell {
         ].asStackView(axis: .vertical, distribution: .fillProportionally, spacing: 0)
         leftStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        blockchainLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-        blockchainLabel.setContentHuggingPriority(.required, for: .vertical)
+        blockchainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        blockchainTagLabel.setContentHuggingPriority(.required, for: .vertical)
         let rightStackView = [
             amountLabel,
-            blockchainLabel,
+            blockchainTagLabel,
         ].asStackView(axis: .vertical, alignment: .trailing)
         rightStackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -56,7 +56,7 @@ class TransactionViewCell: UITableViewCell {
         background.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            blockchainLabel.heightAnchor.constraint(equalToConstant: Screen.TokenCard.Metric.blockChainTagHeight),
+            blockchainTagLabel.heightAnchor.constraint(equalToConstant: Screen.TokenCard.Metric.blockChainTagHeight),
 
             statusImageView.widthAnchor.constraint(lessThanOrEqualToConstant: 26),
 
@@ -85,12 +85,12 @@ class TransactionViewCell: UITableViewCell {
         subTitleLabel.textColor = viewModel.subTitleTextColor
         subTitleLabel.font = viewModel.subTitleFont
 
-        blockchainLabel.textAlignment = viewModel.blockChainNameTextAlignment
-        blockchainLabel.cornerRadius = viewModel.blockChainNameCornerRadius
-        blockchainLabel.backgroundColor = viewModel.blockChainNameBackgroundColor
-        blockchainLabel.textColor = viewModel.blockChainNameColor
-        blockchainLabel.font = viewModel.blockChainNameFont
-        blockchainLabel.text = viewModel.blockChainName
+        blockchainTagLabel.textAlignment = viewModel.blockChainNameTextAlignment
+        blockchainTagLabel.cornerRadius = viewModel.blockChainNameCornerRadius
+        blockchainTagLabel.backgroundColor = viewModel.blockChainNameBackgroundColor
+        blockchainTagLabel.textColor = viewModel.blockChainNameColor
+        blockchainTagLabel.font = viewModel.blockChainNameFont
+        blockchainTagLabel.text = viewModel.blockChainName
 
         amountLabel.attributedText = viewModel.amountAttributedString
         amountLabel.font = viewModel.amountFont

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -46,10 +46,6 @@ struct SendHeaderViewViewModel {
         return Screen.TokenCard.Metric.blockChainTagCornerRadius
     }
 
-    var blockChainName: String {
-        return server.blockChainName
-    }
-
     var backgroundColor: UIColor {
         return Screen.TokenCard.Color.background
     }

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModelWithIntroduction.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModelWithIntroduction.swift
@@ -18,10 +18,6 @@ struct SendHeaderViewViewModelWithIntroduction {
         return ""
     }
 
-    var blockChainName: String {
-        return server.blockChainName
-    }
-
     var backgroundColor: UIColor {
         return Screen.TokenCard.Color.background
     }

--- a/AlphaWallet/Transfer/Views/SendHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/SendHeaderView.swift
@@ -8,8 +8,6 @@ protocol SendHeaderViewDelegate: class {
 class SendHeaderView: UIView {
     private let background = UIView()
     private let titleLabel = UILabel()
-    //TODO rename? Button now
-    private let blockchainLabel = UIButton(type: .system)
     private let issuerLabel = UILabel()
     private let blockChainTagLabel = UILabel()
     private let middleBorder = UIView()
@@ -40,16 +38,15 @@ class SendHeaderView: UIView {
         valueChangeNameLabel.textAlignment = .center
         valueLabel.textAlignment = .center
         valueNameLabel.textAlignment = .center
-
-        blockchainLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
+        //TODO set label on contract page?
+        //blockchainLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
 
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)
         let titleRowStack = [titleLabel, UIView.spacerWidth(flexible: true), blockChainTagLabel].asStackView(spacing: 15, alignment: .center)
 
-        let bottomRowStack = [blockchainLabel, issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
-        blockchainLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        let bottomRowStack = [issuerLabel, UIView.spacerWidth(flexible: true)].asStackView(spacing: 15)
 
         let footerValuesStack = [valuePercentageChangeValueLabel, valueChangeLabel, valueLabel].asStackView(distribution: .equalCentering, spacing: 15)
 
@@ -88,8 +85,6 @@ class SendHeaderView: UIView {
             background.heightAnchor.constraint(equalTo: heightAnchor),
             backgroundWidthConstraint,
 
-            blockchainLabel.heightAnchor.constraint(equalToConstant: Screen.TokenCard.Metric.blockChainTagHeight),
-
             middleBorder.heightAnchor.constraint(equalToConstant: 1),
 
             stackView.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 37),
@@ -118,10 +113,6 @@ class SendHeaderView: UIView {
         titleLabel.font = viewModel.titleFont
         titleLabel.text = viewModel.title
         titleLabel.adjustsFontSizeToFitWidth = true
-
-        blockchainLabel.setTitleColor(viewModel.subtitleColor, for: .normal)
-        blockchainLabel.titleLabel?.font = viewModel.subtitleFont
-        blockchainLabel.setTitle(viewModel.blockChainName, for: .normal)
 
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont

--- a/AlphaWallet/Transfer/Views/SendHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/SendHeaderView.swift
@@ -38,9 +38,6 @@ class SendHeaderView: UIView {
         valueChangeNameLabel.textAlignment = .center
         valueLabel.textAlignment = .center
         valueNameLabel.textAlignment = .center
-        //TODO set label on contract page?
-        //blockchainLabel.addTarget(self, action: #selector(showContractWebPage), for: .touchUpInside)
-
 
         blockChainTagLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         blockChainTagLabel.setContentHuggingPriority(.required, for: .horizontal)

--- a/AlphaWallet/Transfer/Views/SendHeaderViewWithIntroduction.swift
+++ b/AlphaWallet/Transfer/Views/SendHeaderViewWithIntroduction.swift
@@ -3,11 +3,9 @@
 import UIKit
 import WebKit
 
-//TODO remove duplicate of SendHeaderView once IFRAME design is clear
 class SendHeaderViewWithIntroduction: UIView {
     private let background = UIView()
     private let titleLabel = UILabel()
-    private let blockchainLabel = UILabel()
     private let issuerLabel = UILabel()
     private let middleBorder = UIView()
     private var footerStackView: UIStackView?
@@ -35,7 +33,7 @@ class SendHeaderViewWithIntroduction: UIView {
         valueLabel.textAlignment = .center
         valueNameLabel.textAlignment = .center
 
-        let bottomRowStack = [blockchainLabel, issuerLabel].asStackView(spacing: 15)
+        let bottomRowStack = [issuerLabel].asStackView(spacing: 15)
 
         let footerValuesStack = [valuePercentageChangeValueLabel, valueChangeLabel, valueLabel].asStackView(distribution: .fillEqually, spacing: 15)
 
@@ -93,10 +91,6 @@ class SendHeaderViewWithIntroduction: UIView {
         titleLabel.font = viewModel.titleFont
         titleLabel.text = viewModel.title
         titleLabel.adjustsFontSizeToFitWidth = true
-
-        blockchainLabel.textColor = viewModel.subtitleColor
-        blockchainLabel.font = viewModel.subtitleFont
-        blockchainLabel.text = viewModel.blockChainName
 
         issuerLabel.textColor = viewModel.subtitleColor
         issuerLabel.font = viewModel.subtitleFont


### PR DESCRIPTION
Closes #1462

@hboon before merging could you please quickly set the spacing back to how it was before? It has made the token cards smaller

Also, we no longer have a target to show the contract page anymore, I believe this is possible to do on a label indirectly but I am not sure it is valuable to the user as it is not obvious at all that clicking the label does anything and the tx page allows you to access etherscan in a more obvious fashion