### PR TITLE
Make local-ref work with views too, so they work with both normal views and action views, but not item-views, and tweaking local-ref resolution so that it covers both props and card attributes

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetAttribute.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetAttribute.swift
@@ -54,6 +54,21 @@ struct AssetAttribute {
             return false
         }
     }
+    var isDependentOnProps: Bool {
+        switch origin {
+        case .function(let functionOrigin):
+            return functionOrigin.inputs.contains(where: {
+                switch $0 {
+                case .prop:
+                    return true
+                case .value, .ref, .cardRef:
+                    return false
+                }
+            })
+        case .tokenId, .userEntry, .event:
+            return false
+        }
+    }
     var name: String {
         return XMLHandler.getNameElement(fromAttributeTypeElement: attribute, xmlContext: xmlContext)?.text ?? ""
     }
@@ -79,7 +94,7 @@ struct AssetAttribute {
                   let attributeId = attribute["id"],
                   let functionOriginContractName = ethereumFunctionElement["contract"].nilIfEmpty,
                   let contract = XMLHandler.getNonTokenHoldingContract(byName: functionOriginContractName, server: server, fromContractNamesAndAddresses: contractNamesAndAddresses) {
-            originFound = Origin(forEthereumFunctionElement: ethereumFunctionElement, attributeId: attributeId, originContract: contract, xmlContext: xmlContext)
+            originFound = Origin(forEthereumFunctionElement: ethereumFunctionElement, root: root, attributeId: attributeId, originContract: contract, xmlContext: xmlContext)
         } else if let userEntryElement = XMLHandler.getOriginUserEntryElement(fromAttributeTypeElement: attribute, xmlContext: xmlContext),
                   let attributeId = attribute["id"] {
             originFound = Origin(forUserEntryElement: userEntryElement, attributeId: attributeId, xmlContext: xmlContext)

--- a/AlphaWallet/TokenScriptClient/Models/AssetFunctionCall.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetFunctionCall.swift
@@ -26,12 +26,13 @@ struct AssetFunctionCall: Equatable, Hashable {
 
     enum Argument: Equatable {
         case ref(ref: String, type: SolidityType)
-        case localRef(ref: String, type: SolidityType)
+        case cardRef(ref: String, type: SolidityType)
+        case prop(ref: String, type: SolidityType)
         case value(value: String, type: SolidityType)
 
         var type: SolidityType {
             switch self {
-            case .ref(_, let type), .localRef(_, let type), .value(_, let type):
+            case .ref(_, let type), .cardRef(_, let type), .prop(_, let type), .value(_, let type):
                 return type
             }
         }

--- a/AlphaWallet/TokenScriptClient/Models/Origin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/Origin.swift
@@ -92,10 +92,10 @@ enum Origin {
         self = .tokenId(.init(originElement: tokenIdElement, xmlContext: xmlContext, bitmask: bitmask, bitShift: bitShift, asType: asType))
     }
 
-    init?(forEthereumFunctionElement ethereumFunctionElement: XMLElement, attributeId: AttributeId, originContract: AlphaWallet.Address, xmlContext: XmlContext) {
+    init?(forEthereumFunctionElement ethereumFunctionElement: XMLElement, root: XMLDocument, attributeId: AttributeId, originContract: AlphaWallet.Address, xmlContext: XmlContext) {
         let bitmask = XMLHandler.getBitMask(fromTokenIdElement: ethereumFunctionElement) ?? TokenScript.defaultBitmask
         let bitShift = Origin.bitShiftCount(forBitMask: bitmask)
-        guard let result = FunctionOrigin(forEthereumFunctionCallElement: ethereumFunctionElement, attributeId: attributeId, originContract: originContract, xmlContext: xmlContext, bitmask: bitmask, bitShift: bitShift) else { return nil }
+        guard let result = FunctionOrigin(forEthereumFunctionCallElement: ethereumFunctionElement, root: root, attributeId: attributeId, originContract: originContract, xmlContext: xmlContext, bitmask: bitmask, bitShift: bitShift) else { return nil }
         self = .function(result)
     }
 

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -111,7 +111,6 @@ private class PrivateXMLHandler {
     private weak var assetDefinitionStore: AssetDefinitionStore?
     var server: RPCServer?
     //Explicit type so that the variable autocompletes with AppCode
-    private lazy var fields: [AttributeId: AssetAttribute] = extractFieldsForToken()
     private lazy var selections = extractSelectionsForToken()
     private let isOfficial: Bool
     private let isCanonicalized: Bool
@@ -127,6 +126,7 @@ private class PrivateXMLHandler {
 
     var hasValidTokenScriptFile: Bool
     let tokenScriptStatus: Promise<TokenLevelTokenScriptDisplayStatus>
+    lazy var fields: [AttributeId: AssetAttribute] = extractFieldsForToken()
 
     var introductionHtmlString: String {
         //TODO fallback to first if not found
@@ -472,10 +472,10 @@ private class PrivateXMLHandler {
         if let contract = ethereumFunctionElement["contract"].nilIfEmpty {
             guard let server = server else { return nil }
             return XMLHandler.getNonTokenHoldingContract(byName: contract, server: server, fromContractNamesAndAddresses: self.contractNamesAndAddresses)
-                    .flatMap { FunctionOrigin(forEthereumFunctionTransactionElement: ethereumFunctionElement, attributeId: "", originContract: $0, xmlContext: xmlContext, bitmask: nil, bitShift: 0) }
+                    .flatMap { FunctionOrigin(forEthereumFunctionTransactionElement: ethereumFunctionElement, root: xml, attributeId: "", originContract: $0, xmlContext: xmlContext, bitmask: nil, bitShift: 0) }
         } else {
             return XMLHandler.getRecipientAddress(fromEthereumFunctionElement: ethereumFunctionElement, xmlContext: xmlContext)
-                    .flatMap { FunctionOrigin(forEthereumPaymentElement: ethereumFunctionElement, attributeId: "", recipientAddress: $0, xmlContext: xmlContext, bitmask: nil, bitShift: 0) }
+                    .flatMap { FunctionOrigin(forEthereumPaymentElement: ethereumFunctionElement, root: xml, attributeId: "", recipientAddress: $0, xmlContext: xmlContext, bitmask: nil, bitShift: 0) }
         }
     }
 
@@ -591,6 +591,10 @@ public class XMLHandler {
 
     var hasAssetDefinition: Bool {
         return privateXMLHandler.hasValidTokenScriptFile
+    }
+
+    var fields: [AttributeId: AssetAttribute] {
+        privateXMLHandler.fields
     }
 
     var tokenScriptStatus: Promise<TokenLevelTokenScriptDisplayStatus> {
@@ -788,6 +792,10 @@ extension XMLHandler {
 
     fileprivate static func getAttributeTypeElements(fromAttributeTypesElement element: XMLElement, xmlContext: XmlContext) -> XPathObject {
         return element.xpath("attribute-type".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)
+    }
+
+    static func getCardAttributeTypeElements(fromRoot root: XMLDocument, xmlContext: XmlContext) -> XPathObject {
+        root.xpath("cards/action/attribute-type".addToXPath(namespacePrefix: xmlContext.namespacePrefix), namespaces: xmlContext.namespaces)
     }
 
     static func getMappingElement(fromOriginElement originElement: XMLElement, xmlContext: XmlContext) -> XMLElement? {

--- a/AlphaWallet/Tokens/Types/TokenInstanceAction.swift
+++ b/AlphaWallet/Tokens/Types/TokenInstanceAction.swift
@@ -49,9 +49,11 @@ struct TokenInstanceAction {
         }
         let attributeDependencies = inputs.compactMap { each -> String? in
             switch each {
-            case .value, .localRef:
+            case .value, .prop:
                 return nil
             case .ref(ref: let ref, _):
+                return ref
+            case .cardRef(ref: let ref, _):
                 return ref
             }
         }

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -28,6 +28,7 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 	private let spaceAboveBottomRowStack = UIView.spacer(height: 10)
 	private var checkboxRelatedConstraintsWhenShown = [NSLayoutConstraint]()
 	private var checkboxRelatedConstraintsWhenHidden = [NSLayoutConstraint]()
+	private var lastTokenHolder: TokenHolder?
 	private var onlyShowTitle: Bool = false {
 		didSet {
 			if onlyShowTitle {
@@ -199,6 +200,7 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 	}
 
 	func configure(tokenHolder: TokenHolder, tokenView: TokenView, areDetailsVisible: Bool, width: CGFloat, assetDefinitionStore: AssetDefinitionStore) {
+		lastTokenHolder = tokenHolder
         configure(viewModel: TokenCardRowViewModel(tokenHolder: tokenHolder, tokenView: tokenView, assetDefinitionStore: assetDefinitionStore))
 	}
 
@@ -341,6 +343,7 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 
 extension TokenCardRowView: TokenRowView {
 	func configure(tokenHolder: TokenHolder) {
+		lastTokenHolder = tokenHolder
 		configure(viewModel: TokenCardRowViewModel(tokenHolder: tokenHolder, tokenView: tokenView, assetDefinitionStore: assetDefinitionStore))
 	}
 }
@@ -359,6 +362,12 @@ extension TokenCardRowView: TokenInstanceWebViewDelegate {
 	}
 
 	func reinject(tokenInstanceWebView: TokenInstanceWebView) {
-		//no-op
+		//Refresh if view, but not item-view
+        if isStandalone {
+			guard let lastTokenHolder = lastTokenHolder else { return }
+			configure(tokenHolder: lastTokenHolder)
+		} else {
+			//no-op for item-views
+		}
     }
 }


### PR DESCRIPTION
Closes #1790 

This PR:

* Makes local-ref work with views too (but not item-view)
* local-ref resolution now includes card attributes in addition to props

@James-Sangalli Better to assume all the attribute ids/names are still in a single namespace for now as an implementation incompatibility. Just have to not give attributes the same names. I'll fix it after we get 2020/06 is merged. It takes a bigger refactor before being able to do it properly