### PR TITLE
Fix: token balance refreshing in wallet tab is way too slow

### DIFF
--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -486,12 +486,7 @@ class TokensDataStore {
             }
         }
         for tokenObject in tokens {
-            //We don't want a whole lot of RPC calls to go out at once. If the user has 100 ERC20 tokens, that's 100 `balanceOf`. iOS doesn't lke it and will return this error:
-            //Error Domain=NSPOSIXErrorDomain Code=28 "No space left on device" UserInfo={_kCFStreamErrorCodeKey=28, _kCFStreamErrorDomainKey=1}
-            let delay = TimeInterval.random(in: 0...20)
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                self.refreshBalance(forToken: tokenObject, completion: incrementCountAndUpdateDelegate)
-            }
+            refreshBalance(forToken: tokenObject, completion: incrementCountAndUpdateDelegate)
         }
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -26,7 +26,6 @@ class TokensViewController: UIViewController {
     private let assetDefinitionStore: AssetDefinitionStore
     private let eventsDataStore: EventsDataStoreProtocol
     private let sections: [Section] = Section.allCases
-    private var timeOfLastFetchBecauseViewAppears: Date?
 
     private var viewModel: TokensViewModel {
         didSet {
@@ -227,7 +226,7 @@ class TokensViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         hidesBottomBarWhenPushed = false
 
-        fetchWithThrottling()
+        fetch()
         fixNavigationBarAndStatusBarBackgroundColorForiOS13Dot1()
         keyboardChecker.viewWillAppear()
     }
@@ -244,7 +243,7 @@ class TokensViewController: UIViewController {
     @objc func pullToRefresh() {
         tableViewRefreshControl.beginRefreshing()
         collectiblesCollectionViewRefreshControl.beginRefreshing()
-        fetchWithThrottling()
+        fetch()
     }
 
     @objc func openConsole() {
@@ -254,23 +253,6 @@ class TokensViewController: UIViewController {
     func fetch() {
         startLoading()
         tokenCollection.fetch()
-    }
-
-    //To reduce chance of this error occurring:
-    //Error Domain=NSPOSIXErrorDomain Code=28 "No space left on device" UserInfo={_kCFStreamErrorCodeKey=28, _kCFStreamErrorDomainKey=1}
-    private func fetchWithThrottling() {
-        let ttl: TimeInterval = 60 * 5
-        if let timeOfLastFetchBecauseViewAppears = timeOfLastFetchBecauseViewAppears {
-            if Date().timeIntervalSince(timeOfLastFetchBecauseViewAppears) < ttl {
-                //no-op
-            } else {
-                fetch()
-                self.timeOfLastFetchBecauseViewAppears = Date()
-            }
-        } else {
-            fetch()
-            timeOfLastFetchBecauseViewAppears = Date()
-        }
     }
 
     override func viewDidLayoutSubviews() {

--- a/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
@@ -16,7 +16,6 @@ class TransactionsViewController: UIViewController {
     private let refreshControl = UIRefreshControl()
     private let dataCoordinator: TransactionDataCoordinator
     private let sessions: ServerDictionary<WalletSession>
-    private var timeOfLastFetchBecauseViewAppears: Date?
 
     var paymentType: PaymentFlow?
     weak var delegate: TransactionsViewControllerDelegate?
@@ -75,12 +74,12 @@ class TransactionsViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        fetchWithThrottling()
+        fetch()
     }
 
     @objc func pullToRefresh() {
         refreshControl.beginRefreshing()
-        fetchWithThrottling()
+        fetch()
     }
 
     func fetch() {
@@ -90,23 +89,6 @@ class TransactionsViewController: UIViewController {
             DispatchQueue.main.async { [weak self] in
                 self?.dataCoordinator.fetch()
             }
-        }
-    }
-
-    //To reduce chance of this error occurring:
-    //Error Domain=NSPOSIXErrorDomain Code=28 "No space left on device" UserInfo={_kCFStreamErrorCodeKey=28, _kCFStreamErrorDomainKey=1}
-    private func fetchWithThrottling() {
-        let ttl: TimeInterval = 60 * 5
-        if let timeOfLastFetchBecauseViewAppears = timeOfLastFetchBecauseViewAppears {
-            if Date().timeIntervalSince(timeOfLastFetchBecauseViewAppears) < ttl {
-                //no-op
-            } else {
-                fetch()
-                self.timeOfLastFetchBecauseViewAppears = Date()
-            }
-        } else {
-            fetch()
-            timeOfLastFetchBecauseViewAppears = Date()
         }
     }
 


### PR DESCRIPTION
Fixes #2205 

This was due to an aggressive fix for TokenScript values appearing as NaN previously. This is no longer needed (at least not as aggressively) since we batch RPC calls now.

Reproduce before PR:

1. Look at balance of a token in Wallet tab
2. Send token to someone
3. Wait for transaction to be confirmed
4. Observe balance of token in Wallet tab

Expected
---
5a. Balance updated after a while

Observed
---
5b. Balance seems to be stuck (it's just way too slow), until app is restarted.
