### PR TITLE
Fix home screen quick action qr scanner not work with cold launch

### DIFF
--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     }
 
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> ()) {
-        if shortcutItem.type == "com.stormbird.alphawallet.qrScanner" {
+        if shortcutItem.type == Constants.launchShortcutKey {
             appCoordinator.launchUniversalScanner()
         }
         completionHandler(true)

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -28,6 +28,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
             let keystore = try EtherKeystore(analyticsCoordinator: nil)
             appCoordinator = AppCoordinator(window: window!, keystore: keystore)
             appCoordinator.start()
+
+            if let shortcutItem = launchOptions?[UIApplication.LaunchOptionsKey.shortcutItem] as? UIApplicationShortcutItem, shortcutItem.type == Constants.launchShortcutKey {
+                //Delay needed to work because app is launching..
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.appCoordinator.launchUniversalScanner()
+                }
+            }
         } catch {
             print("EtherKeystore init issue.")
         }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -166,6 +166,8 @@ public struct Constants {
     //validator API
     static let tokenScriptValidatorAPI = "https://aw.app/api/v1/verifyXMLDSig"
 
+    static let launchShortcutKey = "com.stormbird.alphawallet.qrScanner"
+
     //CurrencyFormatter
     static let formatterFractionDigits = 2
 


### PR DESCRIPTION
This PR is for this functionality:

1. Tap and hold app icon in home screen
2. Choose Scan QR Code

Before this PR, this only work if the app is in the background, inactive. Doing it after a reboot or if the app is killed, only launches the app, but doesn't show the QR scanner.

This was missing in the implementation of #2153 