### PR TITLE
Make add custom token more reliable

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		5E7C702C4B29AF2B8D61CCA4 /* DappsAutoCompletionViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7D19E3CF96929FB8CEA3 /* DappsAutoCompletionViewControllerViewModel.swift */; };
 		5E7C70397E7E3A9C88E995B1 /* WKWebViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BEDC786FB048A1DD9A8 /* WKWebViewExtension.swift */; };
 		5E7C705166218753CAA19A6D /* TokenIdOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7587F30FF1896039B8C8 /* TokenIdOrigin.swift */; };
+		5E7C7066794663954D9C18E5 /* withRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C71AFE747055742986023 /* withRetry.swift */; };
 		5E7C7067E8FEA5055BF83553 /* HDWallet+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C6759CA1C223DABA462 /* HDWallet+Extension.swift */; };
 		5E7C706F4BDF994D539F8040 /* AssetDefinitionsOverridesViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E54BE622E49554FE4A9 /* AssetDefinitionsOverridesViewCell.swift */; };
 		5E7C70724527639BE4069AB1 /* AssetAttributeToJavaScriptConvertor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7ACC1A14248A68E95F33 /* AssetAttributeToJavaScriptConvertor.swift */; };
@@ -983,6 +984,7 @@
 		5E7C717F1D00B38575B18834 /* AssetAttributesCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetAttributesCache.swift; sourceTree = "<group>"; };
 		5E7C7185AA9F93D4F0B67AF7 /* ABIEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABIEncoder.swift; sourceTree = "<group>"; };
 		5E7C71A8BE594C1D126AB309 /* FakeEventsDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeEventsDataStore.swift; sourceTree = "<group>"; };
+		5E7C71AFE747055742986023 /* withRetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = withRetry.swift; sourceTree = "<group>"; };
 		5E7C71C2C110B621EFDE336F /* TokensCardViewControllerTitleHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensCardViewControllerTitleHeader.swift; sourceTree = "<group>"; };
 		5E7C71CE10548877F1124BF2 /* WelcomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewModel.swift; sourceTree = "<group>"; };
 		5E7C71E355BD14E975AF7491 /* TokensDataStoreTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensDataStoreTest.swift; sourceTree = "<group>"; };
@@ -3500,6 +3502,7 @@
 				CCA4FE371FD428B300749AE4 /* JailbreakChecker.swift */,
 				5E7C77E1E6194F5A1DC8D645 /* ScreenChecker.swift */,
 				5E7C708DE897B6677EAD769B /* ScriptMessageProxy.swift */,
+				5E7C71AFE747055742986023 /* withRetry.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -4515,6 +4518,7 @@
 				5E7C782069BAD4A667543979 /* SettingsViewController.swift in Sources */,
 				5E7C750721DA2745432B1857 /* TokenObject+UI.swift in Sources */,
 				5E7C74B615A84B248D3BE76C /* TokenImageView.swift in Sources */,
