### PR TITLE
Speed up refreshes by not treat signature invalidation as the TokenScript file being modified/updated

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -137,7 +137,7 @@ class InCoordinator: NSObject, Coordinator {
 
     private func setupWatchingTokenScriptFileChangesToFetchEvents() {
         //TODO this is firing twice for each contract. We can be more efficient
-        assetDefinitionStore.subscribe { [weak self] contract in
+        assetDefinitionStore.subscribeToBodyChanges { [weak self] contract in
             guard let strongSelf = self else { return }
             let tokens = strongSelf.tokensStorages.values.flatMap { $0.enabledObject }
             //Assume same contract don't exist in multiple chains

--- a/AlphaWallet/TokenScriptClient/Models/AssetAttributesCache.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetAttributesCache.swift
@@ -21,7 +21,7 @@ class AssetAttributesCache {
     }
 
     private func setUpClearCacheWhenTokenScriptChanges() {
-        assetDefinitionStore?.subscribe { [weak self] contract in
+        assetDefinitionStore?.subscribeToBodyChanges { [weak self] contract in
             guard let strongSelf = self else { return }
             strongSelf.resolvedAttributesData.remove(contract: contract)
             strongSelf.functionOriginAttributes.removeValue(forKey: contract)

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -405,7 +405,13 @@ class SingleChainTokenCoordinator: Coordinator {
     }
 
     private func refreshTokenViewControllerUponAssetDefinitionChanges(_ viewController: TokenViewController, forTransferType transferType: TransferType, transactionsStore: TransactionsStorage) {
-        assetDefinitionStore.subscribe { [weak self] contract in
+        assetDefinitionStore.subscribeToBodyChanges { [weak self] contract in
+            guard let strongSelf = self else { return }
+            guard contract.sameContract(as: transferType.contract) else { return }
+            let viewModel = TokenViewControllerViewModel(transferType: transferType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)
+            viewController.configure(viewModel: viewModel)
+        }
+        assetDefinitionStore.subscribeToSignatureChanges { [weak self] contract in
             guard let strongSelf = self else { return }
             guard contract.sameContract(as: transferType.contract) else { return }
             let viewModel = TokenViewControllerViewModel(transferType: transferType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -81,7 +81,11 @@ class TokensCardCoordinator: NSObject, Coordinator {
     }
 
     private func refreshUponAssetDefinitionChanges() {
-        assetDefinitionStore.subscribe { [weak self] contract in
+        assetDefinitionStore.subscribeToBodyChanges { [weak self] contract in
+            guard let strongSelf = self else { return }
+            strongSelf.refreshScreen(forContract: contract)
+        }
+        assetDefinitionStore.subscribeToSignatureChanges { [weak self] contract in
             guard let strongSelf = self else { return }
             strongSelf.refreshScreen(forContract: contract)
         }


### PR DESCRIPTION
Before the PR, when an `PrivateXMLHandler` (1:1 with reading a TokenScript file) is created, we verify the signature and once upon getting the verification result, we inform all the listeners (subscribers in the code) watching for TokenScript file changes to refresh. This means that soon after app launch, we verify the signature of every TokenScript file we have on-disk and trigger a refresh of every token which has those TokenScript file. Most screens don't care about the signature verification result.

This is unnecessary, so with this PR, we track 2 sets of subscribers — 1 for watching for TokenScript file changes, another for signature verification changes/results.