### PR TITLE
Refactor: remove most `Wallet?` references for current wallet to get rid of optionals

### DIFF
--- a/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
+++ b/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
@@ -23,7 +23,7 @@ class AccountsCoordinator: Coordinator {
     var coordinators: [Coordinator] = []
 
     lazy var accountsViewController: AccountsViewController = {
-        let controller = AccountsViewController(config: config, keystore: keystore, balanceCoordinator: balanceCoordinator, analyticsCoordinator: analyticsCoordinator)
+        let controller = AccountsViewController(config: config, keystore: keystore, balanceCoordinator: balanceCoordinator)
         controller.navigationItem.leftBarButtonItem = UIBarButtonItem(image: R.image.backWhite(), style: .done, target: self, action: #selector(dismiss))
         controller.navigationItem.rightBarButtonItem = UIBarButtonItem(title: R.string.localizable.addButtonTitle(), style: .plain, target: self, action: #selector(addWallet))
         controller.allowsAccountDeletion = true

--- a/AlphaWallet/Accounts/ViewModels/AccountsViewController.swift
+++ b/AlphaWallet/Accounts/ViewModels/AccountsViewController.swift
@@ -21,19 +21,16 @@ class AccountsViewController: UIViewController {
     private let config: Config
     private let keystore: Keystore
     private let balanceCoordinator: GetNativeCryptoCurrencyBalanceCoordinator
-    private let analyticsCoordinator: AnalyticsCoordinator?
-    lazy private var etherKeystore = try? EtherKeystore(analyticsCoordinator: analyticsCoordinator)
     weak var delegate: AccountsViewControllerDelegate?
     var allowsAccountDeletion: Bool = false
     var hasWallets: Bool {
         return !keystore.wallets.isEmpty
     }
 
-    init(config: Config, keystore: Keystore, balanceCoordinator: GetNativeCryptoCurrencyBalanceCoordinator, analyticsCoordinator: AnalyticsCoordinator?) {
+    init(config: Config, keystore: Keystore, balanceCoordinator: GetNativeCryptoCurrencyBalanceCoordinator) {
         self.config = config
         self.keystore = keystore
         self.balanceCoordinator = balanceCoordinator
-        self.analyticsCoordinator = analyticsCoordinator
         super.init(nibName: nil, bundle: nil)
 
         view.backgroundColor = Colors.appBackground
@@ -143,7 +140,7 @@ class AccountsViewController: UIViewController {
         let account = self.account(for: path)
         let walletName = viewModel.walletName(forAccount: account)
         let balance = self.balances[account.address].flatMap { $0 }
-        let model = AccountViewModel(wallet: account, current: etherKeystore?.recentlyUsedWallet, walletBalance: balance, server: balanceCoordinator.server, walletName: walletName)
+        let model = AccountViewModel(wallet: account, current: keystore.currentWallet, walletBalance: balance, server: balanceCoordinator.server, walletName: walletName)
         return model
     }
 
@@ -197,11 +194,11 @@ extension AccountsViewController: UITableViewDataSource {
         guard allowsAccountDeletion else { return false }
         switch AccountViewTableSectionHeader.HeaderType(rawValue: indexPath.section) {
         case .some(.hdWallet):
-            return etherKeystore?.recentlyUsedWallet != viewModel.hdWallets[indexPath.row]
+            return keystore.currentWallet != viewModel.hdWallets[indexPath.row]
         case .some(.keystoreWallet):
-            return etherKeystore?.recentlyUsedWallet != viewModel.keystoreWallets[indexPath.row]
+            return keystore.currentWallet != viewModel.keystoreWallets[indexPath.row]
         case .some(.watchedWallet):
-            return etherKeystore?.recentlyUsedWallet != viewModel.watchedWallets[indexPath.row]
+            return keystore.currentWallet != viewModel.watchedWallets[indexPath.row]
         case .none:
             return false
         }
@@ -294,7 +291,7 @@ extension AccountsViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let account = self.account(for: indexPath)
-        guard etherKeystore?.recentlyUsedWallet != account else { return }
+        guard keystore.currentWallet != account else { return }
 
         delegate?.didSelectAccount(account: account, in: self)
     }

--- a/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
+++ b/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
@@ -33,6 +33,10 @@ class ActivitiesCoordinator: Coordinator {
         tokensStorages.values.flatMap { $0.enabledObject }
     }
 
+    private var wallet: Wallet {
+        sessions.anyValue.account
+    }
+
     lazy var rootViewController: ActivitiesViewController = {
         makeActivitiesViewController()
     }()
@@ -68,13 +72,13 @@ class ActivitiesCoordinator: Coordinator {
 
     private func makeActivitiesViewController() -> ActivitiesViewController {
         let viewModel = ActivitiesViewModel()
-        let controller = ActivitiesViewController(viewModel: viewModel, sessions: sessions)
+        let controller = ActivitiesViewController(viewModel: viewModel, wallet: wallet.address, sessions: sessions)
         controller.delegate = self
         return controller
     }
 
     func showActivity(_ activity: Activity) {
-        let controller = ActivityViewController(assetDefinitionStore: assetDefinitionStore, viewModel: .init(activity: activity))
+        let controller = ActivityViewController(wallet: wallet, assetDefinitionStore: assetDefinitionStore, viewModel: .init(activity: activity))
         controller.delegate = self
         activityViewController = controller
         if UIDevice.current.userInterfaceIdiom == .pad {
@@ -131,8 +135,7 @@ class ActivitiesCoordinator: Coordinator {
                     case .tokenId:
                         continue
                     case .ownerAddress:
-                        let wallet = sessions.anyValue.account.address
-                        interpolatedFilter = "\(filterName)=\(wallet.eip55String)"
+                        interpolatedFilter = "\(filterName)=\(wallet.address.eip55String)"
                     case .label, .contractAddress, .symbol:
                         //TODO support more?
                         continue

--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -11,14 +11,16 @@ protocol ActivitiesViewControllerDelegate: class {
 
 class ActivitiesViewController: UIViewController {
     private var viewModel: ActivitiesViewModel
+    private let wallet: AlphaWallet.Address
     private let sessions: ServerDictionary<WalletSession>
     private let tableView = UITableView(frame: .zero, style: .grouped)
 
     var paymentType: PaymentFlow?
     weak var delegate: ActivitiesViewControllerDelegate?
 
-    init(viewModel: ActivitiesViewModel, sessions: ServerDictionary<WalletSession>) {
+    init(viewModel: ActivitiesViewModel, wallet: AlphaWallet.Address, sessions: ServerDictionary<WalletSession>) {
         self.viewModel = viewModel
+        self.wallet = wallet
         self.sessions = sessions
         super.init(nibName: nil, bundle: nil)
 
@@ -85,8 +87,7 @@ class ActivitiesViewController: UIViewController {
 
     private func createPseudoActivity(fromTransaction transaction: Transaction) -> Activity {
         let activityName: String
-        //TODO pass in instead
-        if EtherKeystore.current!.address.sameContract(as: transaction.from) {
+        if wallet.sameContract(as: transaction.from) {
             activityName = "sent"
         } else {
             activityName = "received"

--- a/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
@@ -11,6 +11,7 @@ protocol ActivityViewControllerDelegate: class {
 
 class ActivityViewController: UIViewController {
     private let roundedBackground = RoundedBackground()
+    private let wallet: Wallet
     private let assetDefinitionStore: AssetDefinitionStore
     private let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
     private let tokenImageView = TokenImageView()
@@ -21,9 +22,7 @@ class ActivityViewController: UIViewController {
     private let separator = UIView()
     private let bottomFiller = UIView.spacerWidth()
     lazy private var tokenScriptRendererView: TokenInstanceWebView = {
-        //TODO pass in keystore or wallet address instead
-        let walletAddress = EtherKeystore.current!.address
-        let webView = TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
+        let webView = TokenInstanceWebView(server: server, wallet: wallet, assetDefinitionStore: assetDefinitionStore)
         webView.isWebViewInteractionEnabled = true
         webView.delegate = self
         webView.isStandalone = true
@@ -41,7 +40,8 @@ class ActivityViewController: UIViewController {
 
     weak var delegate: ActivityViewControllerDelegate?
 
-    init(assetDefinitionStore: AssetDefinitionStore, viewModel: ActivityViewModel) {
+    init(wallet: Wallet, assetDefinitionStore: AssetDefinitionStore, viewModel: ActivityViewModel) {
+        self.wallet = wallet
         self.assetDefinitionStore = assetDefinitionStore
         self.viewModel = viewModel
 

--- a/AlphaWallet/Activities/Views/ActivityViewCell.swift
+++ b/AlphaWallet/Activities/Views/ActivityViewCell.swift
@@ -6,10 +6,10 @@ import BigInt
 class ActivityViewCell: UITableViewCell {
     private let background = UIView()
     lazy private var tokenScriptRendererView: TokenInstanceWebView = {
-        //TODO pass in keystore or wallet address instead
-        let walletAddress = EtherKeystore.current!.address
+        //TODO pass in keystore or wallet address instead. Have to think about initialization of cells
+        let wallet = EtherKeystore.currentWallet
         //TODO server value doesn't matter since we will change it later. But we should improve this
-        let webView = TokenInstanceWebView(server: .main, walletAddress: walletAddress, assetDefinitionStore: AssetDefinitionStore.instance)
+        let webView = TokenInstanceWebView(server: .main, wallet: wallet, assetDefinitionStore: AssetDefinitionStore.instance)
         //TODO needed? Seems like scary, performance-wise
         //webView.delegate = self
         return webView

--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -115,9 +115,9 @@ class AppCoordinator: NSObject, Coordinator {
         resetToWelcomeScreen()
         setupAssetDefinitionStoreCoordinator()
         migrateToStoringRawPrivateKeysInKeychain()
-        
+
         if keystore.hasWallets {
-            showTransactions(for: keystore.recentlyUsedWallet ?? keystore.wallets.first!)
+            showTransactions(for: keystore.currentWallet)
         } else {
             resetToWelcomeScreen()
         }
@@ -184,9 +184,7 @@ class AppCoordinator: NSObject, Coordinator {
             return
         }
         navigationController.dismiss(animated: true, completion: nil)
-        if let wallet = keystore.recentlyUsedWallet {
-            showTransactions(for: wallet)
-        }
+        showTransactions(for: keystore.currentWallet)
     }
 
     private func initializers() {
@@ -247,6 +245,7 @@ class AppCoordinator: NSObject, Coordinator {
         let prices = inCoordinator.nativeCryptoCurrencyPrices
         let balances = inCoordinator.nativeCryptoCurrencyBalances
         guard let universalLinkCoordinator = UniversalLinkCoordinator(
+                wallet: keystore.currentWallet,
                 config: config,
                 ethPrices: prices,
                 ethBalances: balances,

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -619,7 +619,7 @@ class InCoordinator: NSObject, Coordinator {
         let v = UInt8(signature.substring(from: 128), radix: 16)!
         let r = "0x" + signature.substring(with: Range(uncheckedBounds: (0, 64)))
         let s = "0x" + signature.substring(with: Range(uncheckedBounds: (64, 128)))
-        guard let wallet = keystore.recentlyUsedWallet else { return }
+        let wallet = keystore.currentWallet
         claimOrderCoordinator = ClaimOrderCoordinator()
         claimOrderCoordinator?.claimOrder(
                 signedOrder: signedOrder,
@@ -757,8 +757,7 @@ class InCoordinator: NSObject, Coordinator {
 
 extension InCoordinator: CanOpenURL {
     private func open(url: URL, in viewController: UIViewController) {
-        guard let account = keystore.recentlyUsedWallet else { return }
-
+        let account = keystore.currentWallet
         //TODO duplication of code to set up a BrowserCoordinator when creating the application's tabbar
         let realm = self.realm(forAccount: account)
         let browserCoordinator = createBrowserCoordinator(sessions: walletSessions, realm: realm, browserOnly: true)

--- a/AlphaWallet/KeyManagement/Keystore.swift
+++ b/AlphaWallet/KeyManagement/Keystore.swift
@@ -19,12 +19,14 @@ enum KeystoreExportReason {
 }
 
 protocol Keystore {
-    static var current: Wallet? { get }
+    //TODO remove this if possible, replacing with the instance-side version
+    static var currentWallet: Wallet { get }
 
     var hasWallets: Bool { get }
     var isUserPresenceCheckPossible: Bool { get }
     var wallets: [Wallet] { get }
     var recentlyUsedWallet: Wallet? { get set }
+    var currentWallet: Wallet { get }
 
     @available(iOS 10.0, *)
     func createAccount(completion: @escaping (Result<EthereumAccount, KeystoreError>) -> Void)

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -20,9 +20,7 @@ class TokenInstanceActionViewController: UIViewController, TokenVerifiableStatus
     private let tokensStorage: TokensDataStore
     private let roundedBackground = RoundedBackground()
     lazy private var tokenScriptRendererView: TokenInstanceWebView = {
-        //TODO pass in keystore or wallet address instead
-        let walletAddress = EtherKeystore.current!.address
-        let webView = TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
+        let webView = TokenInstanceWebView(server: server, wallet: keystore.currentWallet, assetDefinitionStore: assetDefinitionStore)
         webView.isWebViewInteractionEnabled = true
         webView.delegate = self
         webView.isStandalone = true

--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -212,7 +212,7 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
     //TODO notify user of received tokens too
     private func notifyUserEtherReceived(inNewTransactions transactions: [Transaction]) {
         guard !transactions.isEmpty else { return }
-        guard let wallet = keystore.recentlyUsedWallet else { return }
+        let wallet = keystore.currentWallet
         var toNotify: [Transaction]
         if let newestCached = storage.objects.first {
             toNotify = transactions.filter { $0.blockNumber > newestCached.blockNumber }

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -309,9 +309,9 @@ class TokensCardCoordinator: NSObject, Coordinator {
             nativeCurrencyDrop: false
         )
         let orders = [order]
-        let address = keystore.recentlyUsedWallet?.address
+        let address = keystore.currentWallet.address
         let etherKeystore = try! EtherKeystore(analyticsCoordinator: analyticsCoordinator)
-        let account = etherKeystore.getAccount(for: address!)
+        let account = etherKeystore.getAccount(for: address)
         let signedOrders = try! OrderHandler(keystore: etherKeystore).signOrders(orders: orders, account: account!, tokenType: tokenHolder.tokenType)
         return UniversalLinkHandler(server: server).createUniversalLink(signedOrder: signedOrders[0], tokenType: tokenHolder.tokenType)
     }
@@ -336,9 +336,9 @@ class TokensCardCoordinator: NSObject, Coordinator {
                 nativeCurrencyDrop: false
         )
         let orders = [order]
-        let address = keystore.recentlyUsedWallet?.address
+        let address = keystore.currentWallet.address
         let etherKeystore = try! EtherKeystore(analyticsCoordinator: analyticsCoordinator)
-        let account = etherKeystore.getAccount(for: address!)
+        let account = etherKeystore.getAccount(for: address)
         let signedOrders = try! OrderHandler(keystore: etherKeystore).signOrders(orders: orders, account: account!, tokenType: tokenHolder.tokenType)
         return UniversalLinkHandler(server: server).createUniversalLink(signedOrder: signedOrders[0], tokenType: tokenHolder.tokenType)
     }

--- a/AlphaWallet/UI/Views/TokenCardRowView.swift
+++ b/AlphaWallet/UI/Views/TokenCardRowView.swift
@@ -57,9 +57,9 @@ class TokenCardRowView: UIView, TokenCardRowViewProtocol {
 	var stateLabel = UILabel()
 	var tokenView: TokenView
 	lazy var tokenScriptRendererView: TokenInstanceWebView = {
-		//TODO pass in keystore or wallet address instead
-		let walletAddress = EtherKeystore.current!.address
-		let webView = TokenInstanceWebView(server: server, walletAddress: walletAddress, assetDefinitionStore: assetDefinitionStore)
+		//TODO pass in keystore or wallet instead
+		let wallet = EtherKeystore.currentWallet
+		let webView = TokenInstanceWebView(server: server, wallet: wallet, assetDefinitionStore: assetDefinitionStore)
 		webView.delegate = self
 		return webView
 	}()

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -167,9 +167,8 @@ extension WalletCoordinator: ScanQRCodeCoordinatorDelegate {
 extension WalletCoordinator: ImportWalletViewControllerDelegate {
 
     func openQRCode(in controller: ImportWalletViewController) {
-        guard let wallet = keystore.recentlyUsedWallet, navigationController.ensureHasDeviceAuthorization() else { return }
-
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: wallet, server: config.server)
+        guard navigationController.ensureHasDeviceAuthorization() else { return }
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.currentWallet, server: config.server)
         coordinator.delegate = self
 
         addCoordinator(coordinator)

--- a/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/InCoordinatorTests.swift
@@ -53,11 +53,11 @@ class InCoordinatorTests: XCTestCase {
 
         coordinator.showTabBar(for: account1)
 
-        XCTAssertEqual(coordinator.keystore.recentlyUsedWallet, account1)
+        XCTAssertEqual(coordinator.keystore.currentWallet, account1)
 
         coordinator.showTabBar(for: account2)
 
-        XCTAssertEqual(coordinator.keystore.recentlyUsedWallet, account2)
+        XCTAssertEqual(coordinator.keystore.currentWallet, account2)
     }
 
     func testShowSendFlow() {

--- a/AlphaWalletTests/EtherClient/EtherKeystoreTests.swift
+++ b/AlphaWalletTests/EtherClient/EtherKeystoreTests.swift
@@ -117,6 +117,7 @@ class EtherKeystoreTests: XCTestCase {
         keystore.recentlyUsedWallet = account
 
         XCTAssertEqual(account, keystore.recentlyUsedWallet)
+        XCTAssertEqual(account, keystore.currentWallet)
 
         keystore.recentlyUsedWallet = nil
 

--- a/AlphaWalletTests/Factories/FakeKeystore.swift
+++ b/AlphaWalletTests/Factories/FakeKeystore.swift
@@ -8,7 +8,9 @@ import Result
 
 struct FakeKeystore: Keystore {
 
-    static var current: Wallet?
+    static var currentWallet: Wallet {
+        Wallet(type: .watch(.makeStormBird()))
+    }
 
     enum AssumeAllWalletsType {
         case hdWallet
@@ -25,6 +27,17 @@ struct FakeKeystore: Keystore {
     }
     var wallets: [Wallet]
     var recentlyUsedWallet: Wallet?
+
+    var currentWallet: Wallet {
+        //Better crash now instead of populating callers with optionals
+        if let wallet = recentlyUsedWallet {
+            return wallet
+        } else if wallets.count == 1 {
+            return wallets.first!
+        } else {
+            fatalError("No wallet")
+        }
+    }
 
     init(wallets: [Wallet] = [], recentlyUsedWallet: Wallet? = .none, assumeAllWalletsType: AssumeAllWalletsType = .hdWallet) {
         self.wallets = wallets


### PR DESCRIPTION
No functional change.

If the current wallet is nil, something is very wrong and we should crash early rather than populate call sites with guard/`if let` which does nothing meaningful when the current wallet is nil.

Part of effort to reduce meaningless optionals in the code base.