+				5E7C7066794663954D9C18E5 /* withRetry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Core/Helpers/withRetry.swift
+++ b/AlphaWallet/Core/Helpers/withRetry.swift
@@ -1,0 +1,14 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+
+func withRetry(times: Int, task: @escaping (_ triggerRetry: @escaping () -> Bool) -> ()) {
+    var retriedCount = 0
+    func triggerRetry() -> Bool {
+        guard retriedCount < times else { return false }
+        retriedCount += 1
+        task(triggerRetry)
+        return true
+    }
+    task(triggerRetry)
+}

--- a/AlphaWallet/Tokens/Coordinators/GetDecimalsCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetDecimalsCoordinator.swift
@@ -16,7 +16,7 @@ class GetDecimalsCoordinator {
         completion: @escaping (Result<UInt8, AnyError>) -> Void
     ) {
         let functionName = "decimals"
-        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI).done { dictionary in
+        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI, timeout: TokensDataStore.fetchContractDataTimeout).done { dictionary in
             if let decimalsWithUnknownType = dictionary["0"] {
                 let string = String(describing: decimalsWithUnknownType)
                 if let decimals = UInt8(string) {

--- a/AlphaWallet/Tokens/Coordinators/GetERC20BalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetERC20BalanceCoordinator.swift
@@ -18,7 +18,7 @@ class GetERC20BalanceCoordinator {
             completion: @escaping (ResultResult<BigInt, AnyError>.t) -> Void
     ) {
         let functionName = "balanceOf"
-        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI, parameters: [address.eip55String] as [AnyObject]).done { balanceResult in
+        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI, parameters: [address.eip55String] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout).done { balanceResult in
             if let balanceWithUnknownType = balanceResult["0"] {
                 let string = String(describing: balanceWithUnknownType)
                 if let balance = BigInt(string) {

--- a/AlphaWallet/Tokens/Coordinators/GetERC721BalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetERC721BalanceCoordinator.swift
@@ -20,7 +20,7 @@ class GetERC721BalanceCoordinator {
             completion: @escaping (Result<BigUInt, AnyError>) -> Void
     ) {
         let function = GetERC721Balance()
-        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject]).done { balanceResult in
+        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout).done { balanceResult in
             let balance = self.adapt(balanceResult["0"] as Any)
             completion(.success(balance))
         }.catch { error in

--- a/AlphaWallet/Tokens/Coordinators/GetERC721ForTicketsBalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetERC721ForTicketsBalanceCoordinator.swift
@@ -13,7 +13,7 @@ class GetERC721ForTicketsBalanceCoordinator {
 
     func getERC721ForTicketsTokenBalance(for address: AlphaWallet.Address, contract: AlphaWallet.Address, completion: @escaping (Result<[String], AnyError>) -> Void) {
         let function = GetERC721ForTicketsBalance()
-        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject]).done { balanceResult in
+        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout).done { balanceResult in
             let balances = self.adapt(balanceResult["0"])
             completion(.success(balances))
         }.catch {

--- a/AlphaWallet/Tokens/Coordinators/GetERC875BalanceCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetERC875BalanceCoordinator.swift
@@ -16,7 +16,7 @@ class GetERC875BalanceCoordinator {
         completion: @escaping (Result<[String], AnyError>) -> Void
     ) {
         let function = GetERC875Balance()
-        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject]).done { balanceResult in
+        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [address.eip55String] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout).done { balanceResult in
             let balances = self.adapt(balanceResult["0"])
             completion(.success(balances))
         }.catch {

--- a/AlphaWallet/Tokens/Coordinators/GetInterfaceSupported165Coordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetInterfaceSupported165Coordinator.swift
@@ -18,7 +18,7 @@ class GetInterfaceSupported165Coordinator {
             completion: @escaping (Result<Bool, AnyError>) -> Void
     ) {
         let function = GetInterfaceSupported165Encode()
-        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [hash] as [AnyObject]).done { result in
+        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, parameters: [hash] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout).done { result in
             if let supported = result["0"] as? Bool {
                 completion(.success(supported))
             } else {

--- a/AlphaWallet/Tokens/Coordinators/GetIsERC721ContractCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetIsERC721ContractCoordinator.swift
@@ -42,10 +42,18 @@ class GetIsERC721ContractCoordinator {
             return
         }
 
+        //TODO use callSmartContract() instead
+
         guard let webProvider = Web3HttpProvider(server.rpcURL, network: server.web3Network) else {
             completion(.failure(AnyError(Web3Error(description: "Error creating web provider for: \(server.rpcURL) + \(server.web3Network)"))))
             return
         }
+
+        let configuration = webProvider.session.configuration
+        configuration.timeoutIntervalForRequest = TokensDataStore.fetchContractDataTimeout
+        configuration.timeoutIntervalForResource = TokensDataStore.fetchContractDataTimeout
+        let session = URLSession(configuration: configuration)
+        webProvider.session = session
 
         let contractAddress = EthereumAddress(address: contract)
         let web3 = web3swift.web3(provider: webProvider)

--- a/AlphaWallet/Tokens/Coordinators/GetIsERC721ForTicketsContractCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetIsERC721ForTicketsContractCoordinator.swift
@@ -5,11 +5,11 @@ import Result
 
 class GetIsERC721ForTicketsContractCoordinator {
     private let server: RPCServer
-    
+
     init(forServer server: RPCServer) {
         self.server = server
     }
-    
+
     func getIsERC721ForTicketContract(for contract: AlphaWallet.Address, completion: @escaping (Result<Bool, AnyError>) -> Void) {
         GetInterfaceSupported165Coordinator(forServer: server).getInterfaceSupported165(hash: Constants.balances165Hash721Ticket, contract: contract) { result in
             if let value = result.value {

--- a/AlphaWallet/Tokens/Coordinators/GetIsERC875ContractCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetIsERC875ContractCoordinator.swift
@@ -15,7 +15,7 @@ class GetIsERC875ContractCoordinator {
         completion: @escaping (Result<Bool, AnyError>) -> Void
     ) {
         let function = GetIsERC875()
-        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi).done { dictionary in
+        callSmartContract(withServer: server, contract: contract, functionName: function.name, abiString: function.abi, timeout: TokensDataStore.fetchContractDataTimeout).done { dictionary in
             if let isERC875 = dictionary["0"] as? Bool {
                 completion(.success(isERC875))
             } else {

--- a/AlphaWallet/Tokens/Coordinators/GetNameCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetNameCoordinator.swift
@@ -16,7 +16,7 @@ class GetNameCoordinator {
         completion: @escaping (Result<String, AnyError>) -> Void
     ) {
         let functionName = "name"
-        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI).done { nameResult in
+        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI, timeout: TokensDataStore.fetchContractDataTimeout).done { nameResult in
             if let name = nameResult["0"] as? String {
                 completion(.success(name))
             } else {

--- a/AlphaWallet/Tokens/Coordinators/GetSymbolCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetSymbolCoordinator.swift
@@ -16,7 +16,7 @@ class GetSymbolCoordinator {
         completion: @escaping (Result<String, AnyError>) -> Void
     ) {
         let functionName = "symbol"
-        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI).done { symbolsResult in
+        callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: web3swift.Web3.Utils.erc20ABI, timeout: TokensDataStore.fetchContractDataTimeout).done { symbolsResult in
             if let symbol = symbolsResult["0"] as? String {
                 completion(.success(symbol))
             } else {


### PR DESCRIPTION
Still with Infura, but changing or adding any other compatible RPC node will get the same benefit

This PR does it by:

* decreasing timeout from default 60s to 4s. Too short, and slower connections might not work with the app; too long a timeout, and it's too long a wait (especially since we introduced retries with this PR) when the server doesn't respond.
* retrying when individual smart contract call fails — we have to make many multiple smart contract calls to detect a token. If one of the calls fails, we retry instead of failing the whole process

The retry function is achieved by introducing a new `withRetry(times:task:)` function.