### PR TITLE
Fix: tint color not set correctly in actionsheet etc, including:

### DIFF
--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -22,6 +22,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
+        //Necessary to make UIAlertController have the correct tint colors, despite already doing: `UIWindow.appearance().tintColor = Colors.appTint`
+        window?.tintColor = Colors.appTint
         do {
             let keystore = try EtherKeystore()
             appCoordinator = AppCoordinator(window: window!, keystore: keystore)

--- a/AlphaWallet/Tokens/ViewModels/SegmentedControlViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/SegmentedControlViewModel.swift
@@ -50,6 +50,6 @@ struct SegmentedControlViewModel {
 	}
 
 	var selectedBarColor: UIColor {
-		return R.color.azure()!
+		return Colors.appTint
 	}
 }


### PR DESCRIPTION
* Alerts, actionsheet and cursors
* Copy button in My Wallet Address screen
* Checkboxes in select language and enabled servers screens

Made the tint color magenta to illustrate the problem:

Before PR | After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/75511469-4706ac00-5a29-11ea-9980-55335f95e118.png" width=200>| <img src="https://user-images.githubusercontent.com/56189/75511494-5554c800-5a29-11ea-8368-3fcb69af1af6.png" width=200>