### PR TITLE
Fix: failed transactions are not displayed with the correct state in Activities tab and sort order is enforced correctly for activities/transactions within the same block

### DIFF
--- a/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
+++ b/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
@@ -219,7 +219,7 @@ class ActivitiesCoordinator: Coordinator {
                 }
                 tokensAndTokenHolders[contract] = (tokenObject: tokenObject, tokenHolders: tokenHolders)
             }
-            return (activity: .init(id: Int.random(in: 0..<Int.max), tokenObject: tokenObject, server: eachEvent.server, name: card.name, eventName: eachEvent.eventName, blockNumber: eachEvent.blockNumber, transactionId: eachEvent.transactionId, date: eachEvent.date, values: (token: tokenAttributes, card: cardAttributes), view: card.view, itemView: card.itemView, isBaseCard: card.isBase, state: .completed), tokenObject: tokenObject, tokenHolder: tokenHolders[0])
+            return (activity: .init(id: Int.random(in: 0..<Int.max), tokenObject: tokenObject, server: eachEvent.server, name: card.name, eventName: eachEvent.eventName, blockNumber: eachEvent.blockNumber, transactionId: eachEvent.transactionId, transactionIndex: eachEvent.transactionIndex, logIndex: eachEvent.logIndex, date: eachEvent.date, values: (token: tokenAttributes, card: cardAttributes), view: card.view, itemView: card.itemView, isBaseCard: card.isBase, state: .completed), tokenObject: tokenObject, tokenHolder: tokenHolders[0])
         }
 
         //TODO fix for activities: special fix to filter out the event we don't want - need to doc this and have to handle with TokenScript design
