### PR TITLE
Fix: showing duplicate ETH received notifications for Ropsten

### DIFF
--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -224,7 +224,8 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
         if toNotify.count > maximumNumberOfNotifications {
             toNotify = Array(toNotify[0..<maximumNumberOfNotifications])
         }
-        let newIncomingEthTransactions = toNotify.filter { wallet.address.sameContract(as: $0.to) }
+        let toNotifyUnique: [Transaction] = filterUniqueTransactions(toNotify)
+        let newIncomingEthTransactions = toNotifyUnique.filter { wallet.address.sameContract(as: $0.to) }
         let formatter = EtherNumberFormatter.short
         let thresholdToShowNotification = Date.yesterday
         for each in newIncomingEthTransactions {
@@ -245,6 +246,17 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
         case .kovan, .ropsten, .rinkeby, .poa, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom:
             break
         }
+    }
+
+    //Etherscan for Ropsten returns the same transaction twice. Normally Realm will take care of this, but since we are showing user a notification, we don't want to show duplicates
+    private func filterUniqueTransactions(_ transactions: [Transaction]) -> [Transaction] {
+        var results = [Transaction]()
+        for each in transactions {
+            if !results.contains(where: { each.id == $0.id }) {
+                results.append(each)
+            }
+        }
+        return results
     }
 
     private func notifyUserEtherReceived(for transactionId: String, amount: String) {


### PR DESCRIPTION
Reproduce:

1. Switch to Ropsten
2. Send ETH to self
3. Wait
4. 2 notifications appear for the sent transactions, for ETH received

Looked at the results returned from Etherscan for Ropsten. The same transaction is duplicated there.