### PR TITLE
Fix: Show token 24 hour price change instead of 24 hour market cap change

### DIFF
--- a/AlphaWallet/EtherClient/CoinMarket/Types/CoinTicker.swift
+++ b/AlphaWallet/EtherClient/CoinMarket/Types/CoinTicker.swift
@@ -5,7 +5,7 @@ import RealmSwift
 
 struct CoinTicker: Codable {
     private enum CodingKeys: String, CodingKey {
-        case price_usd = "current_price", percent_change_24h = "market_cap_change_percentage_24h", id = "id", symbol = "symbol", image = "image"
+        case price_usd = "current_price", percent_change_24h = "price_change_percentage_24h", id = "id", symbol = "symbol", image = "image"
     }
 
     private let id: String


### PR DESCRIPTION
Before PR|After PR
-|-
<img src="https://user-images.githubusercontent.com/56189/86320108-adfed080-bc68-11ea-8593-040a36948528.png" width=300>|<img src="https://user-images.githubusercontent.com/56189/86320119-b22aee00-bc68-11ea-8276-2f3eea9e6e7c.png" width=300>