### PR TITLE
Fixes: fiat entry shows "Wrong Input" when sending eth/native crypto tokens if locale is set to region which uses comma as decimal separator:

### DIFF
--- a/AlphaWallet/Foundation/StringFormatter.swift
+++ b/AlphaWallet/Foundation/StringFormatter.swift
@@ -23,7 +23,8 @@ final class StringFormatter {
     func currency(with value: Double, and currencyCode: String) -> String {
         let formatter = currencyFormatter
         formatter.currencyCode = currencyCode
-        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        //Trimming is important because the formatter output for `1.2` becomes "1.2 " (with trailing space) when region = Poland
+        return formatter.string(from: NSNumber(value: value))?.trimmed ?? "\(value)"
     }
     /// Converts a Double to a `String`.
     ///

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -78,7 +78,7 @@ class AmountTextField: UIControl {
             case .cryptoCurrency:
                 textField.text = newValue
             case .usd:
-                if let amount = Double(newValue), let cryptoToDollarRate = cryptoToDollarRate {
+                if let amount = Double(newValue.withDecimalSeparatorReplacedByPeriod), let cryptoToDollarRate = cryptoToDollarRate {
                     textField.text = String(amount * cryptoToDollarRate)
                 } else {
                     textField.text = ""
@@ -92,7 +92,7 @@ class AmountTextField: UIControl {
         case .cryptoCurrency:
             return convertToAlternateAmountNumeric()
         case .usd:
-            return Double(textField.text ?? "")
+            return Double(textFieldString() ?? "")
         }
     }
     var currentPair: Pair
@@ -267,7 +267,7 @@ class AmountTextField: UIControl {
     }
 
     private func convertToAlternateAmount() -> String {
-        if let cryptoToDollarRate = cryptoToDollarRate, let string = textField.text, let amount = Double(string) {
+        if let cryptoToDollarRate = cryptoToDollarRate, let string = textFieldString(), let amount = Double(string) {
             switch currentPair.left {
             case .cryptoCurrency:
                 return StringFormatter().currency(with: amount * cryptoToDollarRate, and: "USD")
@@ -280,7 +280,7 @@ class AmountTextField: UIControl {
     }
 
     private func convertToAlternateAmountNumeric() -> Double? {
-        if let cryptoToDollarRate = cryptoToDollarRate, let string = textField.text, let amount = Double(string) {
+        if let cryptoToDollarRate = cryptoToDollarRate, let string = textFieldString(), let amount = Double(string) {
             switch currentPair.left {
             case .cryptoCurrency:
                 return amount * cryptoToDollarRate
@@ -295,6 +295,10 @@ class AmountTextField: UIControl {
     private func updateAlternatePricingDisplay() {
         computeAlternateAmount()
         delegate?.changeAmount(in: self)
+    }
+
+    private func textFieldString() -> String? {
+        textField.text?.withDecimalSeparatorReplacedByPeriod
     }
 }
 
@@ -327,3 +331,14 @@ extension Double {
     }
 }
 
+fileprivate extension String {
+    var withDecimalSeparatorReplacedByPeriod: String {
+        guard let decimalSeparator = Locale.current.decimalSeparator else { return self }
+        let period = "."
+        if decimalSeparator == period {
+            return self
+        } else {
+            return replacingOccurrences(of: decimalSeparator, with: period)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1884 

This PR fixes 2 problems when input is set to fiat:

* Fix: entering fractional value (using comma) for fiat — eg. "3,4"
* Fix: toggling from ETH to fiat, the value is displayed with trailing space — eg. "1,2 " instead of "1,2"

Set locale to Poland to reproduce.