### PR TITLE
Add number formatters for percentages and crypto (that has already taken into account decimals)

### DIFF
--- a/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
+++ b/AlphaWallet/Core/Formatters/CurrencyFormatter.swift
@@ -6,6 +6,8 @@ extension NumberFormatter {
 
     static let currency = Formatter(.currency)
     static let usd = Formatter(.usd)
+    static let percent = Formatter(.percent)
+    static let shortCrypto = Formatter(.shortCrypto)
 
     class Formatter {
         private let formatter: NumberFormatter
@@ -16,13 +18,15 @@ extension NumberFormatter {
 
         func string(from number: Double) -> String? {
             return formatter.string(from: number as NSNumber)
-        } 
+        }
     }
 }
 
 private enum NumberFormatterConfiguration {
     case usd
     case currency
+    case percent
+    case shortCrypto
 
     var formatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -39,6 +43,16 @@ private enum NumberFormatterConfiguration {
             formatter.positiveFormat = "0.00" + " " + Constants.Currency.usd
             formatter.negativeFormat = "-0.00" + " " + Constants.Currency.usd
             formatter.currencyCode = String()
+        case .percent:
+            formatter.positiveFormat = "0.00%"
+            formatter.negativeFormat = "-0.00%"
+            formatter.numberStyle = .percent
+        case .shortCrypto:
+            formatter.positiveFormat = "0.0000"
+            formatter.negativeFormat = "-0.0000"
+            formatter.numberStyle = .none
+            formatter.minimumFractionDigits = Constants.etherFormatterFractionDigits
+            formatter.maximumFractionDigits = Constants.etherFormatterFractionDigits
         }
 
         return formatter


### PR DESCRIPTION
So we can do things like:

```
NumberFormatter.percent.string(from: 0.4) //40%
NumberFormatter.shortCrypto.string(from: 0.123499) //0.1234
```

Similar to how `.currency` and `.usd` is used now.

`.percent` and `.shortCrypto` aren't actually used yet, but they were used in the `train-leaves` branch. `.shortCrypto` is going to be used in a a future refactor.

That refactor is roughly:

* we can rename `CurrencyFormatter.swift` to `NumberFormatter.swift` (keeping the contents)
* rename `EtherNumberFormatter` to `CryptoValueConvertor`
* change the underlying logic of `CryptoValueConvertor.swift` to use `NumberFormatter.swift` so formatting logic and specs (2 decimals, etc) are kept in 1 place.