### PR TITLE
Make text font/weight in Activity tab cells be different to indicate different states

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
@@ -94,7 +94,7 @@ class ActivityViewController: UIViewController {
         NSLayoutConstraint.activate([
             //Setting height for labels to get their heights to be correct. If we want to remove them, make sure to test with both the native Activity view and TokenScript (HTML) Activity views
             timestampLabel.heightAnchor.constraint(equalToConstant: 20),
-            titleLabel.heightAnchor.constraint(equalToConstant: 20),
+            titleLabel.heightAnchor.constraint(equalToConstant: 26),
             subTitleLabel.heightAnchor.constraint(equalToConstant: 20),
 
             tokenImageView.heightAnchor.constraint(equalToConstant: 60),
@@ -138,7 +138,7 @@ class ActivityViewController: UIViewController {
 
         titleLabel.textColor = viewModel.titleTextColor
         titleLabel.font = viewModel.titleFont
-        titleLabel.text = viewModel.title
+        titleLabel.attributedText = viewModel.title
 
         subTitleLabel.text = viewModel.subTitle
         subTitleLabel.textColor = viewModel.subTitleTextColor

--- a/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
@@ -30,7 +30,15 @@ struct DefaultActivityCellViewModel {
         let symbol = activity.tokenObject.symbol
         switch activity.nativeViewType {
         case .erc20Sent, .erc721Sent, .nativeCryptoSent:
-            let string = NSMutableAttributedString(string: "\(R.string.localizable.transactionCellSentTitle()) \(symbol)")
+            let string: NSMutableAttributedString
+            switch activity.state {
+            case .pending:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activitySendPending(symbol))")
+            case .completed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.transactionCellSentTitle()) \(symbol)")
+            case .failed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activitySendFailed(symbol))")
+            }
             string.addAttribute(.font, value: Fonts.regular(size: 17)!, range: NSRange(location: 0, length: string.length))
             string.addAttribute(.font, value: Fonts.semibold(size: 17)!, range: NSRange(location: string.length - symbol.count, length: symbol.count))
             return string
@@ -40,7 +48,15 @@ struct DefaultActivityCellViewModel {
             string.addAttribute(.font, value: Fonts.semibold(size: 17)!, range: NSRange(location: string.length - symbol.count, length: symbol.count))
             return string
         case .erc20OwnerApproved, .erc721OwnerApproved:
-            let string = NSMutableAttributedString(string: R.string.localizable.activityOwnerApproved(symbol))
+            let string: NSMutableAttributedString
+            switch activity.state {
+            case .pending:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activityOwnerApprovedPending(symbol))")
+            case .completed:
+                string = NSMutableAttributedString(string: R.string.localizable.activityOwnerApproved(symbol))
+            case .failed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activityOwnerApprovedFailed(symbol))")
+            }
             string.addAttribute(.font, value: Fonts.regular(size: 17)!, range: NSRange(location: 0, length: string.length))
             string.addAttribute(.font, value: Fonts.semibold(size: 17)!, range: NSRange(location: string.length - symbol.count, length: symbol.count))
             return string
@@ -93,11 +109,7 @@ struct DefaultActivityCellViewModel {
         Fonts.regular(size: 12)!
     }
 
-    var amountFont: UIFont {
-        Fonts.semibold(size: 17)!
-    }
-
-    var amount: String {
+    var amount: NSAttributedString {
         let sign: String
         switch activity.nativeViewType {
         case .erc20Sent, .nativeCryptoSent:
@@ -112,28 +124,34 @@ struct DefaultActivityCellViewModel {
             sign = ""
         }
 
+        let string: String
         switch activity.nativeViewType {
         case .erc20Sent, .erc20Received, .erc20OwnerApproved, .erc20ApprovalObtained, .nativeCryptoSent, .nativeCryptoReceived:
             if let value = cardAttributes["amount"]?.uintValue {
                 let formatter = EtherNumberFormatter.short
                 let value = formatter.string(from: BigInt(value), decimals: activity.tokenObject.decimals)
-                return "\(sign)\(value) \(activity.tokenObject.symbol)"
+                string = "\(sign)\(value) \(activity.tokenObject.symbol)"
             } else {
-                return ""
+                string = ""
             }
         case .erc721Sent, .erc721Received, .erc721OwnerApproved, .erc721ApprovalObtained:
             if let value = cardAttributes["tokenId"]?.uintValue {
-                return "\(value)"
+                string = "\(value)"
             } else {
-                return ""
+                string = ""
             }
         case .none:
-            return ""
+            string = ""
         }
-    }
 
-    var amountColor: UIColor {
-        R.color.black()!
+        switch activity.state {
+        case .pending:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17)!, .foregroundColor: R.color.black()!])
+        case .completed:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17)!, .foregroundColor: R.color.black()!])
+        case .failed:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17)!, .foregroundColor: R.color.silver()!, .strikethroughStyle: NSUnderlineStyle.single.rawValue])
+        }
     }
 
     var timestampFont: UIFont {

--- a/AlphaWallet/Activities/ViewModels/DefaultActivityViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/DefaultActivityViewModel.swift
@@ -22,11 +22,7 @@ struct DefaultActivityViewModel {
         Colors.appBackground
     }
 
-    var amountFont: UIFont {
-        Fonts.regular(size: 28)!
-    }
-
-    var amount: String {
+    var amount: NSAttributedString {
         let sign: String
         switch activity.nativeViewType {
         case .erc20Sent, .nativeCryptoSent:
@@ -39,27 +35,33 @@ struct DefaultActivityViewModel {
             sign = ""
         }
 
+        let string: String
         switch activity.nativeViewType {
         case .erc20Sent, .erc20Received, .erc20OwnerApproved, .erc20ApprovalObtained, .nativeCryptoSent, .nativeCryptoReceived:
             if let value = cardAttributes["amount"]?.uintValue {
                 let formatter = EtherNumberFormatter.short
                 let value = formatter.string(from: BigInt(value))
-                return "\(sign)\(value) \(activity.tokenObject.symbol)"
+                string = "\(sign)\(value) \(activity.tokenObject.symbol)"
             } else {
-                return ""
+                string = ""
             }
         case .erc721Sent, .erc721Received, .erc721OwnerApproved, .erc721ApprovalObtained:
             if let value = cardAttributes["tokenId"]?.uintValue {
-                return "\(value)"
+                string = "\(value)"
             } else {
-                return ""
+                string = ""
             }
         case .none:
-            return ""
+            string = ""
         }
-    }
 
-    var amountColor: UIColor {
-        R.color.black()!
+        switch activity.state {
+        case .pending:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28)!, .foregroundColor: R.color.black()!])
+        case .completed:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28)!, .foregroundColor: R.color.black()!])
+        case .failed:
+            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28)!, .foregroundColor: R.color.silver()!, .strikethroughStyle: NSUnderlineStyle.single.rawValue])
+        }
     }
 }

