### PR TITLE
Fix: timestamp not appearing in Activity tab for native crypto transfers

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -102,6 +102,9 @@ class ActivitiesViewController: UIViewController {
         if let value = AlphaWallet.Address(string: transaction.from) {
             cardAttributes["from"] = .address(value)
         }
+        var timestamp: GeneralisedTime = .init()
+        timestamp.date = transaction.date
+        cardAttributes["timestamp"] = .generalisedTime(timestamp)
         let state: Activity.State
         switch transaction.state {
         case .pending:


### PR DESCRIPTION
Part of #2179 

<img width="200" src="https://user-images.githubusercontent.com/56189/95821638-d795c080-0d5c-11eb-9738-9dd27b462236.jpeg">
