### PR TITLE
Fix: crash when opening TokenScript views

### DIFF
--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -134,7 +134,7 @@ class TokenInstanceWebView: UIView {
 
     deinit {
         //Necessary to prevent crash when scrolling a table with several cells containing this class
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
+        estimatedProgressObservation.invalidate()
     }
 
     //Implementation: String concatentation is slow, but it's not obvious at all
@@ -289,7 +289,7 @@ class TokenInstanceWebView: UIView {
         }
         webView.loadHTMLString(html, baseURL: nil)
         hashOfLoadedHtml = hashOfCurrentHtml
-    } 
+    }
 
     private func makeIntroductionWebViewFullHeight(renderingAttempt: RenderingAttempt) {
         let forLoadId: Int? = loadId


### PR DESCRIPTION
Any of this:

A. Tap on a token with TokenScript file with item-views. eg. ENS
B. Tap on a token with action-only TokenScript and tap on an action button e.g. xDai