### PR TITLE
[TokenScript schema 2020/03] Assume no more <attribute-types> wrapper tag for token-level attributes

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -488,18 +488,18 @@ private class PrivateXMLHandler {
     }
 
     private func extractFieldsForToken() -> [AttributeId: AssetAttribute] {
-        if let attributeTypesElement = XMLHandler.getTokenAttributeTypesElement(fromRoot: xml, xmlContext: xmlContext) {
-            return extractFields(fromAttributeTypesElement: attributeTypesElement)
+        if let tokensElement = XMLHandler.getTokenElement(fromRoot: xml, xmlContext: xmlContext) {
+            return extractFields(fromElementContainingAttributes: tokensElement)
         } else {
             return .init()
         }
     }
 
     private func extractFields(forActionElement actionElement: XMLElement) -> [AttributeId: AssetAttribute] {
-        return extractFields(fromAttributeTypesElement: actionElement)
+        extractFields(fromElementContainingAttributes: actionElement)
     }
 
-    private func extractFields(fromAttributeTypesElement element: XMLElement) -> [AttributeId: AssetAttribute] {
+    private func extractFields(fromElementContainingAttributes element: XMLElement) -> [AttributeId: AssetAttribute] {
         var fields = [AttributeId: AssetAttribute]()
         for each in XMLHandler.getAttributeTypeElements(fromAttributeTypesElement: element, xmlContext: xmlContext) {
             guard let id = each["id"] else { continue }
@@ -745,10 +745,6 @@ extension String {
 extension XMLHandler {
     fileprivate static func getTokenElement(fromRoot root: XMLDocument, xmlContext: XmlContext) -> XMLElement? {
         return root.at_xpath("/token".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)
-    }
-
-    fileprivate static func getTokenAttributeTypesElement(fromRoot root: XMLDocument, xmlContext: XmlContext) -> XMLElement? {
-        return root.at_xpath("/token/attribute-types".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)
     }
 
     fileprivate static func getHoldingContractElement(fromRoot root: XMLDocument, xmlContext: XmlContext) -> XMLElement? {

--- a/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
+++ b/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
@@ -59,31 +59,29 @@ class XMLHandlerTest: XCTestCase {
           <ts:origins>
               <ts:ethereum contract="Token"/>
           </ts:origins>
-          <ts:attribute-types>
-            <ts:attribute-type id="locality" syntax="1.3.6.1.4.1.1466.115.121.1.15">
-              <ts:name>
-                <ts:string xml:lang="en">City</ts:string>
-                <ts:string xml:lang="zh">城市</ts:string>
-                <ts:string xml:lang="es">Ciudad</ts:string>
-                <ts:string xml:lang="ru">город</ts:string>
-              </ts:nam>
-              <ts:origins>
-                <ts:token-id bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="uint">
-                  <ts:mapping>
-                    <ts:option key="1">
-                      <ts:value xml:lang="ru">Москва́</ts:value>
-                      <ts:value xml:lang="en">Moscow</ts:value>
-                      <ts:value xml:lang="zh">莫斯科</ts:value>
-                      <ts:value xml:lang="es">Moscú</ts:value>
-                    </ts:option>
-                    <ts:option key="2">
-                      <ts:value xml:lang="ru">Санкт-Петербу́рг</ts:value>
-                      <ts:value xml:lang="en">Saint Petersburg</ts:value>
-                  </ts:mapping>
-                </ts:token-id>
-              </ts:origins>
-            </ts:attribute-type>
-          </ts:attribute-types>
+          <ts:attribute-type id="locality" syntax="1.3.6.1.4.1.1466.115.121.1.15">
+            <ts:name>
+              <ts:string xml:lang="en">City</ts:string>
+              <ts:string xml:lang="zh">城市</ts:string>
+              <ts:string xml:lang="es">Ciudad</ts:string>
+              <ts:string xml:lang="ru">город</ts:string>
+            </ts:nam>
+            <ts:origins>
+              <ts:token-id bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="uint">
+                <ts:mapping>
+                  <ts:option key="1">
+                    <ts:value xml:lang="ru">Москва́</ts:value>
+                    <ts:value xml:lang="en">Moscow</ts:value>
+                    <ts:value xml:lang="zh">莫斯科</ts:value>
+                    <ts:value xml:lang="es">Moscú</ts:value>
+                  </ts:option>
+                  <ts:option key="2">
+                    <ts:value xml:lang="ru">Санкт-Петербу́рг</ts:value>
+                    <ts:value xml:lang="en">Saint Petersburg</ts:value>
+                </ts:mapping>
+              </ts:token-id>
+            </ts:origins>
+          </ts:attribute-type>
         </ts:token>
         """
         let contractAddress = AlphaWallet.Address(string: "0x830E1650a87a754e37ca7ED76b700395A7C61614")!


### PR DESCRIPTION
Closes #1775 