### PR TITLE
When access to wallet fails, in the error message, mention that should re-import their seed/key if they have restored/migrated to new device

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -333,7 +333,7 @@
 "accounts.delete.error.accountNotFound" = "Account not found";
 "accounts.delete.error.failedToSignMessage" = "Failed to sign message";
 "accounts.delete.error.failedToExportPrivateKey" = "Failed to export private key";
-"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed";
+"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "Chain ID" = "Chain ID";
 "Endpoint" = "Endpoint";
 "settings.preferences.button.title" = "Show Tokens on Launch";
@@ -402,7 +402,7 @@
 "keystore.accessKey.hd.verify" = "Accessing your wallet seed phrase to verify against it";
 "keystore.accessKey.hd.prepareToVerify" = "Accessing your wallet seed phrase to let you verify against it";
 "keystore.accessKey.sign" = "Accessing your wallet key to sign";
-"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. Import your wallet again or enable passcode";
+"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "keystore.accessKey.cancelled" = "You have denied access to your wallet";
 "keystore.accessKey.lock.fail" = "Can't lock your wallet key. Maybe your iOS Passcode is not enabled?";
 "keystore.accessKey.hd.lock" = "To lock your seed phrase to increase security";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -330,7 +330,7 @@
 "accounts.delete.error.accountNotFound" = "No se ha encontrado la cuenta";
 "accounts.delete.error.failedToSignMessage" = "Error al firmar el mensaje";
 "accounts.delete.error.failedToExportPrivateKey" = "Error al exportar la clave privada";
-"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed";
+"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "Chain ID" = "ID de cadena";
 "Endpoint" = "Punto final";
 "settings.preferences.button.title" = "Mostrar tokens al iniciar";
@@ -401,7 +401,7 @@
 "keystore.accessKey.hd.verify" = "Accessing your wallet seed phrase to verify against it";
 "keystore.accessKey.hd.prepareToVerify" = "Accessing your wallet seed phrase to let you verify against it";
 "keystore.accessKey.sign" = "Accessing your wallet key to sign";
-"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. Import your wallet again or enable passcode";
+"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "keystore.accessKey.cancelled" = "You have denied access to your wallet";
 "keystore.accessKey.lock.fail" = "Can't lock your wallet key. Maybe your iOS Passcode is not enabled?";
 "keystore.accessKey.hd.lock" = "To lock your seed phrase to increase security";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -331,7 +331,7 @@
 "accounts.delete.error.accountNotFound" = "アカウントが見つかりません";
 "accounts.delete.error.failedToSignMessage" = "メッセージの署名に失敗しました";
 "accounts.delete.error.failedToExportPrivateKey" = "秘密鍵をエクスポートできませんでした";
-"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed";
+"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "Chain ID" = "チェーン ID";
 "Endpoint" = "エンドポイント";
 "settings.preferences.button.title" = "起動時にトークンを表示";
@@ -402,7 +402,7 @@
 "keystore.accessKey.hd.verify" = "Accessing your wallet seed phrase to verify against it";
 "keystore.accessKey.hd.prepareToVerify" = "Accessing your wallet seed phrase to let you verify against it";
 "keystore.accessKey.sign" = "Accessing your wallet key to sign";
-"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. Import your wallet again or enable passcode";
+"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "keystore.accessKey.cancelled" = "You have denied access to your wallet";
 "keystore.accessKey.lock.fail" = "Can't lock your wallet key. Maybe your iOS Passcode is not enabled?";
 "keystore.accessKey.hd.lock" = "To lock your seed phrase to increase security";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -330,7 +330,7 @@
 "accounts.delete.error.accountNotFound" = "계정을 찾을 수 없습니다";
 "accounts.delete.error.failedToSignMessage" = "메시지에 서명하지 못했습니다";
 "accounts.delete.error.failedToExportPrivateKey" = "개인 키를 내보내지 못했습니다";
-"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed";
+"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "Chain ID" = "체인 ID";
 "Endpoint" = "엔드포인트";
 "settings.preferences.button.title" = "시작 시 토큰 표시";
@@ -401,7 +401,7 @@
 "keystore.accessKey.hd.verify" = "Accessing your wallet seed phrase to verify against it";
 "keystore.accessKey.hd.prepareToVerify" = "Accessing your wallet seed phrase to let you verify against it";
 "keystore.accessKey.sign" = "Accessing your wallet key to sign";
-"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. Import your wallet again or enable passcode";
+"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "keystore.accessKey.cancelled" = "You have denied access to your wallet";
 "keystore.accessKey.lock.fail" = "Can't lock your wallet key. Maybe your iOS Passcode is not enabled?";
 "keystore.accessKey.hd.lock" = "To lock your seed phrase to increase security";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -330,7 +330,7 @@
 "accounts.delete.error.accountNotFound" = "找不到账户";
 "accounts.delete.error.failedToSignMessage" = "签署消息失败";
 "accounts.delete.error.failedToExportPrivateKey" = "导出私钥失败";
-"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed";
+"accounts.delete.error.failedToExportSeed" = "Failed to export wallet seed. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "Chain ID" = "Chain ID";
 "Endpoint" = "端点";
 "settings.preferences.button.title" = "在开始页面显示 Token";
@@ -401,7 +401,7 @@
 "keystore.accessKey.hd.verify" = "Accessing your wallet seed phrase to verify against it";
 "keystore.accessKey.hd.prepareToVerify" = "Accessing your wallet seed phrase to let you verify against it";
 "keystore.accessKey.sign" = "Accessing your wallet key to sign";
-"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. Import your wallet again or enable passcode";
+"keystore.accessKey.needImportOrPasscode" = "Can't access your wallet. If you have migrated to a new phone or restored your device, you need to import your wallet again";
 "keystore.accessKey.cancelled" = "You have denied access to your wallet";
 "keystore.accessKey.lock.fail" = "Can't lock your wallet key. Maybe your iOS Passcode is not enabled?";
 "keystore.accessKey.hd.lock" = "To lock your seed phrase to increase security";

--- a/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
@@ -181,6 +181,7 @@ class ShowSeedPhraseViewController: UIViewController {
         errorLabel.textColor = viewModel.errorColor
         errorLabel.font = viewModel.errorFont
         errorLabel.text = viewModel.errorMessage
+        errorLabel.numberOfLines = 0
 
         seedPhraseCollectionView.configure()
 


### PR DESCRIPTION
It's a stop-gap until #1642 is properly implemented.