### PR TITLE
Refactor transaction gas price limit estimating

### DIFF
--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -152,7 +152,7 @@ class TransactionConfigurator {
     }
 
 // swiftlint:disable function_body_length
-    func load(completion: @escaping (ResultResult<Void, AnyError>.t) -> Void) {
+    func start(completion: @escaping (ResultResult<Void, AnyError>.t) -> Void) {
         switch transaction.transferType {
         case .dapp:
             configuration = TransactionConfiguration(

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -29,20 +29,16 @@ class TransactionConfigurator {
             //xdai transactions are always 1 gwei in gasPrice
             return GasPriceConfiguration.xDaiGasPrice
         case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom:
-            return configureGasPrice()
+            if let gasPrice = transaction.gasPrice, gasPrice > 0 {
+                return gasPrice
+            } else {
+                return configuration.gasPrice
+            }
         }
     }()
 
-    private func configureGasPrice() -> BigInt {
-        if let gasPrice = transaction.gasPrice, gasPrice > 0 {
-            return gasPrice
-        } else {
-            return configuration.gasPrice
-        }
-    }
-
-    private var gasLimitNotSet: Bool {
-        return transaction.gasLimit == .none
+    private var isGasLimitSpecifiedByTransaction: Bool {
+        transaction.gasLimit != nil
     }
 
     let transaction: UnconfirmedTransaction
@@ -69,7 +65,8 @@ class TransactionConfigurator {
             data: transaction.data ?? Data()
         )
     }
-    func estimateGasLimit() {
+
+    private func estimateGasLimit() {
         let to: AlphaWallet.Address? = {
             switch transaction.transferType {
             case .nativeCryptocurrency, .dapp: return transaction.to
@@ -105,26 +102,22 @@ class TransactionConfigurator {
             case .success(let gasLimit):
                 let gasLimit: BigInt = {
                     let limit = BigInt(gasLimit.drop0x, radix: 16) ?? BigInt()
-                    if limit == BigInt(21000) {
+                    if limit == GasLimitConfiguration.minGasLimit {
                         return limit
                     }
                     return min(limit + (limit * 20 / 100), GasLimitConfiguration.maxGasLimit)
                 }()
-                strongSelf.configuration.gasLimit = gasLimit
-            case .failure: break
+                strongSelf.configuration.setEstimated(gasLimit: gasLimit)
+            case .failure:
+                break
             }
         }
     }
 
-    func estimateGasPrice() {
+    private func estimateGasPrice() {
         _ = TransactionConfigurator.estimateGasPrice(server: self.session.server).done { [weak self] gasPrice in
             guard let strongSelf = self else { return }
-            strongSelf.configuration = TransactionConfiguration(
-                    gasPrice: gasPrice,
-                    gasLimit: strongSelf.transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
-                    data: strongSelf.configuration.data,
-                    nonce: strongSelf.configuration.nonce
-            )
+            strongSelf.configuration.setEstimated(gasPrice: gasPrice)
         }
     }
 
@@ -162,10 +155,9 @@ class TransactionConfigurator {
     func load(completion: @escaping (ResultResult<Void, AnyError>.t) -> Void) {
         switch transaction.transferType {
         case .dapp:
-            estimateGasPrice()
             configuration = TransactionConfiguration(
                     gasPrice: calculatedGasPrice,
-                    gasLimit: GasLimitConfiguration.maxGasLimit,
+                    gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
                     data: transaction.data ?? configuration.data,
                     nonce: configuration.nonce
             )
@@ -186,8 +178,8 @@ class TransactionConfigurator {
                 let encoder = ABIEncoder()
                 try encoder.encode(function: function, arguments: parameters)
                 self.configuration = TransactionConfiguration(
-                        gasPrice: self.calculatedGasPrice,
-                        gasLimit: GasLimitConfiguration.maxGasLimit,
+                        gasPrice: calculatedGasPrice,
+                        gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
                         data: encoder.data
                 )
                 completion(.success(()))
@@ -211,8 +203,8 @@ class TransactionConfigurator {
                 let encoder = ABIEncoder()
                 try encoder.encode(function: functionEncoder, arguments: parameters)
                 self.configuration = TransactionConfiguration(
-                        gasPrice: self.calculatedGasPrice,
-                        gasLimit: GasLimitConfiguration.maxGasLimit,
+                        gasPrice: calculatedGasPrice,
+                        gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
                         data: encoder.data
                 )
                 completion(.success(()))
@@ -244,8 +236,8 @@ class TransactionConfigurator {
                 let encoder = ABIEncoder()
                 try encoder.encode(function: functionEncoder, arguments: parameters)
                 self.configuration = TransactionConfiguration(
-                        gasPrice: self.calculatedGasPrice,
-                        gasLimit: GasLimitConfiguration.maxGasLimit,
+                        gasPrice: calculatedGasPrice,
+                        gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
                         data: encoder.data
                 )
                 completion(.success(()))
@@ -266,8 +258,8 @@ class TransactionConfigurator {
                 let encoder = ABIEncoder()
                 try encoder.encode(function: function, arguments: parameters)
                 self.configuration = TransactionConfiguration(
-                        gasPrice: self.calculatedGasPrice,
-                        gasLimit: GasLimitConfiguration.maxGasLimit,
+                        gasPrice: calculatedGasPrice,
+                        gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit,
                         data: encoder.data
                 )
                 completion(.success(()))
@@ -275,10 +267,12 @@ class TransactionConfigurator {
                 completion(.failure(AnyError(Web3Error(description: "malformed tx"))))
             }
         }
-        /* the node can provide reliable gas limit estimates, this prevents running out of gas or defaulting to an
-        inappropriately high gas limit. This can also be an issue for native transfers which are 21k if send to an EOA
-        address but may be higher if sent to a contract address. */
-        estimateGasLimit()
+
+        //Estimation for gas limit must be after configuring `configuration` above to get the correct data
+        estimateGasPrice()
+        if !isGasLimitSpecifiedByTransaction {
+            estimateGasLimit()
+        }
     }
 // swiftlint:enable function_body_length
 

--- a/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
@@ -68,43 +68,38 @@ class TransferNFTCoordinator: Coordinator {
 
     private func transfer() {
         if case .send(let transferType) = paymentFlow {
-            _ = TransactionConfigurator.estimateGasPrice(server: self.session.server).done { [weak self] gasPrice in
+            let transaction = UnconfirmedTransaction(
+                    transferType: transferType,
+                    value: BigInt(0),
+                    to: walletAddress,
+                    data: Data(),
+                    gasLimit: .none,
+                    tokenId: String(tokenHolder.tokens[0].id),
+                    gasPrice: .none,
+                    nonce: .none,
+                    v: .none,
+                    r: .none,
+                    s: .none,
+                    expiry: .none,
+                    indices: tokenHolder.indices,
+                    tokenIds: .none
+            )
+
+            let configurator = TransactionConfigurator(
+                    session: session,
+                    account: account,
+                    transaction: transaction
+            )
+            configurator.load { [weak self] result in
                 guard let strongSelf = self else {
                     return
                 }
-                let transaction = UnconfirmedTransaction(
-                        transferType: transferType,
-                        value: BigInt(0),
-                        to: strongSelf.walletAddress,
-                        data: Data(),
-                        gasLimit: .none,
-                        tokenId: String(strongSelf.tokenHolder.tokens[0].id),
-                        gasPrice: gasPrice,
-                        nonce: .none,
-                        v: .none,
-                        r: .none,
-                        s: .none,
-                        expiry: .none,
-                        indices: strongSelf.tokenHolder.indices,
-                        tokenIds: .none
-                )
-
-                let configurator = TransactionConfigurator(
-                        session: strongSelf.session,
-                        account: strongSelf.account,
-                        transaction: transaction
-                )
-                configurator.load { [weak self] result in
-                    guard let strongSelf = self else {
-                        return
-                    }
-                    switch result {
-                    case .success:
-                        strongSelf.sendTransaction(with: configurator)
-                    case .failure:
-                        //TODO use the error object or remove it from the case-statement
-                        strongSelf.processFailed()
-                    }
+                switch result {
+                case .success:
+                    strongSelf.sendTransaction(with: configurator)
+                case .failure:
+                    //TODO use the error object or remove it from the case-statement
+                    strongSelf.processFailed()
                 }
             }
         }

--- a/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
@@ -90,7 +90,7 @@ class TransferNFTCoordinator: Coordinator {
                     account: account,
                     transaction: transaction
             )
-            configurator.load { [weak self] result in
+            configurator.start { [weak self] result in
                 guard let strongSelf = self else {
                     return
                 }

--- a/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
@@ -4,15 +4,31 @@ import Foundation
 import BigInt
 
 struct TransactionConfiguration {
-    let gasPrice: BigInt
+    var gasPrice: BigInt
     var gasLimit: BigInt
     let data: Data
     let nonce: Int?
+    var hasUserAdjustedGasPrice: Bool
+    var hasUserAdjustedGasLimit: Bool
 
-    init(gasPrice: BigInt, gasLimit: BigInt, data: Data, nonce: Int? = nil) {
+    init(gasPrice: BigInt, gasLimit: BigInt, data: Data, nonce: Int? = nil, hasUserAdjustedGasPrice: Bool = false, hasUserAdjustedGasLimit: Bool = false) {
         self.gasPrice = gasPrice
         self.gasLimit = gasLimit
         self.data = data
         self.nonce = nonce
+        self.hasUserAdjustedGasPrice = hasUserAdjustedGasPrice
+        self.hasUserAdjustedGasLimit = hasUserAdjustedGasLimit
+    }
+
+    mutating func setEstimated(gasPrice estimate: BigInt) {
+        guard !hasUserAdjustedGasPrice else { return }
+        hasUserAdjustedGasPrice = true
+        gasPrice = estimate
+    }
+
+    mutating func setEstimated(gasLimit estimate: BigInt) {
+        guard !hasUserAdjustedGasLimit else { return }
+        hasUserAdjustedGasLimit = true
+        gasLimit = estimate
     }
 }

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -120,7 +120,7 @@ class ConfigureTransactionViewController: FormViewController {
 
         <<< SliderTextFieldRow(Values.gasLimit) {
             $0.title = R.string.localizable.configureTransactionGasLimitLabelTitle()
-            $0.value = Float(configuration.gasLimit.description) ?? 21000
+            $0.value = Float(configuration.gasLimit.description) ?? Float(GasLimitConfiguration.minGasLimit)
             $0.minimumValue = Float(GasLimitConfiguration.minGasLimit)
             $0.maximumValue = Float(GasLimitConfiguration.maxGasLimit)
             $0.steps = UInt((GasLimitConfiguration.maxGasLimit - GasLimitConfiguration.minGasLimit) / 1000)
@@ -194,11 +194,15 @@ class ConfigureTransactionViewController: FormViewController {
 
         let nonce: Int? = Int(nonceString)
 
+        let hasUserAdjustedGasPrice = self.configuration.hasUserAdjustedGasPrice || (self.configuration.gasPrice != gasPrice)
+        let hasUserAdjustedGasLimit = self.configuration.hasUserAdjustedGasLimit || (self.configuration.gasLimit != gasLimit)
         let configuration = TransactionConfiguration(
             gasPrice: gasPrice,
             gasLimit: gasLimit,
             data: data,
-            nonce: nonce
+            nonce: nonce,
+            hasUserAdjustedGasPrice: hasUserAdjustedGasPrice,
+            hasUserAdjustedGasLimit: hasUserAdjustedGasLimit
         )
         delegate?.didEdit(configuration: configuration, in: self)
     }

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -233,7 +233,6 @@ class ConfirmPaymentViewController: UIViewController {
 extension ConfirmPaymentViewController: ConfigureTransactionViewControllerDelegate {
     func didEdit(configuration: TransactionConfiguration, in viewController: ConfigureTransactionViewController) {
         configurator.update(configuration: configuration)
-        reloadView()
         navigationController?.popViewController(animated: true)
     }
 }

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -89,7 +89,7 @@ class ConfirmPaymentViewController: UIViewController {
             footerBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
-        configurator.load { [weak self] result in
+        configurator.start { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
             case .success:

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmPaymentViewController.swift
@@ -32,7 +32,7 @@ class ConfirmPaymentViewController: UIViewController {
     private let scrollView = UIScrollView()
     private let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
     private let viewModel = ConfirmPaymentViewModel()
-    private var configurator: TransactionConfigurator
+    private let configurator: TransactionConfigurator
     private let confirmType: ConfirmType
 
     var didCompleted: ((Result<ConfirmResult, AnyError>) -> Void)?

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -34,7 +34,6 @@ class SendViewController: UIViewController, CanScanQRCode {
     private let account: EthereumAccount
     private let ethPrice: Subscribable<Double>
     private let assetDefinitionStore: AssetDefinitionStore
-    private var gasPrice: BigInt?
     private var data = Data()
     private lazy var decimalFormatter: DecimalFormatter = {
         return DecimalFormatter()
@@ -187,7 +186,6 @@ class SendViewController: UIViewController, CanScanQRCode {
         ] + roundedBackground.createConstraintsWithContainer(view: view))
 
         storage.updatePrices()
-        getGasPrice()
     }
 // swiftlint:enable function_body_length
 
@@ -268,17 +266,6 @@ class SendViewController: UIViewController, CanScanQRCode {
         title = "\(R.string.localizable.send()) \(transferType.symbol)"
     }
 
-    func getGasPrice() {
-        let request = EtherServiceRequest(server: session.server, batch: BatchFactory().create(GasPriceRequest()))
-        Session.send(request) { [weak self] result in
-            switch result {
-            case .success(let balance):
-                self?.gasPrice = BigInt(balance.drop0x, radix: 16)
-            case .failure: break
-            }
-        }
-    }
-
     @objc func send() {
         let input = targetAddressTextField.value.trimmed
         targetAddressTextField.errorState = .none
@@ -308,7 +295,7 @@ class SendViewController: UIViewController, CanScanQRCode {
                 data: data,
                 gasLimit: .none,
                 tokenId: .none,
-                gasPrice: gasPrice,
+                gasPrice: .none,
                 nonce: .none,
                 v: .none,
                 r: .none,

--- a/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
+++ b/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
@@ -8,34 +8,34 @@ class TransactionConfiguratorTests: XCTestCase {
 
     func testDefault() {
         let configurator = TransactionConfigurator(session: .make(), account: .make(), transaction: .make(gasLimit: BigInt(90000), gasPrice: .none))
-        
+
         XCTAssertEqual(GasPriceConfiguration.defaultPrice, configurator.configuration.gasPrice)
     }
-    
+
     func testAdjustGasPrice() {
         let desiderGasPrice = BigInt(1000000000)
         let configurator = TransactionConfigurator(session: .make(), account: .make(), transaction: .make(gasPrice: desiderGasPrice))
-        
+
         XCTAssertEqual(desiderGasPrice, configurator.configuration.gasPrice)
     }
-    
+
     func testMinGasPrice() {
         let configurator = TransactionConfigurator(session: .make(), account: .make(), transaction: .make(gasPrice: BigInt(1)))
-        
+
         XCTAssertEqual(GasPriceConfiguration.minPrice, configurator.configuration.gasPrice)
     }
-    
+
     func testMaxGasPrice() {
         let configurator = TransactionConfigurator(session: .make(), account: .make(), transaction: .make(gasPrice: BigInt(990000000000)))
-        
+
         XCTAssertEqual(GasPriceConfiguration.maxPrice, configurator.configuration.gasPrice)
     }
-    
+
     func testLoadEtherConfiguration() {
         let configurator = TransactionConfigurator(session: .make(), account: .make(), transaction: .make(gasLimit: BigInt(50000), gasPrice: .none))
 
-        configurator.load { _ in }
-        
+        configurator.start { _ in }
+
         XCTAssertEqual(BigInt(GasPriceConfiguration.defaultPrice), configurator.configuration.gasPrice)
         //gas limit is always 21k for native ether transfers
         XCTAssertEqual(BigInt(21000), configurator.configuration.gasLimit)


### PR DESCRIPTION
Closes #2101 

* Estimate gas price and gas limit for all type of transactions
* Estimation of gas price and gas limit for send transactions is now only done in 1 place (not done for TokenScript transactions as well as import ERC875 transactions yet)
* Make sure that when the gas price and limit estimates are retrieved, it is only applied if the user hasn't set their own
* Only provide gas limit estimate if it hasn't already been specified in the transaction (currently only dapp-initiated transactions optionally set this)
