### PR TITLE
Support copy watched wallet's address in list of wallets screen

### DIFF
--- a/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
+++ b/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
@@ -134,7 +134,14 @@ class AccountsCoordinator: Coordinator {
 
             navigationController.present(controller, animated: true, completion: nil)
         case .watch:
-            break
+            let copyAction = UIAlertAction(title: R.string.localizable.copyAddress(), style: .default) { _ in
+                UIPasteboard.general.string = account.address.eip55String
+            }
+            controller.addAction(copyAction)
+            let cancelAction = UIAlertAction(title: R.string.localizable.cancel(), style: .cancel) { _ in }
+            controller.addAction(cancelAction)
+            controller.makePresentationFullScreenForiOS13Migration()
+            navigationController.present(controller, animated: true, completion: nil)
         }
     }
 


### PR DESCRIPTION
Before the PR, long tap on a watch wallet in "Change Wallet" screen does nothing.

This PR adds an option to copy address when a watched wallet is long tapped.