### PR TITLE
Fix: deleting a watched wallet doesn't clean up wallet name storage correctly

### DIFF
--- a/AlphaWallet/KeyManagement/EtherKeystore.swift
+++ b/AlphaWallet/KeyManagement/EtherKeystore.swift
@@ -381,11 +381,11 @@ open class EtherKeystore: Keystore {
             removeAccountFromBookkeeping(account)
             deleteKeysAndSeedCipherTextFromKeychain(forAccount: account)
             deletePrivateKeysFromSecureEnclave(forAccount: account)
-            //TODO: pass in Config instance instead
-            Config().deleteWalletName(forAccount: account.address)
         case .watch(let address):
             removeAccountFromBookkeeping(.init(address: address))
         }
+        //TODO: pass in Config instance instead
+        Config().deleteWalletName(forAccount: account.address)
         (try? LegacyFileBasedKeystore(analyticsCoordinator: analyticsCoordinator))?.delete(wallet: wallet)
         return .success(())
     }


### PR DESCRIPTION
Before this PR:

1. Watch a wallet W
2. Give it a name N
3. Delete W
4. Watch or import W

Observed
---
W is called N

Expected
---
W is not called N