### PR TITLE
Make token balance displayed be always 4 decimal places, except for send confirmation and transaction details screen and for fiat to be 2 decimal places. Rounding down is always used

### DIFF
--- a/AlphaWallet/Accounts/ViewModels/AccountViewModel.swift
+++ b/AlphaWallet/Accounts/ViewModels/AccountViewModel.swift
@@ -22,7 +22,7 @@ struct AccountViewModel {
         return wallet.type == .watch(wallet.address)
     }
     var balance: String {
-        let amount = walletBalance?.amountFull ?? "--"
+        let amount = walletBalance?.amountShort ?? "--"
         return "\(amount) \(server.symbol)"
     }
     var address: AlphaWallet.Address {

--- a/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
+++ b/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
@@ -7,6 +7,7 @@ class CurrencyFormatter {
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
+        formatter.roundingMode = .down
         //TODO support multiple currency values
         formatter.currencyCode = Currency.USD.rawValue
         formatter.numberStyle = .currency

--- a/AlphaWallet/Foundation/StringFormatter.swift
+++ b/AlphaWallet/Foundation/StringFormatter.swift
@@ -9,6 +9,7 @@ final class StringFormatter {
         formatter.currencySymbol = ""
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
+        formatter.roundingMode = .down
         formatter.numberStyle = .currencyAccounting
         formatter.isLenient = true
         return formatter

--- a/AlphaWallet/Transactions/ViewModels/BalanceTokenViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/BalanceTokenViewModel.swift
@@ -14,7 +14,7 @@ struct BalanceTokenViewModel: BalanceBaseViewModel {
     }
 
     var amountShort: String {
-        return EtherNumberFormatter.full.string(from: token.valueBigInt, decimals: token.decimals)
+        return EtherNumberFormatter.short.string(from: token.valueBigInt, decimals: token.decimals)
     }
 
     var name: String {


### PR DESCRIPTION
Before this PR, fiat is rounded off, and token balance is rounded down, and not always rounded to 4 decimal places.

This PR is sync from a downstream project. It makes sense to bring it upstream, because the people who raised this are good with money and one of their rationale for rounding down instead of rounding off ("the conventional rounding we are usually used to") is if a balance of X is shown because of rounding, the user should be able to transfer X instead of the app complaining that the balance is less than X when they enter X (ignoring gas for the moment).

This is also consistent with upcoming Fiji changes where the browser and list of wallets screen displays balance in 4 decimal places and how we have always done it in most parts of the app.

In particular, this PR affects:

* balance in wallets list screen and token screen (with send/receive buttons)
* fiat in send screen

