### PR TITLE
Fix: Should reveal Transactions tab after sending a token instead of showing the single token screen

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -705,9 +705,11 @@ extension InCoordinator: PaymentCoordinatorDelegate {
         switch result {
         case .sentTransaction(let transaction):
             handlePendingTransaction(transaction: transaction)
-            coordinator.navigationController.dismiss(animated: true, completion: nil)
             showTransactionSent(transaction: transaction)
             removeCoordinator(coordinator)
+
+            guard let currentTab = tabBarController?.selectedViewController else { return }
+            currentTab.dismiss(animated: true)
 
             // Once transaction sent, show transactions screen.
             showTab(.transactions)


### PR DESCRIPTION
This is the screen shown after confirming the transaction:

Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/74312542-da46ad00-4dac-11ea-98ec-b9bdb0901253.png" width=200>|<img src="https://user-images.githubusercontent.com/56189/74312545-dc107080-4dac-11ea-9731-570ef400a473.png" width=200>

The code was originally written to switch to the Transactions tab, but a bug was causing it to work incorrectly. It's better since the balance and transaction history in the screen before the PR doesn't reflect the pending transaction and the Transactions tab does.
