### PR TITLE
Fix: localization for segment controls in Wallet tab do not kick in immediately when user override local in Settings

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -5,7 +5,8 @@ import UIKit
 
 //Must be a class, and not a struct, otherwise changing `filter` will silently create a copy of TokensViewModel when user taps to change the filter in the UI and break filtering
 class TokensViewModel {
-    static let segmentedControlTitles = WalletFilter.orderedTabs.map { $0.title }
+    //Must be computed because localization can be overridden by user dynamically
+    static var segmentedControlTitles: [String] { WalletFilter.orderedTabs.map { $0.title } }
 
     private let filterTokensCoordinator: FilterTokensCoordinator
     var tokens: [TokenObject]

--- a/AlphaWallet/Wallet/ViewModels/ImportWalletViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ImportWalletViewModel.swift
@@ -3,7 +3,8 @@
 import UIKit
 
 struct ImportWalletViewModel {
-    static let segmentedControlTitles = ImportWalletTab.orderedTabs.map { $0.title }
+    //Must be computed because localization can be overridden by user dynamically
+    static var segmentedControlTitles: [String] { ImportWalletTab.orderedTabs.map { $0.title } }
 
     var backgroundColor: UIColor {
         return Colors.appBackground


### PR DESCRIPTION
Closes #1900

Should have been a computed property because the RHS isn't actually a constant