### PR TITLE
Automatically select all text in textfield in gas configuration screen when the textfield is tapped for better usability

### DIFF
--- a/AlphaWallet/UI/Form/SliderTextFieldRow.swift
+++ b/AlphaWallet/UI/Form/SliderTextFieldRow.swift
@@ -184,6 +184,10 @@ open class SliderTextFieldCell: Cell<Float>, CellType, UITextFieldDelegate {
         textField.layer.borderColor = DataEntry.Color.textFieldShadowWhileEditing.cgColor
 
         textField.dropShadow(color: DataEntry.Color.textFieldShadowWhileEditing, radius: DataEntry.Metric.shadowRadius)
+        //Selecting all the text upon focus is more user-friendly. Without DispatchQueue, select all sometimes doesn't work when tapping between text fields
+        DispatchQueue.main.async {
+            textField.selectedTextRange = textField.textRange(from: textField.beginningOfDocument, to: textField.endOfDocument)
+        }
     }
 
     @objc public func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
This screen, showing text automatically selected when tapped, so user can just type over it

<img width="200" src="https://user-images.githubusercontent.com/56189/96540989-9dcf3780-12d1-11eb-883b-c2f5c6c885a6.png">