### PR TITLE
Improve activities performance

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/EventsActivityDataStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/EventsActivityDataStore.swift
@@ -7,9 +7,13 @@ protocol EventsActivityDataStoreProtocol {
     func add(events: [EventActivity], forTokenContract contract: AlphaWallet.Address)
     func getMatchingEventsSortedByBlockNumber(forContract contract: AlphaWallet.Address, tokenContract: AlphaWallet.Address, server: RPCServer, eventName: String) -> [EventActivity]
     func getEvents(forContract contract: AlphaWallet.Address, forEventName eventName: String, filter: String, server: RPCServer) -> [EventActivity]
+    func getRecentEvents() -> [EventActivity]
 }
 
 class EventsActivityDataStore: EventsActivityDataStoreProtocol {
+    //For performance. Fetching and displaying 10k activities stalls the app for a few seconds. We just keep it simple, no pagination. Pagination is complicated because we have to handle re-fetching of activities, updates as well as blending with transactions
+    static let numberOfActivitiesToUse = 1000
+
     private let realm: Realm
 
     init(realm: Realm) {
@@ -31,6 +35,13 @@ class EventsActivityDataStore: EventsActivityDataStoreProtocol {
                 .filter("chainId = \(server.chainID)")
                 .filter("eventName = '\(eventName)'")
                 .filter("filter = '\(filter)'"))
+    }
+
+    func getRecentEvents() -> [EventActivity] {
+        return Array(realm.objects(EventActivity.self)
+                .sorted(byKeyPath: "date", ascending: false)
+                .prefix(Self.numberOfActivitiesToUse)
+        )
     }
 
     private func delete<S: Sequence>(events: S) where S.Element: EventActivity {

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -331,7 +331,9 @@ private class PrivateXMLHandler {
                 } else {
                     self.server = PrivateXMLHandler.extractServer(fromXML: xml, xmlContext: self.xmlContext, matchingContract: contract).flatMap { .server($0) }
                 }
-                self.assetDefinitionStore?.invalidateSignatureStatus(forContract: self.contractAddress)
+                if !isBase {
+                    self.assetDefinitionStore?.invalidateSignatureStatus(forContract: self.contractAddress)
+                }
             }.cauterize()
         }
     }

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -704,7 +704,7 @@ extension TokensCardCoordinator: TokenInstanceActionViewControllerDelegate {
 }
 
 extension TokensCardCoordinator: TransactionInProgressCoordinatorDelegate {
-    
+
     func transactionInProgressDidDissmiss(in coordinator: TransactionInProgressCoordinator) {
         removeCoordinator(coordinator)
     }


### PR DESCRIPTION
Especially from app launch till Activities tab is available.

Primarily by only ever, loading a subset of activities. 1000 for now, as well as transactions in the same period.