### PR TITLE
Wallet address is truncated in iPhone 5s in the Change/add wallet cell in Settings tab #2259

### DIFF
--- a/AlphaWallet/Accounts/Views/AccountViewCell.swift
+++ b/AlphaWallet/Accounts/Views/AccountViewCell.swift
@@ -32,7 +32,7 @@ class AccountViewCell: UITableViewCell {
         contentView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            stackView.anchorsConstraint(to: contentView, edgeInsets: .init(top: 20, left: 20, bottom: 20, right: 20)),
+            stackView.anchorsConstraint(to: contentView, edgeInsets: .init(top: 20, left: 20, bottom: 20, right: 0)),
         ])
     }
 


### PR DESCRIPTION
Closes #2259