### PR TITLE
Fix: TokenScript attribute fetching (actually most smart contract function calls) not working anymore, so TokenScript views display NaN #1652

### DIFF
--- a/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
@@ -4,14 +4,34 @@ import Foundation
 import PromiseKit
 import web3swift
 
-//TODO maybe we should cache promises that haven't resolved yet. This is useful/needed because users can switch between Wallet and Transactions tab multiple times quickly and trigger the same call to fire many times before any of them have been completed
+//TODO wrap callSmartContract() and cache into a type
+var smartContractCallsCache = [String: (promise: Promise<[String: Any]>, timestamp: Date)]()
+
 func callSmartContract(withServer server: RPCServer, contract: AlphaWallet.Address, functionName: String, abiString: String, parameters: [AnyObject] = [AnyObject](), timeout: TimeInterval? = nil) -> Promise<[String: Any]> {
-    return firstly { () -> Promise<(EthereumAddress)> in
+    //We must include the ABI string in the key because the order of elements in a dictionary when serialized in the string is not ordered. Parameters (which is ordered) should ensure it's the same function
+    let cacheKey = "\(contract).\(functionName) \(parameters) \(server.chainID)"
+    let ttlForCache: TimeInterval = 3
+    let now = Date()
+    if let (cachedPromise, cacheTimestamp) = smartContractCallsCache[cacheKey] {
+        let diff = now.timeIntervalSince(cacheTimestamp)
+        if diff < ttlForCache {
+            //HACK: We can't return the cachedPromise directly and immediately because if we use the value as a TokenScript attribute in a TokenScript view, timing issues will cause the webview to not load properly or for the injection with updates to fail
+            return Promise { seal in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    cachedPromise.done {
+                        seal.fulfill($0)
+                    }.catch {
+                        seal.reject($0)
+                    }
+                }
+            }
+        }
+    }
+
+    let result: Promise<[String: Any]> = Promise { seal in
         let contractAddress = EthereumAddress(address: contract)
-        return .value(contractAddress)
-    }.then { contractAddress -> Promise<[String: Any]> in
         guard let webProvider = Web3HttpProvider(server.rpcURL, network: server.web3Network) else {
-            return Promise(error: Web3Error(description: "Error creating web provider for: \(server.rpcURL) + \(server.web3Network)"))
+            throw Web3Error(description: "Error creating web provider for: \(server.rpcURL) + \(server.web3Network)")
         }
         if let timeout = timeout {
             let configuration = webProvider.session.configuration
@@ -24,15 +44,22 @@ func callSmartContract(withServer server: RPCServer, contract: AlphaWallet.Addre
         let web3 = web3swift.web3(provider: webProvider)
 
         guard let contractInstance = web3swift.web3.web3contract(web3: web3, abiString: abiString, at: contractAddress, options: web3.options) else {
-            return Promise(error: Web3Error(description: "Error creating web3swift contract instance to call \(functionName)()"))
+            throw Web3Error(description: "Error creating web3swift contract instance to call \(functionName)()")
         }
         guard let promiseCreator = contractInstance.method(functionName, parameters: parameters, options: nil) else {
-            return Promise(error: Web3Error(description: "Error calling \(contract.eip55String).\(functionName)() with parameters: \(parameters)"))
+            throw Web3Error(description: "Error calling \(contract.eip55String).\(functionName)() with parameters: \(parameters)")
         }
 
         //callPromise() creates a promise. It doesn't "call" a promise. Bad name
-        return promiseCreator.callPromise(options: nil)
+        promiseCreator.callPromise(options: nil).done {
+            seal.fulfill($0)
+        }.catch {
+            seal.reject($0)
+        }
     }
+
+    smartContractCallsCache[cacheKey]  = (result, now)
+    return result
 }
 
 func getEventLogs(


### PR DESCRIPTION
Fixes #1652

This was because too many calls are made. Since the Ethereum block time is > 10s as of now, the (simple) solution is to cache the values for a few seconds (3).

This is only reproducible on a device, not in the simulator

This took a long time to fix. Lots of debugging code written and very slow tweak-verify-build cycle because I was sent down the rabbit hole at https://github.com/AlphaWallet/web3swift/pull/1 (which is hard to test because I had to rebuild the project after each tweak in the pod) mistaking that it was the cause.

<p align=center style='font-size: 100%'>··•··</p>

To reproduce the problem, trigger 1000s of smart contract calls fairly quickly.