### PR TITLE
Raise gas fee max to 3 ETH

### DIFF
--- a/AlphaWallet/Transfer/Types/ConfigureTransaction.swift
+++ b/AlphaWallet/Transfer/Types/ConfigureTransaction.swift
@@ -4,5 +4,5 @@ import Foundation
 
 struct ConfigureTransaction {
     static var gasLimitMax: Int = 6370515
-    static var gasFeeMax: Int64 = 2_000_000_000_000_000_000 / 10
+    static var gasFeeMax: Int64 = 3_000_000_000_000_000_000
 }


### PR DESCRIPTION
Closes #2099.

Still a limit because it's quite scary if we remove it completely.