--- a/AlphaWallet/Activities/Views/DefaultActivityItemViewCell.swift
+++ b/AlphaWallet/Activities/Views/DefaultActivityItemViewCell.swift
@@ -95,9 +95,7 @@ class DefaultActivityItemViewCell: UITableViewCell {
         timestampLabel.font = viewModel.timestampFont
         timestampLabel.text = viewModel.timestamp
 
-        amountLabel.text = viewModel.amount
-        amountLabel.font = viewModel.amountFont
-        amountLabel.textColor = viewModel.amountColor
+        amountLabel.attributedText = viewModel.amount
 
         tokenImageView.subscribable = viewModel.iconImage
         stateImageView.image = viewModel.stateImage

--- a/AlphaWallet/Activities/Views/DefaultActivityView.swift
+++ b/AlphaWallet/Activities/Views/DefaultActivityView.swift
@@ -34,10 +34,7 @@ class DefaultActivityView: UIView {
 
         backgroundColor = viewModel.backgroundColor
 
-        amountLabel.text = viewModel.amount
-        amountLabel.font = viewModel.amountFont
-        amountLabel.textColor = viewModel.amountColor
-
+        amountLabel.attributedText = viewModel.amount
         amountLabel.textAlignment = .center
     }
 }

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -476,4 +476,8 @@
 "activity.to" = "to %@";
 "activity.approvalObtained" = "Gave approval to move %@";
 "activity.ownerApproved" = "Approved to move %@";
