### PR TITLE
Only read specifically for URL(s) in the pasteboard when app is launch/resumed

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -107,7 +107,8 @@ class InCoordinator: NSObject, Coordinator {
         self.appTracker = appTracker
         self.analyticsCoordinator = analyticsCoordinator
         self.assetDefinitionStore = assetDefinitionStore
-        self.assetDefinitionStore.enableFetchXMLForContractInPasteboard()
+        //Disabled for now. Refer to function's comment
+        //self.assetDefinitionStore.enableFetchXMLForContractInPasteboard()
 
         super.init()
     }
@@ -838,7 +839,7 @@ extension InCoordinator: UITabBarControllerDelegate {
             dappBrowserCoordinator?.willHide()
         }
         return true
-    } 
+    }
 }
 
 extension InCoordinator: TransactionsStorageDelegate {

--- a/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkInPasteboardCoordinator.swift
@@ -11,10 +11,11 @@ class UniversalLinkInPasteboardCoordinator: Coordinator {
     weak var delegate: UniversalLinkInPasteboardCoordinatorDelegate?
 
     func start() {
-        guard let contents = UIPasteboard.general.string?.trimmed else { return }
-        guard let url = URL(string: contents) else { return }
-        guard RPCServer(withMagicLink: url) != nil else { return }
-        UIPasteboard.general.string = ""
-        delegate?.importUniversalLink(url: url, for: self)
+        if UIPasteboard.general.hasURLs {
+            guard let url = UIPasteboard.general.url else { return }
+            guard RPCServer(withMagicLink: url) != nil else { return }
+            UIPasteboard.general.string = ""
+            delegate?.importUniversalLink(url: url, for: self)
+        }
     }
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -93,6 +93,7 @@ class AssetDefinitionStore {
         return backingStore.hasOutdatedTokenScript(forContract: contract)
     }
 
+    //Calling this in >= iOS 14 will trigger a scary "AlphaWallet pasted from <app>" message
     func enableFetchXMLForContractInPasteboard() {
         NotificationCenter.default.addObserver(self, selector: #selector(fetchXMLForContractInPasteboard), name: UIApplication.didBecomeActiveNotification, object: nil)
     }


### PR DESCRIPTION
This is avoid the scary iOS 14 warning: 'AlphaWallet pasted from <app>' like in the screenshot unnecessarily.

This means only urls copied as a link will be auto detected as MagicLink.

More specifically:

A. if someone selects and uses the cursors on iOS to copy a URL from a passage of text, it will no longer be detected as a MagicLink
B. taps and hold a link on iOS and choose Copy, it will be detected as a MagicLink
C. ctrl-clicks on macOS a link and choose Copy Link and has Universal Clipboard enabled, it will be detected as a MagicLink

<img src="https://user-images.githubusercontent.com/56189/93180273-7e406e80-f769-11ea-8c0c-4db3670ec869.jpeg" width=200>

This means that if the user copies a URL which is not a MagicLink with (B) or (C), the scary message will still appear.