### PR TITLE
FIx: TokenScript actionsheet should show contract the transaction is …

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
@@ -79,12 +79,12 @@ struct FunctionOrigin {
         }
     }
 
-    private let originContractOrRecipientAddress: AlphaWallet.Address
     private let attributeId: AttributeId
     private let functionType: FunctionType
     private let bitmask: BigUInt?
     private let bitShift: Int
 
+    let originContractOrRecipientAddress: AlphaWallet.Address
     let originElement: XMLElement
     let xmlContext: XmlContext
 

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -191,7 +191,8 @@ class TokenInstanceActionViewController: UIViewController, TokenVerifiableStatus
             return allAttributesAndValues
         }.done { values in
             let strongSelf = self
-            guard let contract = strongSelf.action.contract, let transactionFunction = strongSelf.action.transactionFunction else { return }
+            guard let transactionFunction = strongSelf.action.transactionFunction else { return }
+            let contract = transactionFunction.originContractOrRecipientAddress
             let tokenId = strongSelf.tokenId
 
             func notify(message: String) {


### PR DESCRIPTION
…posting to, not the holding contract