### PR TITLE
Showing the send screen the first time for a token which has no exchange rate/price should not show the down arrow #1949

### DIFF
--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -221,9 +221,9 @@ class SendViewController: UIViewController, CanScanQRCode {
         amountLabel.font = viewModel.textFieldsLabelFont
         amountLabel.textColor = viewModel.textFieldsLabelTextColor
         amountTextField.currentPair = viewModel.amountTextFieldPair
-        amountTextField.isAlternativeAmountEnabled = viewModel.isAlternativeAmountEnabled
-        amountTextField.selectCurrencyButton.isHidden = viewModel.selectCurrencyButtonHidden
-        amountTextField.selectCurrencyButton.expandIconHidden = !viewModel.isAlternativeAmountEnabled
+        amountTextField.isAlternativeAmountEnabled = false
+        amountTextField.selectCurrencyButton.isHidden = viewModel.currencyButtonHidden
+        amountTextField.selectCurrencyButton.expandIconHidden = viewModel.selectCurrencyButtonHidden
 
         amountTextField.statusLabel.text = viewModel.availableLabelText
         amountTextField.availableTextHidden = viewModel.availableTextHidden

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -41,14 +41,7 @@ struct SendViewModel {
         case .dapp:
             return nil
         }
-    }
-
-    var showAlternativeAmount: Bool {
-        guard let currentTokenInfo = storage.tickers?[destinationAddress], currentTokenInfo.price_usd > 0 else {
-            return false
-        }
-        return true
-    }
+    } 
 
     var textFieldsLabelTextColor: UIColor {
         return Colors.appGrayLabel
@@ -73,16 +66,19 @@ struct SendViewModel {
         return AmountTextField.Pair(left: .cryptoCurrency(transferType.tokenObject), right: .usd)
     }
 
-    var isAlternativeAmountEnabled: Bool {
+    var selectCurrencyButtonHidden: Bool {
         switch transferType {
         case .nativeCryptocurrency:
-            return true
-        case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .dapp:
+            guard let currentTokenInfo = storage.tickers?[destinationAddress], currentTokenInfo.price_usd > 0 else {
+                return true
+            }
             return false
+        case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .dapp:
+            return true
         }
     }
 
-    var selectCurrencyButtonHidden: Bool {
+    var currencyButtonHidden: Bool {
         switch transferType {
         case .nativeCryptocurrency, .ERC20Token:
             return false


### PR DESCRIPTION
Closes #1949