### PR TITLE
Fix: background color of Activity tab section headers appears to be 2-toned becaused the section footers are showing up with a very similar background color

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -77,15 +77,9 @@ class ActivitiesViewController: UIViewController {
         title.font = viewModel.headerTitleFont
         container.addSubview(title)
         title.translatesAutoresizingMaskIntoConstraints = false
-        if section == 0 {
-            NSLayoutConstraint.activate([
-                title.anchorsConstraint(to: container, edgeInsets: .init(top: 18, left: 20, bottom: 16, right: 0))
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                title.anchorsConstraint(to: container, edgeInsets: .init(top: 4, left: 20, bottom: 16, right: 0))
-            ])
-        }
+        NSLayoutConstraint.activate([
+            title.anchorsConstraint(to: container, edgeInsets: .init(top: 18, left: 20, bottom: 16, right: 0))
+        ])
         return container
     }
 }
@@ -106,6 +100,14 @@ extension ActivitiesViewController: UITableViewDelegate {
         case .transaction(let transaction):
             delegate?.didPressTransaction(transaction: transaction, in: self)
         }
+    }
+
+    //Hide the footer
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        .leastNormalMagnitude
+    }
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        UIView()
     }
 }
 


### PR DESCRIPTION
Closes #2169 

Made the section header green to illustrate the problem in following screenshots. Notice in the first screenshot, there's a white-ish area in the 2nd and 3rd section header

Before PR|After PR
-|-
<img width=200 src="https://user-images.githubusercontent.com/56189/94779833-1db46100-03fa-11eb-96af-15c5764d34a3.png">|<img width=200 src="https://user-images.githubusercontent.com/56189/94779744-05dcdd00-03fa-11eb-8254-344371189026.png">
