### PR TITLE
Show activity view for native crypto send/receives transactions when they are tapped in the Activity tab.

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -88,6 +88,42 @@ class ActivitiesViewController: UIViewController {
         }
         return container
     }
+
+    private func createPseudoActivity(fromTransaction transaction: Transaction) -> Activity {
+        let activityName: String
+        //TODO pass in instead
+        if EtherKeystore.current!.address.sameContract(as: transaction.from) {
+            activityName = "sent"
+        } else {
+            activityName = "received"
+        }
+        var cardAttributes = [AttributeId: AssetInternalValue]()
+        cardAttributes["symbol"] = .string(transaction.server.symbol)
+        if let value = BigUInt(transaction.value) {
+            cardAttributes["amount"] = .uint(value)
+        }
+        if let value = AlphaWallet.Address(string: transaction.to) {
+            cardAttributes["to"] = .address(value)
+        }
+        if let value = AlphaWallet.Address(string: transaction.from) {
+            cardAttributes["from"] = .address(value)
+        }
+        return .init(
+                //We only use this ID for refreshing the display of specific activity, since the display for ETH send/receives don't ever need to be refreshed, just need a number that don't clash with other activities
+                id: transaction.blockNumber + 10000000,
+                tokenObject: TokensDataStore.etherToken(forServer: transaction.server),
+                server: transaction.server,
+                name: activityName,
+                eventName: activityName,
+                blockNumber: transaction.blockNumber,
+                transactionId: transaction.id,
+                date: transaction.date,
+                values: (token: .init(), card: cardAttributes),
+                view: (html: "", style: ""),
+                itemView: (html: "", style: ""),
+                isBaseCard: true
+        )
+    }
 }
 
 extension ActivitiesViewController: StatefulViewController {
@@ -104,7 +140,13 @@ extension ActivitiesViewController: UITableViewDelegate {
         case .activity(let activity):
             delegate?.didPressActivity(activity: activity, in: self)
         case .transaction(let transaction):
-            delegate?.didPressTransaction(transaction: transaction, in: self)
+            //ETH
+            if transaction.operation == nil {
+                let activity = createPseudoActivity(fromTransaction: transaction)
+                delegate?.didPressActivity(activity: activity, in: self)
+            } else {
+                delegate?.didPressTransaction(transaction: transaction, in: self)
+            }
         }
     }
 }
@@ -131,42 +173,8 @@ extension ActivitiesViewController: UITableViewDataSource {
         case .transaction(let transaction):
             //ETH
             if transaction.operation == nil {
-                let activityName: String
-                //TODO pass in instead
-                if EtherKeystore.current!.address.sameContract(as: transaction.from) {
-                    activityName = "sent"
-                } else {
-                    activityName = "received"
-                }
-
-                var cardAttributes = [AttributeId: AssetInternalValue]()
-                cardAttributes["symbol"] = .string(transaction.server.symbol)
-                if let value = BigUInt(transaction.value) {
-                    cardAttributes["amount"] = .uint(value)
-                }
-                if let value = AlphaWallet.Address(string: transaction.to) {
-                    cardAttributes["to"] = .address(value)
-                }
-                if let value = AlphaWallet.Address(string: transaction.from) {
-                    cardAttributes["from"] = .address(value)
-                }
-
+                let activity = createPseudoActivity(fromTransaction: transaction)
                 let cell: DefaultActivityItemViewCell = tableView.dequeueReusableCell(for: indexPath)
-                let activity = Activity(
-                        //We only use this ID for refreshing the display of specific activity, since the display for ETH send/receives don't ever need to be refreshed, just need a number that don't clash with other activities
-                        id: transaction.blockNumber + 10000000,
-                        tokenObject: TokensDataStore.etherToken(forServer: transaction.server),
-                        server: transaction.server,
-                        name: activityName,
-                        eventName: activityName,
-                        blockNumber: transaction.blockNumber,
-                        transactionId: "",
-                        date: transaction.date,
-                        values: (token: .init(), card: cardAttributes),
-                        view: (html: "", style: ""),
-                        itemView: (html: "", style: ""),
-                        isBaseCard: true
-                        )
                 cell.configure(viewModel: .init(activity: activity))
                 return cell
             } else {


### PR DESCRIPTION
Show activity view (like how the base ERC20 describes it for ERC20 tokens send/receive) for native crypto send/receives transactions when they are tapped in the Activity tab.
    
Prior to this, while these native crypto send/receive transactions are displayed similarly to ERC20 send/receive activities in the Activities tab, they show the transaction details screen when tapped.

And with #2165, tapping the top right button in the Activity View will show the transaction screen

Before PR | After PR
-|-
<img width=200 src="https://user-images.githubusercontent.com/56189/94646582-1705eb00-0321-11eb-82c7-00910d0eb501.png">|<img width=200 src="https://user-images.githubusercontent.com/56189/94646587-1a997200-0321-11eb-9d58-7a6428cfb86e.png">
