### PR TITLE
set gas limit from node rather than hardcoding for token transactions

### DIFF
--- a/AlphaWallet/EtherClient/Requests/EstimateGasRequest.swift
+++ b/AlphaWallet/EtherClient/Requests/EstimateGasRequest.swift
@@ -21,7 +21,7 @@ struct EstimateGasRequest: JSONRPCKit.Request {
             [
                 "from": from.description,
                 "to": to?.description ?? "",
-                "value": value.description.hexEncoded,
+                "value": "0x" + String(value, radix: 16) ?? "0x0",
                 "data": data.hexEncoded,
             ],
         ]

--- a/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
@@ -5,6 +5,6 @@ import BigInt
 
 public struct GasLimitConfiguration {
     static let defaultGasLimit = BigInt(90_000)
-    static let minGasLimit = BigInt(21_000) // ETH transfers are always 21k
+    static let minGasLimit = BigInt(21_000)
     static let maxGasLimit = BigInt(1_000_000)
 }

--- a/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
@@ -5,7 +5,7 @@ import BigInt
 
 struct TransactionConfiguration {
     let gasPrice: BigInt
-    let gasLimit: BigInt
+    var gasLimit: BigInt
     let data: Data
     let nonce: Int?
 


### PR DESCRIPTION
Fixes #2046 

The problem was 3 things:

1. The data was not yet included in the configurator and therefore couldn't estimate properly
2. the value param was encoded incorrectly, running BigInt.description.hexEncoded produced 0x30 on a 0 value
3. The value param is used incorrectly, for erc20 transfers the value is the amount of tokens being sent instead of the attached native currency amount, doing so can and will produce an error because erc20 transfers that include a value are often reverted in the contract.

Created https://github.com/AlphaWallet/alpha-wallet-ios/issues/2101 as the code base is not good here. 

