### PR TITLE
In Activity tab, show "All <symbol>" instead of an very long string of numbers that garbles the display for ERC20 approvals for very large amounts

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "activity.ownerApproved" = "Approved to move %@";
 "activity.ownerApproved.pending" = "Approving to move %@";
 "activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.approve.amount.all" = "All %@";
 "activity.send.pending" = "Sending %@";
 "activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "activity.ownerApproved" = "Approved to move %@";
 "activity.ownerApproved.pending" = "Approving to move %@";
 "activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.approve.amount.all" = "All %@";
 "activity.send.pending" = "Sending %@";
 "activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "activity.ownerApproved" = "Approved to move %@";
 "activity.ownerApproved.pending" = "Approving to move %@";
 "activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.approve.amount.all" = "All %@";
 "activity.send.pending" = "Sending %@";
 "activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "activity.ownerApproved" = "Approved to move %@";
 "activity.ownerApproved.pending" = "Approving to move %@";
 "activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.approve.amount.all" = "All %@";
 "activity.send.pending" = "Sending %@";
 "activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "activity.ownerApproved" = "Approved to move %@";
 "activity.ownerApproved.pending" = "Approving to move %@";
 "activity.ownerApproved.failed" = "Failed to Approve to move %@";
+"activity.approve.amount.all" = "All %@";
 "activity.send.pending" = "Sending %@";
 "activity.send.failed" = "Failed to Send %@";
 "activity.goToToken" = "Go to Token";


### PR DESCRIPTION
Doesn't look like there's a standard number being used for incredibly large amounts, so this PR just picks an arbitrarily large number.

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/99211682-d6e0c600-2803-11eb-9232-94685b11d0a6.png'>| <img width='200' src='https://user-images.githubusercontent.com/56189/99211690-dba57a00-2803-11eb-9e05-2929779866dc.png'>