@@ -275,7 +275,7 @@ class ActivitiesCoordinator: Coordinator {
         }
         if let (index, oldActivity) = activitiesIndexLookup[activity.id] {
             let updatedValues = (token: oldActivity.values.token.merging(resolvedAttributeNameValues) { _, new in new }, card: oldActivity.values.card)
-            let updatedActivity: Activity = .init(id: oldActivity.id, tokenObject: tokenObject, server: oldActivity.server, name: oldActivity.name, eventName: oldActivity.eventName, blockNumber: oldActivity.blockNumber, transactionId: oldActivity.transactionId, date: oldActivity.date, values: updatedValues, view: oldActivity.view, itemView: oldActivity.itemView, isBaseCard: oldActivity.isBaseCard, state: oldActivity.state)
+            let updatedActivity: Activity = .init(id: oldActivity.id, tokenObject: tokenObject, server: oldActivity.server, name: oldActivity.name, eventName: oldActivity.eventName, blockNumber: oldActivity.blockNumber, transactionId: oldActivity.transactionId, transactionIndex: oldActivity.transactionIndex, logIndex: oldActivity.logIndex, date: oldActivity.date, values: updatedValues, view: oldActivity.view, itemView: oldActivity.itemView, isBaseCard: oldActivity.isBaseCard, state: oldActivity.state)
             activities[index] = updatedActivity
             reloadViewController()
             if let activityViewController = activityViewController, activityViewController.isForActivity(updatedActivity) {

--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -121,6 +121,9 @@ class ActivitiesViewController: UIViewController {
                 eventName: activityName,
                 blockNumber: transaction.blockNumber,
                 transactionId: transaction.id,
+                transactionIndex: transaction.transactionIndex,
+                //We don't use this for transactions, so it's ok
+                logIndex: 0,
                 date: transaction.date,
                 values: (token: .init(), card: cardAttributes),
                 view: (html: "", style: ""),

--- a/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
@@ -19,7 +19,34 @@ struct ActivitiesViewModel {
             newItems[date] = currentItems
         }
         let tuple = newItems.map { each in
-            (date: each.key, items: (each.value as! [ActivityOrTransaction]).sorted { $0.date > $1.date })
+            (date: each.key, items: (each.value as! [ActivityOrTransaction]).sorted {
+                if $0.blockNumber > $1.blockNumber {
+                    return true
+                } else if $0.blockNumber < $1.blockNumber {
+                    return false
+                } else {
+                    if $0.transactionIndex > $1.transactionIndex {
+                        return true
+                    } else if $0.transactionIndex < $1.transactionIndex {
+                        return false
+                    } else {
+                        switch ($0, $1) {
+                        case let (.activity(a0), .activity(a1)):
+                            return a0.logIndex > a1.logIndex
+                        case let (.transaction, .activity):
+                            return false
+                        case let (.activity, .transaction):
+                            return true
+                        case let (.transaction(t0), .transaction(t1)):
+                            if let n0 = Int(t0.nonce), let n1 = Int(t1.nonce) {
+                                return n0 > n1
+                            } else {
+                                return false
+                            }
+                        }
+                    }
+                }
+            })
         }
         items = tuple.sorted { (object1, object2) -> Bool in
             formatter.date(from: object1.date)! > formatter.date(from: object2.date)!

--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -7,6 +7,7 @@ import PromiseKit
 struct RawTransaction: Decodable {
     let hash: String
     let blockNumber: String
+    let transactionIndex: String
     let timeStamp: String
     let nonce: String
     let from: String
@@ -17,6 +18,7 @@ struct RawTransaction: Decodable {
     let input: String
     let gasUsed: String
     let error: String?
+    let isError: String?
 
     ///
     ///It is possible for the etherscan.io API to return an empty `to` even if the transaction actually has a `to`. It doesn't seem to be linked to `"isError" = "1"`, because other transactions that fail (with isError="1") has a non-empty `to`.
@@ -32,6 +34,7 @@ struct RawTransaction: Decodable {
     enum CodingKeys: String, CodingKey {
         case hash = "hash"
         case blockNumber
+        case transactionIndex
         case timeStamp
         case nonce
         case from
@@ -43,6 +46,7 @@ struct RawTransaction: Decodable {
         case gasUsed
         case operationsLocalized = "operations"
         case error = "error"
+        case isError = "isError"
     }
 
     let operationsLocalized: [LocalizedOperation]?
@@ -54,7 +58,7 @@ extension Transaction {
             return Promise.value(nil)
         }
         let state: TransactionState = {
-            if transaction.error?.isEmpty == false {
+            if transaction.error?.isEmpty == false || transaction.isError == "1" {
                 return .error
             }
             return .completed
@@ -67,6 +71,7 @@ extension Transaction {
                     id: transaction.hash,
                     server: tokensStorage.server,
                     blockNumber: Int(transaction.blockNumber)!,
+                    transactionIndex: Int(transaction.transactionIndex)!,
                     from: from.description,
                     to: to,
                     value: transaction.value,

--- a/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinatorForActivities.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinatorForActivities.swift
@@ -104,13 +104,14 @@ class EventSourceCoordinatorForActivities {
         guard let blockNumber = event.eventLog?.blockNumber else { return nil }
         guard let logIndex = event.eventLog?.logIndex else { return nil }
         guard let transactionHash = event.eventLog?.transactionHash else { return nil }
+        guard let transactionIndex = event.eventLog?.transactionIndex else { return nil }
         let transactionId = transactionHash.hexEncoded
         let decodedResult = self.convertToJsonCompatible(dictionary: event.decodedResult)
         guard let json = decodedResult.jsonString else { return nil }
         //TODO when TokenScript schema allows it, support more than 1 filter
         let filterTextEquivalent = filterParam.compactMap({ $0?.textEquivalent }).first
         let filterText = filterTextEquivalent ?? "\(eventOrigin.eventFilter.name)=\(eventOrigin.eventFilter.value)"
-        return EventActivity(contract: eventOrigin.contract, tokenContract: token.contractAddress, server: server, date: date, eventName: eventOrigin.eventName, blockNumber: Int(blockNumber), transactionId: transactionId, logIndex: Int(logIndex), filter: filterText, json: json)
+        return EventActivity(contract: eventOrigin.contract, tokenContract: token.contractAddress, server: server, date: date, eventName: eventOrigin.eventName, blockNumber: Int(blockNumber), transactionId: transactionId, transactionIndex: Int(transactionIndex), logIndex: Int(logIndex), filter: filterText, json: json)
     }
 
     private func convertToJsonCompatible(dictionary: [String: Any]) -> [String: Any] {

--- a/AlphaWallet/TokenScriptClient/Models/Activity.swift
+++ b/AlphaWallet/TokenScriptClient/Models/Activity.swift
@@ -32,6 +32,8 @@ struct Activity {
     let eventName: String
     let blockNumber: Int
     let transactionId: String
+    let transactionIndex: Int
+    let logIndex: Int
     let date: Date
     let values: (token: [AttributeId: AssetInternalValue], card: [AttributeId: AssetInternalValue])
     let view: (html: String, style: String)

--- a/AlphaWallet/TokenScriptClient/Models/ActivityOrTransaction.swift
+++ b/AlphaWallet/TokenScriptClient/Models/ActivityOrTransaction.swift
@@ -14,4 +14,22 @@ enum ActivityOrTransaction {
             return transaction.date
         }
     }
+
+    var blockNumber: Int {
+        switch self {
+        case .activity(let activity):
+            return activity.blockNumber
+        case .transaction(let transaction):
+            return transaction.blockNumber
+        }
+    }
+
+    var transactionIndex: Int {
+        switch self {
+        case .activity(let activity):
+            return activity.transactionIndex
+        case .transaction(let transaction):
+            return transaction.transactionIndex
+        }
+    }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -44,6 +44,7 @@ class GetContractInteractions {
                                 id: transactionJson["hash"].description,
                                 server: server,
                                 blockNumber: transactionJson["blockNumber"].intValue,
+                                transactionIndex: transactionJson["transactionIndex"].intValue,
                                 from: transactionJson["from"].description,
                                 to: transactionJson["to"].description,
                                 value: transactionJson["value"].description,
@@ -53,6 +54,7 @@ class GetContractInteractions {
                                 nonce: transactionJson["nonce"].description,
                                 date: Date(timeIntervalSince1970: Double(string: transactionJson["timeStamp"].description) ?? Double(0)),
                                 localizedOperations: [localizedTokenObj],
+                                //The API only returns successful transactions
                                 state: .completed,
                                 isErc20Interaction: true
                         )

--- a/AlphaWallet/Tokens/Types/EventActivity.swift
+++ b/AlphaWallet/Tokens/Types/EventActivity.swift
@@ -5,8 +5,8 @@ import BigInt
 import RealmSwift
 
 class EventActivity: Object {
-    static func generatePrimaryKey(fromContract contract: AlphaWallet.Address, tokenContract: AlphaWallet.Address, server: RPCServer, eventName: String, blockNumber: Int, logIndex: Int, filter: String) -> String {
-        "\(contract.eip55String)-\(tokenContract.eip55String)-\(server.chainID)-\(eventName)-\(blockNumber)-\(logIndex)-\(filter)"
+    static func generatePrimaryKey(fromContract contract: AlphaWallet.Address, tokenContract: AlphaWallet.Address, server: RPCServer, eventName: String, blockNumber: Int, transactionId: String, logIndex: Int, filter: String) -> String {
+        "\(contract.eip55String)-\(tokenContract.eip55String)-\(server.chainID)-\(eventName)-\(blockNumber)-\(transactionId)-\(logIndex)-\(filter)"
     }
 
     @objc dynamic var primaryKey: String = ""
@@ -17,6 +17,7 @@ class EventActivity: Object {
     @objc dynamic var eventName: String = ""
     @objc dynamic var blockNumber: Int = 0
     @objc dynamic var transactionId: String = ""
+    @objc dynamic var transactionIndex: Int = 0
     @objc dynamic var logIndex: Int = 0
     @objc dynamic var filter: String = ""
     @objc dynamic var json: String = "{}" {
@@ -45,9 +46,9 @@ class EventActivity: Object {
         .init(chainID: chainId)
     }
 
-    convenience init(contract: AlphaWallet.Address, tokenContract: AlphaWallet.Address, server: RPCServer, date: Date, eventName: String, blockNumber: Int, transactionId: String, logIndex: Int, filter: String, json: String) {
+    convenience init(contract: AlphaWallet.Address, tokenContract: AlphaWallet.Address, server: RPCServer, date: Date, eventName: String, blockNumber: Int, transactionId: String, transactionIndex: Int, logIndex: Int, filter: String, json: String) {
         self.init()
-        self.primaryKey = EventActivity.generatePrimaryKey(fromContract: contract, tokenContract: tokenContract, server: server, eventName: eventName, blockNumber: blockNumber, logIndex: logIndex, filter: filter)
+        self.primaryKey = EventActivity.generatePrimaryKey(fromContract: contract, tokenContract: tokenContract, server: server, eventName: eventName, blockNumber: blockNumber, transactionId: transactionId, logIndex: logIndex, filter: filter)
         self.contract = contract.eip55String
         self.tokenContract = tokenContract.eip55String
         self.chainId = server.chainID
@@ -55,6 +56,7 @@ class EventActivity: Object {
         self.eventName = eventName
         self.blockNumber = blockNumber
         self.transactionId = transactionId
+        self.transactionIndex = transactionIndex
         self.logIndex = logIndex
         self.filter = filter
         self.json = json

--- a/AlphaWallet/Transactions/Storage/Transaction.swift
+++ b/AlphaWallet/Transactions/Storage/Transaction.swift
@@ -8,6 +8,7 @@ class Transaction: Object {
     @objc dynamic var chainId: Int = 0
     @objc dynamic var id: String = ""
     @objc dynamic var blockNumber: Int = 0
+    @objc dynamic var transactionIndex: Int = 0
     @objc dynamic var from = ""
     @objc dynamic var to = ""
     @objc dynamic var value = ""
@@ -24,6 +25,7 @@ class Transaction: Object {
         id: String,
         server: RPCServer,
         blockNumber: Int,
+        transactionIndex: Int,
         from: String,
         to: String,
         value: String,
@@ -42,6 +44,7 @@ class Transaction: Object {
         self.id = id
         self.chainId = server.chainID
         self.blockNumber = blockNumber
+        self.transactionIndex = transactionIndex
         self.from = from
         self.to = to
         self.value = value

--- a/AlphaWallet/Transfer/Types/SentTransaction.swift
+++ b/AlphaWallet/Transfer/Types/SentTransaction.swift
@@ -13,6 +13,7 @@ extension SentTransaction {
             id: transaction.id,
             server: transaction.original.server,
             blockNumber: 0,
+            transactionIndex: 0,
             from: from.eip55String,
             to: transaction.original.to?.eip55String ?? "",
             value: transaction.original.value.description,

--- a/AlphaWalletTests/Factories/Transaction.swift
+++ b/AlphaWalletTests/Factories/Transaction.swift
@@ -7,6 +7,7 @@ extension Transaction {
     static func make(
         id: String = "0x1",
         blockNumber: Int = 1,
+        transactionIndex: Int = 0,
         from: String = "0x1",
         to: String = "0x1",
         value: String = "1",
@@ -22,6 +23,7 @@ extension Transaction {
             id: id,
             server: .main,
             blockNumber: blockNumber,
+            transactionIndex: transactionIndex,
             from: from,
             to: to,
             value: value,
@@ -32,7 +34,7 @@ extension Transaction {
             date: date,
             localizedOperations: localizedOperations,
             state: state,
-            isErc20Interaction: false 
+            isErc20Interaction: false
         )
     }
 }


### PR DESCRIPTION
Fixes #2192

* transaction ID should be included as the primary key for EventActivity (the Realm object representing activities)
* transactions that failed were displayed like they are successful [1]
* sort order of activities (i.e events) and transactions within the same block was incorrect

This PR contains a database migration.

Before PR| -> Error states displayed correctly| -> With order corrected
-|-|-
<img width="200" src="https://user-images.githubusercontent.com/56189/95545883-aa31d580-0a31-11eb-8d02-b4b37e2cc301.PNG">|<img width="200" src="https://user-images.githubusercontent.com/56189/95545872-a4d48b00-0a31-11eb-95ef-c457862e4b24.png">| <img width="200" src="https://user-images.githubusercontent.com/56189/95545880-a900a880-0a31-11eb-85ab-0605378e0744.png">


[1]:

The transaction "entity" returned by Etherscan contains the field `isError` which is "0" when there are no errors. The field we were checking against for errors `error`, either no longer exists or might have no value even when `isError` == 1.

```
{
    "blockNumber": "10999432",
    "timeStamp": "1601950354",
    "hash": "0xdfe89ded2490f6917c6aa83fd4b4d9790ac40521c441b419980f94abf9ae14bc",
    "nonce": "32",
    "blockHash": "0x33cb8281386e9c24aeb4ae080259ce129f259c66d9f310394edb967f8e6cbfed",
    "transactionIndex": "128",
    "from": "0xfcabe3451ac8edfb8fb6b9274c2e095d9ccc8082",
    "to": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
    "value": "0",
    "gas": "224637",
    "gasPrice": "77000001459",
    "isError": "0",
    "txreceipt_status": "1",
    "input": "0x18cbafe50000000000000000000000000000000000000000000000004563918244f4000000000000000000000000000000000000000000000000000000a15a75f894067e00000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000fcabe3451ac8edfb8fb6b9274c2e095d9ccc8082000000000000000000000000000000000000000000000000000000005f7bd70a00000000000000000000000000000000000000000000000000000000000000030000000000000000000000001f9840a85d5af5bf1d1762f925bdaddc4201f9840000000000000000000000006b175474e89094c44da98b954eedeac495271d0f000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
    "contractAddress": "",
    "cumulativeGasUsed": "12419473",
    "gasUsed": "186820",
    "confirmations": "14337"
}
```