### PR TITLE
Open URL in AlphaWallet using share extension doesn't convert % escapes #2289

### DIFF
--- a/AlphaWallet/Share/ShareContentAction.swift
+++ b/AlphaWallet/Share/ShareContentAction.swift
@@ -61,7 +61,7 @@ enum ShareContentAction {
         switch self {
         case .url(let url):
             components.queryItems = [
-                .init(name: "q", value: url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
+                .init(name: "q", value: url.absoluteString)
             ]
         case .string(let text):
             components.queryItems = [


### PR DESCRIPTION
Fixes #2289

Before PR:
![photo_2020-11-18_10-43-43](https://user-images.githubusercontent.com/55975226/99506620-feae6600-298a-11eb-8505-d67bec633075.jpg)

After PR:
![photo_2020-11-18_10-41-35](https://user-images.githubusercontent.com/55975226/99506388-b1ca8f80-298a-11eb-8ba2-db832167ecab.jpg)

