### PR TITLE
Get rid of unnecessary func arg in `BackupCoordinator.export(for:)` #1910

### DIFF
--- a/AlphaWallet/Export/Coordinators/BackupCoordinator.swift
+++ b/AlphaWallet/Export/Coordinators/BackupCoordinator.swift
@@ -25,7 +25,7 @@ class BackupCoordinator: Coordinator {
     }
 
     func start() {
-        export(for: account)
+        export()
     }
 
     private func finish(result: Result<Bool, AnyError>) {
@@ -104,7 +104,7 @@ class BackupCoordinator: Coordinator {
         addCoordinator(coordinator)
     }
 
-    private func export(for account: EthereumAccount) {
+    private func export() {
         if keystore.isHdWallet(account: account) {
             let coordinator = BackupSeedPhraseCoordinator(navigationController: navigationController, keystore: keystore, account: account)
             coordinator.delegate = self


### PR DESCRIPTION
Closes #1910