### PR TITLE
Speed up app by not fetching all blocks when fetching transactions for token detection

### DIFF
--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -64,6 +64,51 @@ struct Config {
         return id
     }
 
+    private static func generateLastFetchedErc20InteractionBlockNumberKey(_ wallet: AlphaWallet.Address) -> String {
+        "\(Keys.lastFetchedAutoDetectedTransactedTokenErc20BlockNumber)-\(wallet.eip55String)"
+    }
+
+    private static func generateLastFetchedAutoDetectedTransactedTokenErc20BlockNumberKey(_ wallet: AlphaWallet.Address) -> String {
+        "\(Keys.lastFetchedAutoDetectedTransactedTokenErc20BlockNumber)-\(wallet.eip55String)"
+    }
+
+    private static func generateLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumberKey(_ wallet: AlphaWallet.Address) -> String {
+        "\(Keys.lastFetchedAutoDetectedTransactedTokenNonErc20BlockNumber)-\(wallet.eip55String)"
+    }
+
+    static func setLastFetchedErc20InteractionBlockNumber(_ blockNumber: Int, server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) {
+        var dictionary: [String: NSNumber] = (defaults.value(forKey: generateLastFetchedErc20InteractionBlockNumberKey(wallet)) as? [String: NSNumber]) ?? .init()
+        dictionary["\(server.chainID)"] = NSNumber(value: blockNumber)
+        defaults.set(dictionary, forKey: generateLastFetchedErc20InteractionBlockNumberKey(wallet))
+    }
+
+    static func getLastFetchedErc20InteractionBlockNumber(_ server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) -> Int? {
+        guard let dictionary = defaults.value(forKey: generateLastFetchedErc20InteractionBlockNumberKey(wallet)) as? [String: NSNumber] else { return nil }
+        return dictionary["\(server.chainID)"]?.intValue
+    }
+
+    static func setLastFetchedAutoDetectedTransactedTokenErc20BlockNumber(_ blockNumber: Int, server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) {
+        var dictionary: [String: NSNumber] = (defaults.value(forKey: generateLastFetchedAutoDetectedTransactedTokenErc20BlockNumberKey(wallet)) as? [String: NSNumber]) ?? .init()
+        dictionary["\(server.chainID)"] = NSNumber(value: blockNumber)
+        defaults.set(dictionary, forKey: generateLastFetchedAutoDetectedTransactedTokenErc20BlockNumberKey(wallet))
+    }
+
+    static func getLastFetchedAutoDetectedTransactedTokenErc20BlockNumber(_ server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) -> Int? {
+        guard let dictionary = defaults.value(forKey: generateLastFetchedAutoDetectedTransactedTokenErc20BlockNumberKey(wallet)) as? [String: NSNumber] else { return nil }
+        return dictionary["\(server.chainID)"]?.intValue
+    }
+
+    static func setLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumber(_ blockNumber: Int, server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) {
+        var dictionary: [String: NSNumber] = (defaults.value(forKey: generateLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumberKey(wallet)) as? [String: NSNumber]) ?? .init()
+        dictionary["\(server.chainID)"] = NSNumber(value: blockNumber)
+        defaults.set(dictionary, forKey: generateLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumberKey(wallet))
+    }
+
+    static func getLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumber(_ server: RPCServer, wallet: AlphaWallet.Address, defaults: UserDefaults = UserDefaults.standard) -> Int? {
+        guard let dictionary = defaults.value(forKey: generateLastFetchedAutoDetectedTransactedTokenNonErc20BlockNumberKey(wallet)) as? [String: NSNumber] else { return nil }
+        return dictionary["\(server.chainID)"]?.intValue
+    }
+
     struct Keys {
         static let chainID = "chainID"
         static let isCryptoPrimaryCurrency = "isCryptoPrimaryCurrency"
@@ -73,6 +118,9 @@ struct Config {
         static let walletAddressesAlreadyPromptedForBackUp = "walletAddressesAlreadyPromptedForBackUp "
         static let locale = "locale"
         static let enabledServers = "enabledChains"
+        static let lastFetchedErc20InteractionBlockNumber = "lastFetchedErc20InteractionBlockNumber"
+        static let lastFetchedAutoDetectedTransactedTokenErc20BlockNumber = "lastFetchedAutoDetectedTransactedTokenErc20BlockNumber"
+        static let lastFetchedAutoDetectedTransactedTokenNonErc20BlockNumber = "lastFetchedAutoDetectedTransactedTokenNonErc20BlockNumber"
     }
 
     let defaults: UserDefaults

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -134,12 +134,24 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
-    func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address) -> URL? {
-        return getEtherscanURL.flatMap { URL(string: "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)") }
+    func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
+         getEtherscanURL.flatMap {
+             var url = "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)"
+             if let startBlock = startBlock {
+                 url = "\(url)&startBlock=\(startBlock)"
+             }
+             return URL(string: url)
+         }
     }
 
