### PR TITLE
Make pending ERC20/721 sends in Activity tab be displayed using the new Activity cells rather than old-style transactions

### DIFF
--- a/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
+++ b/AlphaWallet/Activities/Coordinators/ActivitiesCoordinator.swift
@@ -72,7 +72,7 @@ class ActivitiesCoordinator: Coordinator {
 
     private func makeActivitiesViewController() -> ActivitiesViewController {
         let viewModel = ActivitiesViewModel()
-        let controller = ActivitiesViewController(viewModel: viewModel, wallet: wallet.address, sessions: sessions)
+        let controller = ActivitiesViewController(viewModel: viewModel, wallet: wallet.address, sessions: sessions, tokensStorages: tokensStorages)
         controller.delegate = self
         return controller
     }


### PR DESCRIPTION
Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/97527675-dadcad80-19e6-11eb-89c0-7ed87fe8d608.png'>| <img width='200' src='https://user-images.githubusercontent.com/56189/97527681-df08cb00-19e6-11eb-9d17-425304dff0db.png'>
