### PR TITLE
Fix: default ERC20 send/receive activities always assumed (wrongly) that token decimals = 18

### DIFF
--- a/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
@@ -116,7 +116,7 @@ struct DefaultActivityCellViewModel {
         case .erc20Sent, .erc20Received, .erc20OwnerApproved, .erc20ApprovalObtained, .nativeCryptoSent, .nativeCryptoReceived:
             if let value = cardAttributes["amount"]?.uintValue {
                 let formatter = EtherNumberFormatter.short
-                let value = formatter.string(from: BigInt(value))
+                let value = formatter.string(from: BigInt(value), decimals: activity.tokenObject.decimals)
                 return "\(sign)\(value) \(activity.tokenObject.symbol)"
             } else {
                 return ""


### PR DESCRIPTION
Thus some token value will be shown as 0, eg. USDT which is decimals=6.

Before PR|After PR
-|-
<img width="200" src="https://user-images.githubusercontent.com/56189/95836975-a6c08600-0d72-11eb-9250-6acbef7fa897.png">|<img width="200" src="https://user-images.githubusercontent.com/56189/95836963-a3c59580-0d72-11eb-9dc6-117a41d838dd.png">