### PR TITLE
Show pending erc20 transactions as such rather than as 0 eth sends

### DIFF
--- a/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
@@ -20,7 +20,12 @@ struct ActivitiesViewModel {
         }
         let tuple = newItems.map { each in
             (date: each.key, items: (each.value as! [ActivityOrTransaction]).sorted {
-                if $0.blockNumber > $1.blockNumber {
+                //Show pending transactions at the top
+                if $0.blockNumber == 0 && $1.blockNumber != 0 {
+                    return true
+                } else if $0.blockNumber != 0 && $1.blockNumber == 0 {
+                    return false
+                } else if $0.blockNumber > $1.blockNumber {
                     return true
                 } else if $0.blockNumber < $1.blockNumber {
                     return false

--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -108,7 +108,7 @@ class TransactionDataCoordinator: Coordinator {
         let session = sessions[transaction.original.server]
 
         let tokensDataStore = tokensStorages[transaction.original.server]
-        let transaction = SentTransaction.from(from: session.account.address, transaction: transaction, tokensDataStore: tokensDataStore)
+        let transaction = Transaction.from(from: session.account.address, transaction: transaction, tokensDataStore: tokensDataStore)
         transactionCollection.add([transaction])
         handleUpdateItems(reloadImmediately: true)
     }

--- a/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TransactionDataCoordinator.swift
@@ -8,7 +8,7 @@ enum TransactionError: Error {
 }
 
 protocol TransactionDataCoordinatorDelegate: class {
-    func didUpdate(result: ResultResult<[Transaction], TransactionError>.t)
+    func didUpdate(result: ResultResult<[Transaction], TransactionError>.t, reloadImmediately: Bool)
 }
 
 class TransactionDataCoordinator: Coordinator {
@@ -75,7 +75,7 @@ class TransactionDataCoordinator: Coordinator {
         //Since start() is called at launch, and user don't see the Transactions tab immediately, we don't want it to block launching
         DispatchQueue.global().async {
             DispatchQueue.main.async { [weak self] in
-                self?.handleUpdateItems()
+                self?.handleUpdateItems(reloadImmediately: false)
             }
         }
     }
@@ -106,9 +106,11 @@ class TransactionDataCoordinator: Coordinator {
 
     func addSentTransaction(_ transaction: SentTransaction) {
         let session = sessions[transaction.original.server]
-        let transaction = SentTransaction.from(from: session.account.address, transaction: transaction)
+
+        let tokensDataStore = tokensStorages[transaction.original.server]
+        let transaction = SentTransaction.from(from: session.account.address, transaction: transaction, tokensDataStore: tokensDataStore)
         transactionCollection.add([transaction])
-        handleUpdateItems()
+        handleUpdateItems(reloadImmediately: true)
     }
 
     func stop() {
@@ -121,14 +123,14 @@ class TransactionDataCoordinator: Coordinator {
         return singleChainTransactionDataCoordinators.first { $0.isServer(server) }
     }
 
-    private func handleUpdateItems() {
-        delegate?.didUpdate(result: .success(transactionCollection.objects))
-        delegate2?.didUpdate(result: .success(transactionCollection.objects))
+    private func handleUpdateItems(reloadImmediately: Bool) {
+        delegate?.didUpdate(result: .success(transactionCollection.objects), reloadImmediately: reloadImmediately)
+        delegate2?.didUpdate(result: .success(transactionCollection.objects), reloadImmediately: reloadImmediately)
     }
 }
 
 extension TransactionDataCoordinator: SingleChainTransactionDataCoordinatorDelegate {
     func handleUpdateItems(inCoordinator: SingleChainTransactionDataCoordinator) {
-        handleUpdateItems()
+        handleUpdateItems(reloadImmediately: false)
     }
 }

--- a/AlphaWallet/Transactions/Storage/Transaction.swift
+++ b/AlphaWallet/Transactions/Storage/Transaction.swift
@@ -1,6 +1,7 @@
 // Copyright SIX DAY LLC. All rights reserved.
 
 import Foundation
+import BigInt
 import RealmSwift
 
 class Transaction: Object {
@@ -80,5 +81,46 @@ extension Transaction {
 
     var server: RPCServer {
         return .init(chainID: chainId)
+    }
+}
+
+extension Transaction {
+    static func from(from: AlphaWallet.Address, transaction: SentTransaction, tokensDataStore: TokensDataStore) -> Transaction {
+        let (operations: operations, isErc20Interaction: isErc20Interaction)  = decodeOperations(fromData: transaction.original.data, from: transaction.original.account.address, contractOrRecipient: transaction.original.to, tokensDataStore: tokensDataStore)
+        return Transaction(
+                id: transaction.id,
+                server: transaction.original.server,
+                blockNumber: 0,
+                transactionIndex: 0,
+                from: from.eip55String,
+                to: transaction.original.to?.eip55String ?? "",
+                value: transaction.original.value.description,
+                gas: transaction.original.gasLimit.description,
+                gasPrice: transaction.original.gasPrice.description,
+                gasUsed: "",
+                nonce: String(transaction.original.nonce),
+                date: Date(),
+                localizedOperations: operations,
+                state: .pending,
+                isErc20Interaction: isErc20Interaction
+        )
+    }
+
+    //TODO add support for more types of pending transactions. Probably can be supported via TokenScript in the future
+    //TODO add support for more types of pending transactions. Use a more general decoder at some point
+    fileprivate static func decodeOperations(fromData data: Data, from: AlphaWallet.Address, contractOrRecipient: AlphaWallet.Address?, tokensDataStore: TokensDataStore) -> (operations: [LocalizedOperationObject], isErc20Interaction: Bool) {
+        //transfer(address,uint256)
+        let erc20Transfer = (
+                interfaceHash: "a9059cbb",
+                byteCount: 68
+        )
+        if data[0..<4].hex() == erc20Transfer.interfaceHash && data.count == erc20Transfer.byteCount, let contract = contractOrRecipient, let value = BigUInt(data[(4 + 32)..<(4 + 32 + 32)].hex(), radix: 16), let token = tokensDataStore.token(forContract: contract) {
+            //Compiler thinks it's a `Slice<Data>` if don't explicitly state the type, so we have to split into 2 `if`s
+            let recipientData: Data = data[4..<(4 + 32)][4 + 12..<(4 + 32)]
+            if let recipient = AlphaWallet.Address(string: recipientData.hexEncoded) {
+                return (operations: [LocalizedOperationObject(from: from.eip55String, to: recipient.eip55String, contract: contract, type: "erc20TokenTransfer", value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
+            }
+        }
+        return (operations: .init(), isErc20Interaction: false)
     }
 }

--- a/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
+++ b/AlphaWallet/Transactions/ViewControllers/TransactionsViewController.swift
@@ -130,7 +130,7 @@ extension TransactionsViewController: UITableViewDelegate {
 }
 
 extension TransactionsViewController: TransactionDataCoordinatorDelegate {
-    func didUpdate(result: Result<[Transaction], TransactionError>) {
+    func didUpdate(result: Result<[Transaction], TransactionError>, reloadImmediately: Bool) {
         switch result {
         case .success(let items):
         let viewModel = TransactionsViewModel(transactions: items)

--- a/AlphaWallet/Transfer/Types/SentTransaction.swift
+++ b/AlphaWallet/Transfer/Types/SentTransaction.swift
@@ -1,50 +1,8 @@
 // Copyright SIX DAY LLC. All rights reserved.
 
 import Foundation
-import BigInt
 
 struct SentTransaction {
     let id: String
     let original: UnsignedTransaction
-}
-
-extension SentTransaction {
-    static func from(from: AlphaWallet.Address, transaction: SentTransaction, tokensDataStore: TokensDataStore) -> Transaction {
-        let (operations: operations, isErc20Interaction: isErc20Interaction)  = decodeOperations(fromData: transaction.original.data, from: transaction.original.account.address, contractOrRecipient: transaction.original.to, tokensDataStore: tokensDataStore)
-        return Transaction(
-            id: transaction.id,
-            server: transaction.original.server,
-            blockNumber: 0,
-            transactionIndex: 0,
-            from: from.eip55String,
-            to: transaction.original.to?.eip55String ?? "",
-            value: transaction.original.value.description,
-            gas: transaction.original.gasLimit.description,
-            gasPrice: transaction.original.gasPrice.description,
-            gasUsed: "",
-            nonce: String(transaction.original.nonce),
-            date: Date(),
-            localizedOperations: operations,
-            state: .pending,
-            isErc20Interaction: isErc20Interaction
-        )
-    }
-
-    //TODO add support for more types of pending transactions. Probably can be supported via TokenScript in the future
-    //TODO add support for more types of pending transactions. Use a more general decoder at some point
-    private static func decodeOperations(fromData data: Data, from: AlphaWallet.Address, contractOrRecipient: AlphaWallet.Address?, tokensDataStore: TokensDataStore) -> (operations: [LocalizedOperationObject], isErc20Interaction: Bool) {
-        //transfer(address,uint256)
-        let erc20Transfer = (
-                interfaceHash: "a9059cbb",
-                byteCount: 68
-        )
-        if data[0..<4].hex() == erc20Transfer.interfaceHash && data.count == erc20Transfer.byteCount, let contract = contractOrRecipient, let value = BigUInt(data[(4 + 32)..<(4 + 32 + 32)].hex(), radix: 16), let token = tokensDataStore.token(forContract: contract) {
-            //Compiler thinks it's a `Slice<Data>` if don't explicitly state the type, so we have to split into 2 `if`s
-            let recipientData: Data = data[4..<(4 + 32)][4 + 12..<(4 + 32)]
-            if let recipient = AlphaWallet.Address(string: recipientData.hexEncoded) {
-                return (operations: [LocalizedOperationObject(from: from.eip55String, to: recipient.eip55String, contract: contract, type: "erc20TokenTransfer", value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
-            }
-        }
-        return (operations: .init(), isErc20Interaction: false)
-    }
 }

--- a/AlphaWallet/Transfer/Types/SentTransaction.swift
+++ b/AlphaWallet/Transfer/Types/SentTransaction.swift
@@ -1,6 +1,7 @@
 // Copyright SIX DAY LLC. All rights reserved.
 
 import Foundation
+import BigInt
 
 struct SentTransaction {
     let id: String
@@ -8,7 +9,8 @@ struct SentTransaction {
 }
 
 extension SentTransaction {
-    static func from(from: AlphaWallet.Address, transaction: SentTransaction) -> Transaction {
+    static func from(from: AlphaWallet.Address, transaction: SentTransaction, tokensDataStore: TokensDataStore) -> Transaction {
+        let (operations: operations, isErc20Interaction: isErc20Interaction)  = decodeOperations(fromData: transaction.original.data, from: transaction.original.account.address, contractOrRecipient: transaction.original.to, tokensDataStore: tokensDataStore)
         return Transaction(
             id: transaction.id,
             server: transaction.original.server,
@@ -22,10 +24,27 @@ extension SentTransaction {
             gasUsed: "",
             nonce: String(transaction.original.nonce),
             date: Date(),
-            //TODO we should know what type of transaction (transfer) here and create accordingly if it's ERC20, ERC721, ERC875
-            localizedOperations: [],
+            localizedOperations: operations,
             state: .pending,
-            isErc20Interaction: false
+            isErc20Interaction: isErc20Interaction
         )
+    }
+
+    //TODO add support for more types of pending transactions. Probably can be supported via TokenScript in the future
+    //TODO add support for more types of pending transactions. Use a more general decoder at some point
+    private static func decodeOperations(fromData data: Data, from: AlphaWallet.Address, contractOrRecipient: AlphaWallet.Address?, tokensDataStore: TokensDataStore) -> (operations: [LocalizedOperationObject], isErc20Interaction: Bool) {
+        //transfer(address,uint256)
+        let erc20Transfer = (
+                interfaceHash: "a9059cbb",
+                byteCount: 68
+        )
+        if data[0..<4].hex() == erc20Transfer.interfaceHash && data.count == erc20Transfer.byteCount, let contract = contractOrRecipient, let value = BigUInt(data[(4 + 32)..<(4 + 32 + 32)].hex(), radix: 16), let token = tokensDataStore.token(forContract: contract) {
+            //Compiler thinks it's a `Slice<Data>` if don't explicitly state the type, so we have to split into 2 `if`s
+            let recipientData: Data = data[4..<(4 + 32)][4 + 12..<(4 + 32)]
+            if let recipient = AlphaWallet.Address(string: recipientData.hexEncoded) {
+                return (operations: [LocalizedOperationObject(from: from.eip55String, to: recipient.eip55String, contract: contract, type: "erc20TokenTransfer", value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
+            }
+        }
+        return (operations: .init(), isErc20Interaction: false)
     }
 }


### PR DESCRIPTION
The UI isn't the best (still using the old-style transaction cell), but at least the information displayed is much more useful and correct than before the PR.

<img width="200" src="https://user-images.githubusercontent.com/56189/97078478-152d0000-161f-11eb-8f16-aa02c8da88c0.png">