### PR TITLE
Tap to open Etherscan now opens token page if Ethereum mainnet which provides a richer page than if opened as a contract

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -772,7 +772,7 @@ extension InCoordinator: CanOpenURL {
             let url = server.etherscanContractDetailsWebPageURL(for: wallet.address)
             open(url: url, in: viewController)
         } else {
-            let url = server.etherscanContractDetailsWebPageURL(for: contract)
+            let url = server.etherscanTokenDetailsWebPageURL(for: contract)
             open(url: url, in: viewController)
         }
     }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -94,6 +94,7 @@ public struct Constants {
     public static let artisTau1NetworkCoreAPIErc20Events = "https://explorer.tau1.artis.network/api?module=account&action=tokentx&address="
 
     //etherscan-compatible contract details web page
+    public static let mainnetEtherscanTokenDetailsWebPageURL = "https://cn.etherscan.com/token/"
     public static let mainnetEtherscanContractDetailsWebPageURL = "https://cn.etherscan.com/address/"
     public static let kovanEtherscanContractDetailsWebPageURL = "https://kovan.etherscan.io/address/"
     public static let rinkebyEtherscanContractDetailsWebPageURL = "https://rinkeby.etherscan.io/address/"

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -134,6 +134,16 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    //We assume that only Etherscan supports this and only for Ethereum mainnet: The token page instead of contract page
+    var etherscanTokenDetailsWebPageURL: String {
+        switch self {
+        case .main:
+            return Constants.mainnetEtherscanTokenDetailsWebPageURL
+        case .ropsten, .rinkeby, .kovan, .xDai, .goerli, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom:
+            return etherscanContractDetailsWebPageURL
+        }
+    }
+
     func etherscanAPIURLForTransactionList(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
          getEtherscanURL.flatMap {
              var url = "\($0)\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)"
@@ -156,6 +166,10 @@ enum RPCServer: Hashable, CaseIterable {
 
     func etherscanContractDetailsWebPageURL(for address: AlphaWallet.Address) -> URL {
         return URL(string: etherscanContractDetailsWebPageURL + address.eip55String)!
+    }
+
+    func etherscanTokenDetailsWebPageURL(for address: AlphaWallet.Address) -> URL {
+        return URL(string: etherscanTokenDetailsWebPageURL + address.eip55String)!
     }
 
     var priceID: AlphaWallet.Address {


### PR DESCRIPTION
Before PR|After PR
-|-
<img width="200" src="https://user-images.githubusercontent.com/56189/97260813-86a3c300-1858-11eb-9685-e4e85f58e62c.png">|<img width="200" src="https://user-images.githubusercontent.com/56189/97260827-8acfe080-1858-11eb-8366-68380aac4b9e.png">
