### PR TITLE
[TokenScript schema 2020/03] Extract <style>, <script>, <body> tags from TokenScript views

### DIFF
--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenCardRowViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenCardRowViewModel.swift
@@ -126,9 +126,10 @@ struct ImportMagicTokenCardRowViewModel: TokenCardRowViewModelProtocol {
     var tokenScriptHtml: (html: String, hash: Int) {
         guard let tokenHolder = importMagicTokenViewControllerViewModel.tokenHolder else { return (html: "", hash: 0) }
         let xmlHandler = XMLHandler(contract: tokenHolder.contractAddress, assetDefinitionStore: assetDefinitionStore)
-        let html = xmlHandler.tokenViewIconifiedHtml
-        let hash = html.hashForCachingHeight
-        return (html: wrapWithHtmlViewport(html, forTokenHolder: tokenHolder), hash: hash)
+        let (html: html, style: style) = xmlHandler.tokenViewIconifiedHtml
+        //Just an easy way to generate a hash for style + HTML
+        let hash = "\(style)\(html)".hashForCachingHeight
+        return (html: wrapWithHtmlViewport(html: html, style: style, forTokenHolder: tokenHolder), hash: hash)
     }
 
     var hasTokenScriptHtml: Bool {

--- a/AlphaWallet/Tokens/Types/OpenSeaNonFungibleTokenHandling.swift
+++ b/AlphaWallet/Tokens/Types/OpenSeaNonFungibleTokenHandling.swift
@@ -16,9 +16,9 @@ enum OpenSeaBackedNonFungibleTokenHandling {
                 let view: String
                 switch tokenViewType {
                 case .viewIconified:
-                    view = xmlHandler.tokenViewIconifiedHtml
+                    view = xmlHandler.tokenViewIconifiedHtml.html
                 case .view:
-                    view = xmlHandler.tokenViewHtml
+                    view = xmlHandler.tokenViewHtml.html
                 }
                 if xmlHandler.hasAssetDefinition && !view.isEmpty {
                     return .notBackedByOpenSea

--- a/AlphaWallet/Tokens/Types/TokenInstanceAction.swift
+++ b/AlphaWallet/Tokens/Types/TokenInstanceAction.swift
@@ -10,7 +10,7 @@ struct TokenInstanceAction {
         case nftRedeem
         case nftSell
         case nonFungibleTransfer
-        case tokenScript(contract: AlphaWallet.Address, title: String, viewHtml: String, attributes: [AttributeId: AssetAttribute], transactionFunction: FunctionOrigin?)
+        case tokenScript(contract: AlphaWallet.Address, title: String, viewHtml: (html: String, style: String), attributes: [AttributeId: AssetAttribute], transactionFunction: FunctionOrigin?)
     }
     var name: String {
         switch type {
@@ -74,9 +74,10 @@ struct TokenInstanceAction {
             return (html: "", hash: 0)
         case .nonFungibleTransfer:
             return (html: "", hash: 0)
-        case .tokenScript(_, _, let viewHtml, _, _):
-            let hash = viewHtml.hashForCachingHeight
-            return (html: wrapWithHtmlViewport(viewHtml, forTokenHolder: tokenHolder), hash: hash)
+        case .tokenScript(_, _, (html: let html, style: let style) , _, _):
+            //Just an easy way to generate a hash for style + HTML
+            let hash = "\(style)\(html)".hashForCachingHeight
+            return (html: wrapWithHtmlViewport(html: html, style: style, forTokenHolder: tokenHolder), hash: hash)
         }
     }
 }

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -393,7 +393,7 @@ private func generateContainerCssId(forTokenId tokenId: TokenId) -> String {
     return "token-card-\(tokenId)"
 }
 
-func wrapWithHtmlViewport(_ html: String, forTokenId tokenId: TokenId) -> String {
+func wrapWithHtmlViewport(html: String, style: String, forTokenId tokenId: TokenId) -> String {
     if html.isEmpty {
         return ""
     } else {
@@ -402,17 +402,20 @@ func wrapWithHtmlViewport(_ html: String, forTokenId tokenId: TokenId) -> String
                <html>
                <head>
                <meta name="viewport" content="width=device-width, initial-scale=1,  maximum-scale=1, shrink-to-fit=no">
+               \(style)
                </head>
+               <body>
                <div id="\(containerCssId)" class="token-card">
                \(html)
                </div>
+               </body>
                </html>
                """
     }
 }
 
-func wrapWithHtmlViewport(_ html: String, forTokenHolder tokenHolder: TokenHolder) -> String {
-    return wrapWithHtmlViewport(html, forTokenId: tokenHolder.tokenIds[0])
+func wrapWithHtmlViewport(html: String, style: String, forTokenHolder tokenHolder: TokenHolder) -> String {
+    return wrapWithHtmlViewport(html: html, style: style, forTokenId: tokenHolder.tokenIds[0])
 }
 
 extension String {

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModelWithIntroduction.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModelWithIntroduction.swift
@@ -109,7 +109,7 @@ struct SendHeaderViewViewModelWithIntroduction {
         guard let contract = contractAddress else { return "" }
         let xmlHandler = XMLHandler(contract: contract, assetDefinitionStore: assetDefinitionStore)
         //Any number works for tokenId here, since it's only used for generating the unique CSS ID
-        return wrapWithHtmlViewport(xmlHandler.introductionHtmlString, forTokenId: 1)
+        return wrapWithHtmlViewport(html: xmlHandler.introductionHtmlString, style: "", forTokenId: 1)
     }
 
     init(server: RPCServer, assetDefinitionStore: AssetDefinitionStore) {

--- a/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
+++ b/AlphaWallet/UI/ViewModels/TokenCardRowViewModel.swift
@@ -151,14 +151,15 @@ struct TokenCardRowViewModel: TokenCardRowViewModelProtocol {
     var tokenScriptHtml: (html: String, hash: Int) {
         let xmlHandler = XMLHandler(contract: tokenHolder.contractAddress, assetDefinitionStore: assetDefinitionStore)
         let html: String
+        let style: String
         switch tokenView {
         case .view:
-            html = xmlHandler.tokenViewHtml
+            (html, style) = xmlHandler.tokenViewHtml
         case .viewIconified:
-            html = xmlHandler.tokenViewIconifiedHtml
+            (html, style) = xmlHandler.tokenViewIconifiedHtml
         }
         let hash = html.hashForCachingHeight
-        return (html: wrapWithHtmlViewport(html, forTokenHolder: tokenHolder), hash: hash)
+        return (html: wrapWithHtmlViewport(html: html, style: style, forTokenHolder: tokenHolder), hash: hash)
     }
 
     var hasTokenScriptHtml: Bool {


### PR DESCRIPTION
Closes #1777 

Supporting this for `<item-view>` and `<view>`:

```
<ts:item-view xml:lang="en">
      <xhtml:style/>
      <xhtml:script/>
      <xhtml:body/>
```