### PR TITLE
Fix: setter should use newValue, not the attribute name (which is the old value)

### DIFF
--- a/AlphaWallet/Core/Collection+UIView.swift
+++ b/AlphaWallet/Core/Collection+UIView.swift
@@ -6,7 +6,7 @@ extension Collection where Element == UIView {
     var alpha: CGFloat {
         set {
             for each in self {
-                each.alpha = alpha
+                each.alpha = newValue
             }
         }
         get {

--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -63,7 +63,7 @@ class TokenObject: Object {
             AlphaWallet.Address(uncheckedAgainstNullAddress: contract)!
         }
         set {
-            contract = contractAddress.eip55String
+            contract = newValue.eip55String
         }
     }
 


### PR DESCRIPTION
Just happened to not make a difference in functionality, and it's (currently) only used in test code. Code was wrong, nevertheless.