### PR TITLE
Get rid of or replace unnecessary `default: ` in switches across the code base #1909

### DIFF
--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -99,7 +99,7 @@ class OpenSea {
             return Constants.openseaAPI
         case .rinkeby:
             return Constants.openseaRinkebyAPI
-        default:
+        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .custom:
             return Constants.openseaAPI
         }
     }

--- a/AlphaWallet/Extensions/Error.swift
+++ b/AlphaWallet/Extensions/Error.swift
@@ -23,7 +23,8 @@ extension Error {
                     switch JSONError {
                     case .responseError(_, let message, _):
                         return message
-                    default: return R.string.localizable.undefinedError()
+                    case .responseNotFound, .resultObjectParseError, .errorObjectParseError, .unsupportedVersion, .unexpectedTypeObject, .missingBothResultAndError, .nonArrayResponse:
+                        return R.string.localizable.undefinedError()
                     }
                 }
             default:

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -416,7 +416,7 @@ class UniversalLinkCoordinator: Coordinator {
         switch server {
         case .xDai:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughXDAITitle()
-        default:
+        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughEthTitle()
         }
         if ethPrice.value == nil {

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -66,7 +66,7 @@ class UniversalLinkCoordinator: Coordinator {
         switch server {
         case .xDai:
             return "xDAI"
-        default:
+        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom:
             return "ETH"
         }
     }

--- a/AlphaWallet/Settings/Types/ConfigExplorer.swift
+++ b/AlphaWallet/Settings/Types/ConfigExplorer.swift
@@ -20,7 +20,7 @@ struct ConfigExplorer {
                 return endpoint + "/txid/search/" + ID
             case .custom, .callisto:
                 return .none
-            default:
+            case .main, .kovan, .ropsten, .rinkeby, .sokol, .classic, .xDai, .goerli, .artis_sigma1, .artis_tau1:
                 return endpoint + "/tx/" + ID
             }
         }()

--- a/AlphaWallet/Settings/ViewControllers/SupportViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SupportViewController.swift
@@ -125,7 +125,7 @@ extension SupportViewController: UITableViewDelegate {
             openURL(.reddit)
         case .facebook:
             openURL(.facebook)
-        default:
+        case .blog: 
             break
         }
     }

--- a/AlphaWallet/Tokens/Models/WalletFilter.swift
+++ b/AlphaWallet/Tokens/Models/WalletFilter.swift
@@ -22,8 +22,12 @@ func == (lhs: WalletFilter, rhs: WalletFilter) -> Bool {
 		return true
 	case (.keyword(let keyword1), .keyword(let keyword2)):
 		return keyword1 == keyword2
-	default:
-		return false
-	}
+    case (.keyword, .all), (.keyword, .currencyOnly), (.keyword, .assetsOnly), (.keyword, .collectiblesOnly), (.collectiblesOnly, .all), (.collectiblesOnly, .currencyOnly), (.collectiblesOnly, .assetsOnly), (.collectiblesOnly, .keyword), (.assetsOnly, .all), (.assetsOnly, .currencyOnly), (.assetsOnly, .collectiblesOnly), (.assetsOnly, .keyword), (.currencyOnly, .all), (.currencyOnly, .assetsOnly), (.currencyOnly, .collectiblesOnly), (.currencyOnly, .keyword), (.all, .currencyOnly), (.all, .assetsOnly):
+        return false
+    case (.all, .collectiblesOnly):
+        return false
+    case (.all, .keyword):
+        return false
+    }
 }
 

--- a/AlphaWallet/Tokens/Views/TextField.swift
+++ b/AlphaWallet/Tokens/Views/TextField.swift
@@ -39,7 +39,7 @@ class TextField: UIControl {
             switch self {
             case .error:
                 return true
-            default:
+            case .none: 
                 return whileEditing
             }
         }

--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -160,9 +160,11 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
                         if transaction.date > Date().addingTimeInterval(TransactionDataCoordinator.deleteMissingInternalSeconds) {
                             strongSelf.update(state: .failed, for: transaction)
                         }
-                    default: break
+                    case .responseNotFound, .errorObjectParseError, .unsupportedVersion, .unexpectedTypeObject, .missingBothResultAndError, .nonArrayResponse:
+                        break
                     }
-                default: break
+                case .connectionError, .requestError:
+                    break
                 }
             }
         }

--- a/AlphaWallet/Transfer/Types/TransferType.swift
+++ b/AlphaWallet/Transfer/Types/TransferType.swift
@@ -38,15 +38,6 @@ enum TransferType {
 
 extension TransferType {
 
-    var icon: UIImage {
-        switch symbol {
-        case "ETH":
-            return R.image.eth()!
-        default:
-            return R.image.ethSmall()!
-        }
-    }
-
     var symbol: String {
         switch self {
         case .nativeCryptocurrency(let server, _, _):

--- a/AlphaWallet/Vendors/TrustCore/ABIValue.swift
+++ b/AlphaWallet/Vendors/TrustCore/ABIValue.swift
@@ -157,7 +157,7 @@ public indirect enum ABIValue: Equatable {
             self = .dynamicArray(type, try array.map({ try ABIValue($0, type: type) }))
         case (.tuple(let types), let array as [Any]):
             self = .tuple(try zip(types, array).map({ try ABIValue($1, type: $0) }))
-        default:
+        case (_, _):
             throw ABIError.invalidArgumentType
         }
     }


### PR DESCRIPTION
Closes #1909