### PR TITLE
Support EIP681 payment links for EIP681 that has no recipient address

### DIFF
--- a/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
+++ b/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
@@ -67,7 +67,7 @@ class CustomUrlSchemeCoordinator: Coordinator {
         return true
     }
 
-    private func openSendPayFlowFor(server: RPCServer, contract: AlphaWallet.Address, recipient: AddressOrEnsName, amount: String) {
+    private func openSendPayFlowFor(server: RPCServer, contract: AlphaWallet.Address, recipient: AddressOrEnsName?, amount: String) {
         let tokensDatastore = tokensDatastores[server]
         guard let tokenObject = tokensDatastore.token(forContract: contract) else { return }
         let amountConsideringDecimals: String

--- a/AlphaWallet/Foundation/Eip681Parser.swift
+++ b/AlphaWallet/Foundation/Eip681Parser.swift
@@ -7,10 +7,10 @@ import PromiseKit
 //In the future, this can include invoking functions other than for sending of Ether and tokens
 enum Eip681Type {
     case nativeCryptoSend(server: RPCServer?, recipient: AddressOrEnsName, amount: String)
-    case erc20Send(contract: AlphaWallet.Address, server: RPCServer?, recipient: AddressOrEnsName, amount: String)
+    case erc20Send(contract: AlphaWallet.Address, server: RPCServer?, recipient: AddressOrEnsName?, amount: String)
     case invalidOrNotSupported
 
-    var parameters: (contract: AlphaWallet.Address, RPCServer?, recipient: AddressOrEnsName, amount: String)? {
+    var parameters: (contract: AlphaWallet.Address, RPCServer?, recipient: AddressOrEnsName?, amount: String)? {
         switch self {
         case .nativeCryptoSend(let server, let recipient, let amount):
             return (Constants.nativeCryptoAddressInDatabase, server, recipient, amount)
@@ -41,7 +41,8 @@ struct Eip681Parser {
     //https://github.com/ethereum/EIPs/blob/master/EIPS/eip-681.md
     func parse() -> Promise<Eip681Type> {
         let chainId = params["chainId"].flatMap { Int($0) }
-        if let recipient = params["address"].flatMap({ AddressOrEnsName(string: $0) }), functionName == "transfer", let contract = address.contract {
+        if functionName == "transfer", let contract = address.contract {
+            let recipient = params["address"].flatMap({ AddressOrEnsName(string: $0) })
             let optionalAmountBigInt = params["uint256"].flatMap({ Double($0) }).flatMap({ BigInt($0) })
             let amount: String
             if let amountBigInt = optionalAmountBigInt {

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -383,7 +383,7 @@ extension SendViewController: QRCodeReaderDelegate {
         return amountString.flatMap { BigInt($0) }
     }
 
-    private func configureFor(contract: AlphaWallet.Address, recipient: AddressOrEnsName, amount: BigInt?, shouldConfigureBalance: Bool = true) {
+    private func configureFor(contract: AlphaWallet.Address, recipient: AddressOrEnsName?, amount: BigInt?, shouldConfigureBalance: Bool = true) {
         guard let tokenObject = storage.token(forContract: contract) else { return }
         let amount = amount.flatMap { EtherNumberFormatter.full.string(from: $0, decimals: tokenObject.decimals) }
         let transferType: TransferType

--- a/AlphaWalletTests/Foundation/QRCodeValueParserTests.swift
+++ b/AlphaWalletTests/Foundation/QRCodeValueParserTests.swift
@@ -181,8 +181,31 @@ class QRCodeValueParserTests: XCTestCase {
                 case .erc20Send(let contract, let chainId, let recipient, let amount):
                     XCTAssertEqual(contract, AlphaWallet.Address(string: "0x744d70fdbe2ba4cf95131626614a1763df805b9e"))
                     XCTAssertNil(chainId)
-                    XCTAssertTrue(recipient.sameContract(as: "0x3d597789ea16054a084ac84ce87f50df9198f415"))
+                    XCTAssertTrue(recipient?.sameContract(as: "0x3d597789ea16054a084ac84ce87f50df9198f415") ?? false)
                     XCTAssertEqual(amount, "31400000000000000000")
+                case .nativeCryptoSend, .invalidOrNotSupported:
+                    XCTFail("Parsed as wrong EIP 681 type")
+                }
+            }.cauterize()
+        }
+        wait(for: [expectation], timeout: 20)
+    }
+
+    func testParseErc20SendWithoutRecipient() {
+        guard let qrCodeValue = QRCodeValueParser.from(string: "ethereum:0x60fa213f48cd0d83b54380108ccd03a6993247e0/transfer?uint256=1.5e18") else { return XCTFail("Can't parse EIP 681") }
+        let expectation = self.expectation(description: "Promise resolves")
+        switch qrCodeValue {
+        case .address:
+            XCTFail("Can't parse EIP 681")
+        case .eip681(let protocolName, let address, let functionName, let params):
+            Eip681Parser(protocolName: protocolName, address: address, functionName: functionName, params: params).parse().done { result in
+                expectation.fulfill()
+                switch result {
+                case .erc20Send(let contract, let chainId, let recipient, let amount):
+                    XCTAssertEqual(contract, AlphaWallet.Address(string: "0x60fa213f48cd0d83b54380108ccd03a6993247e0"))
+                    XCTAssertNil(chainId)
+                    XCTAssertNil(recipient)
+                    XCTAssertEqual(amount, "1500000000000000000")
                 case .nativeCryptoSend, .invalidOrNotSupported:
                     XCTFail("Parsed as wrong EIP 681 type")
                 }
@@ -226,7 +249,7 @@ class QRCodeValueParserTests: XCTestCase {
                 case .erc20Send(let contract, let chainId, let recipient, let amount):
                     XCTAssertEqual(contract, AlphaWallet.Address(string: "0x744d70fdbe2ba4cf95131626614a1763df805b9e"))
                     XCTAssertNil(chainId)
-                    XCTAssertTrue(recipient.sameContract(as: "0x3d597789ea16054a084ac84ce87f50df9198f415"))
+                    XCTAssertTrue(recipient?.sameContract(as: "0x3d597789ea16054a084ac84ce87f50df9198f415") ?? false)
                     XCTAssertEqual(amount, "")
                 case .nativeCryptoSend, .invalidOrNotSupported:
                     XCTFail("Parsed as wrong EIP 681 type")


### PR DESCRIPTION
This PR adds support for EIP681 payment links for ERC20 without the recipient `address`, e.g.

ethereum:0x744d70fdbe2ba4cf95131626614a1763df805b9e/transfer?uint256=314e17