-    func etherscanAPIURLForERC20TxList(for address: AlphaWallet.Address) -> URL? {
-        return getEtherscanURLERC20Events.flatMap { URL(string: "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)") }
+    func etherscanAPIURLForERC20TxList(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
+        getEtherscanURLERC20Events.flatMap {
+            var url = "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)"
+            if let startBlock = startBlock {
+                url = "\(url)&startBlock=\(startBlock)"
+            }
+            return URL(string: url)
+        }
     }
 
     func etherscanContractDetailsWebPageURL(for address: AlphaWallet.Address) -> URL {

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -9,8 +9,8 @@ import SwiftyJSON
 
 class GetContractInteractions {
 
-    func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, completion: @escaping ([Transaction]) -> Void) {
-        guard let etherscanURL = server.etherscanAPIURLForERC20TxList(for: address) else { return }
+    func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([Transaction]) -> Void) {
+        guard var etherscanURL = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) else { return }
         Alamofire.request(etherscanURL).validate().responseJSON { response in
             switch response.result {
             case .success(let value):
@@ -68,16 +68,16 @@ class GetContractInteractions {
         }
     }
 
-    func getContractList(address: AlphaWallet.Address, server: RPCServer, erc20: Bool, completion: @escaping ([AlphaWallet.Address]) -> Void) {
+    func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool, completion: @escaping ([AlphaWallet.Address], Int?) -> Void) {
         let etherscanURL: URL
         if erc20 {
-            if let url = server.etherscanAPIURLForERC20TxList(for: address) {
+            if let url = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return
             }
         } else {
-            if let url = server.etherscanAPIURLForTransactionList(for: address) {
+            if let url = server.etherscanAPIURLForTransactionList(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return
@@ -89,28 +89,32 @@ class GetContractInteractions {
                 //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
                 DispatchQueue.global().async {
                     let json = JSON(value)
-                    let contracts: [String] = json["result"].map { _, transactionJson in
+                    let contracts: [(String, Int?)] = json["result"].map { _, transactionJson in
+                        let blockNumber = transactionJson["blockNumber"].string.flatMap { Int($0) }
                         if transactionJson["input"] != "0x" {
                             //every transaction that has input is by default a transaction to a contract
                             //Note: etherscan API only returns contractAddress for this call
                             //if it is an initialisation of a contract
                             if transactionJson["contractAddress"].description == "" {
-                                return transactionJson["to"].description
+                                return (transactionJson["to"].description, blockNumber)
                             } else {
-                                return transactionJson["contractAddress"].description
+                                return (transactionJson["contractAddress"].description, blockNumber)
                             }
                         }
-                        return ""
+                        return ("", blockNumber)
                     }
-                    let nonEmptyContracts = contracts.filter { !$0.isEmpty }
+                    let nonEmptyContracts = contracts
+                            .map { $0.0 }
+                            .filter { !$0.isEmpty }
                     let uniqueNonEmptyContracts = Set(nonEmptyContracts).compactMap { AlphaWallet.Address(uncheckedAgainstNullAddress: $0) }
+                    let maxBlockNumber = contracts.compactMap { $0.1 } .max()
                     DispatchQueue.main.async {
-                        completion(uniqueNonEmptyContracts)
+                        completion(uniqueNonEmptyContracts, maxBlockNumber)
                     }
                 }
             case .failure(let error):
                 print(error)
-                completion([])
+                completion([], nil)
             }
         }
     }

--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -77,10 +77,16 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
 
     //TODO should this be added to the queue?
     private func autoDetectERC20Transactions() {
+        let wallet = session.account.address
+        let startBlock = Config.getLastFetchedErc20InteractionBlockNumber(session.server, wallet: wallet).flatMap { $0 + 1 }
         GetContractInteractions().getErc20Interactions(
-                address: session.account.address,
-                server: session.server
+                address: wallet,
+                server: session.server,
+                startBlock: startBlock
         ) { result in
+            if let maxBlockNumber = result.map { $0.blockNumber }.max() {
+                Config.setLastFetchedErc20InteractionBlockNumber(maxBlockNumber, server: self.session.server, wallet: wallet)
+            }
             self.update(items: result)
         }
     }


### PR DESCRIPTION
A. `GetContractInteractions.getContractList()` is called once per launch (called again if the user switches wallet) for ERC20 transactions and once for non-ERC20s [1]
B. `GetContractInteractions.getErc20Interactions()` is called at regular intervals

Before this PR, they both attempt to fetch data without specifying the `startBlock`.

This PR stores the last seen block from the results of each of these calls and only looks at newer blocks.

(B) in particular is really heavy and blocks the UI for *a few seconds* when running a decent-sized wallet

[1] The call for ERC20s transactions is actually a duplicate of (B), but this PR doesn't fix/refactor this.