+"activity.ownerApproved.pending" = "Approving to move %@";
+"activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.send.pending" = "Sending %@";
+"activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -476,4 +476,8 @@
 "activity.to" = "to %@";
 "activity.approvalObtained" = "Gave approval to move %@";
 "activity.ownerApproved" = "Approved to move %@";
+"activity.ownerApproved.pending" = "Approving to move %@";
+"activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.send.pending" = "Sending %@";
+"activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -476,4 +476,8 @@
 "activity.to" = "to %@";
 "activity.approvalObtained" = "Gave approval to move %@";
 "activity.ownerApproved" = "Approved to move %@";
+"activity.ownerApproved.pending" = "Approving to move %@";
+"activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.send.pending" = "Sending %@";
+"activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -476,4 +476,8 @@
 "activity.to" = "to %@";
 "activity.approvalObtained" = "Gave approval to move %@";
 "activity.ownerApproved" = "Approved to move %@";
+"activity.ownerApproved.pending" = "Approving to move %@";
+"activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.send.pending" = "Sending %@";
+"activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -476,4 +476,8 @@
 "activity.to" = "to %@";
 "activity.approvalObtained" = "Gave approval to move %@";
 "activity.ownerApproved" = "Approved to move %@";
+"activity.ownerApproved.pending" = "Approving to move %@";
+"activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.send.pending" = "Sending %@";
+"activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Transactions/ViewModels/ActivityViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/ActivityViewModel.swift
@@ -26,20 +26,38 @@ struct ActivityViewModel {
         Fonts.regular(size: 20)!
     }
 
-    var title: String {
+    var title: NSAttributedString {
         let symbol = activity.tokenObject.symbol
         switch activity.nativeViewType {
         case .erc20Sent, .erc721Sent, .nativeCryptoSent:
-            return "\(R.string.localizable.transactionCellSentTitle()) \(symbol)"
+            let string: NSMutableAttributedString
+            switch activity.state {
+            case .pending:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activitySendPending(symbol))")
+            case .completed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.transactionCellSentTitle()) \(symbol)")
+            case .failed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activitySendFailed(symbol))")
+            }
+            return string
         case .erc20Received, .erc721Received, .nativeCryptoReceived:
-            return "\(R.string.localizable.transactionCellReceivedTitle()) \(symbol)"
+            return NSAttributedString(string: "\(R.string.localizable.transactionCellReceivedTitle()) \(symbol)")
         case .erc20OwnerApproved, .erc721OwnerApproved:
-            return R.string.localizable.activityOwnerApproved(symbol)
+            let string: NSMutableAttributedString
+            switch activity.state {
+            case .pending:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activityOwnerApprovedPending(symbol))")
+            case .completed:
+                string = NSMutableAttributedString(string: R.string.localizable.activityOwnerApproved(symbol))
+            case .failed:
+                string = NSMutableAttributedString(string: "\(R.string.localizable.activityOwnerApprovedFailed(symbol))")
+            }
+            return string
         case .erc20ApprovalObtained, .erc721ApprovalObtained:
-            return R.string.localizable.activityApprovalObtained(symbol)
+            return NSAttributedString(string: R.string.localizable.activityApprovalObtained(symbol))
         case .none:
             //Displaying the symbol is intentional
-            return symbol
+            return NSAttributedString(string: symbol)
         }
     }
 


### PR DESCRIPTION
Closes #2255 

Before PR: failed state | After PR: failed state
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/99039425-4c5d5400-25c2-11eb-875f-cef5534d1fb5.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/99039436-4ff0db00-25c2-11eb-8ae1-501766cd1bb8.png'>

Also after PR for pending state:

<img width='200' src='https://user-images.githubusercontent.com/56189/99039442-51ba9e80-25c2-11eb-9bbc-0f2bc229b2b0.png'>

