### PR TITLE
Fix: rate limited code using `RateLimiter` doesn't fire during busy periods

### DIFF
--- a/AlphaWallet/Core/Types/RateLimiter.swift
+++ b/AlphaWallet/Core/Types/RateLimiter.swift
@@ -2,23 +2,43 @@
 
 import Foundation
 
-///One limitation of this class due to simplification: if "requests" keep coming in, each with the time limit from the last, the block will not fire until one of the request gets a breather of `limit`
 class RateLimiter {
+    private let name: String?
     private let block: () -> Void
     private let limit: TimeInterval
     private var timer: Timer?
+    private var shouldRunWhenWindowCloses = false
+    private var isWindowActive: Bool {
+        timer?.isValid ?? false
+    }
 
-    init(limit: TimeInterval, block: @escaping () -> Void) {
+    init(name: String? = nil, limit: TimeInterval, autoRun: Bool = false, block: @escaping () -> Void) {
+        self.name = name
         self.limit = limit
         self.block = block
+        if autoRun {
+            run()
+        }
     }
 
     func run() {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(timeInterval: limit, target: self, selector: #selector(runBlock), userInfo: nil, repeats: false)
+        if isWindowActive {
+            shouldRunWhenWindowCloses = true
+        } else {
+            runWithNewWindow()
+        }
     }
 
-    @objc private func runBlock() {
+    @objc private func windowIsClosed() {
+        if shouldRunWhenWindowCloses {
+            runWithNewWindow()
+        }
+    }
+
+    private func runWithNewWindow() {
+        shouldRunWhenWindowCloses = false
         block()
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(timeInterval: limit, target: self, selector: #selector(windowIsClosed), userInfo: nil, repeats: false)
     }
 }


### PR DESCRIPTION
The `RateLimiter` class is useful because it lets us specify a `block` which can only run 1 time within a certain time limit T. eg. not to refresh by hitting an API endpoint too often without the client code having to deal with this directly.

```
let rateLimiter = RateLimiter(limit: 10) { [weak self] in
    doSomethingThatShouldNotHappenTooOften()
}

rateLimiter.run() //as often as we like
```


Before this PR, if "requests" to run this block repeatedly occurred within the window T, T will be reset each time, so `block` finally runs when no requests arrive within the last T window. During busy periods, this can mean `block` never runs.

This PR fixes it so that `block` is run immediately and then the window T starts and during this window, `block` no longer gets fired (as one would expect rate limiting to work)