### PR TITLE
Fix: pushing Advanced Settings screen and List of wallets screen did not hide the tab bar

### DIFF
--- a/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
+++ b/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
@@ -28,6 +28,7 @@ class AccountsCoordinator: Coordinator {
         controller.navigationItem.rightBarButtonItem = UIBarButtonItem(title: R.string.localizable.addButtonTitle(), style: .plain, target: self, action: #selector(addWallet))
         controller.allowsAccountDeletion = true
         controller.delegate = self
+        controller.hidesBottomBarWhenPushed = true
         return controller
     }()
 

--- a/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/SettingsCoordinator.swift
@@ -39,6 +39,7 @@ class SettingsCoordinator: Coordinator {
     lazy var advancedSettingsViewController: AdvancedSettingsViewController = {
         let controller = AdvancedSettingsViewController()
         controller.delegate = self
+        controller.hidesBottomBarWhenPushed = true
         return controller
     }()
 


### PR DESCRIPTION
Before PR|After PR
-|-
<img width=200 src="https://user-images.githubusercontent.com/56189/95040438-409a8a00-0706-11eb-97b7-0d58c3b516ac.png">| <img width=200 src="https://user-images.githubusercontent.com/56189/95040448-44c6a780-0706-11eb-8bcd-89d47dc1aaf9.png">
<img width=200 src="https://user-images.githubusercontent.com/56189/95040450-455f3e00-0706-11eb-8f15-4a479f491e61.png">| <img width=200 src="https://user-images.githubusercontent.com/56189/95040444-442e1100-0706-11eb-83ea-73e75c854614.png">
