### PR TITLE
Fix: Navigation bar is too tall (like with large title enabled) for NFT token views

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -171,6 +171,11 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: R.image.backWhite(), style: .plain, target: self, action: #selector(didTapCancelButton))
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         guard let buttonsBarHolder = buttonsBar.superview else {


### PR DESCRIPTION
Before PR | After PR
-|-
<img width=200 src="https://user-images.githubusercontent.com/56189/93289573-4260e400-f811-11ea-8e4f-d9ecfe54ff89.png">| <img width=200 src="https://user-images.githubusercontent.com/56189/93289577-45f46b00-f811-11ea-8f06-afa1da13a22b.png">

introduced by #2139