### PR TITLE
Fix: QR code scanners in the app are broken, besides the universal scanner. The scanner screen don't close

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import UIKit
-import BigInt 
+import BigInt
 import RealmSwift
 import WebKit
 
@@ -217,7 +217,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
         if forceReload {
             browserViewController.reload()
         }
-    } 
+    }
 
     func signMessage(with type: SignMessageType, account: EthereumAccount, callbackID: Int) {
         nativeCryptoCurrencyBalanceView.hide()
@@ -682,7 +682,7 @@ extension DappBrowserCoordinator: ScanQRCodeCoordinatorDelegate {
 
     func didScan(result: String, in coordinator: ScanQRCodeCoordinator) {
         removeCoordinator(coordinator)
-        
+
         guard let url = URL(string: result) else { return }
         open(url: url, animated: false)
     }

--- a/AlphaWallet/Tokens/Coordinators/AddHideTokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/AddHideTokensCoordinator.swift
@@ -25,7 +25,7 @@ class AddHideTokensCoordinator: Coordinator {
     private let assetDefinitionStore: AssetDefinitionStore
     private let singleChainTokenCoordinators: [SingleChainTokenCoordinator]
     private let config: Config
-    
+
     var coordinators: [Coordinator] = []
     weak var delegate: AddHideTokensCoordinatorDelegate?
 

--- a/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
@@ -18,7 +18,7 @@ protocol NewTokenCoordinatorDelegate: class {
 }
 
 class NewTokenCoordinator: Coordinator {
-    
+
     private var serverToAddCustomTokenOn: RPCServerOrAuto = .auto {
         didSet {
             switch serverToAddCustomTokenOn {
@@ -212,7 +212,6 @@ extension NewTokenCoordinator: ScanQRCodeCoordinatorDelegate {
 
     func didScan(result: String, in coordinator: ScanQRCodeCoordinator) {
         removeCoordinator(coordinator)
-
         viewController.didScanQRCode(result)
     }
 }

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -171,7 +171,7 @@ extension WalletCoordinator: ImportWalletViewControllerDelegate {
 
         let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: wallet, server: config.server)
         coordinator.delegate = self
-        
+
         addCoordinator(coordinator)
         coordinator.start()
     }


### PR DESCRIPTION
Fixes #2164 

Other than the universal scanner, all the other QR code scanner camera screen can't be closed. This PR fixes this.