### PR TITLE
Fix: if enter "" for eth when sending ETH, should show "0 ETH" instead of " ETH"

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -150,11 +150,12 @@ extension TransactionConfirmationViewModel {
             switch transferType {
             case .nativeCryptocurrency(let token, _, _):
                 let cryptoToDollarSymbol = Constants.Currency.usd
-                if let cryptoToDollarRate = cryptoToDollarRate, let amount = Double(amount) {
-                    let cryptoToDollarValue = StringFormatter().currency(with: amount * cryptoToDollarRate, and: cryptoToDollarSymbol)
-                    return "\(amount) \(token.symbol) ≈ \(cryptoToDollarValue) \(cryptoToDollarSymbol)"
+                let double = Double(amount) ?? 0
+                if let cryptoToDollarRate = cryptoToDollarRate {
+                    let cryptoToDollarValue = StringFormatter().currency(with: double * cryptoToDollarRate, and: cryptoToDollarSymbol)
+                    return "\(double) \(token.symbol) ≈ \(cryptoToDollarValue) \(cryptoToDollarSymbol)"
                 } else {
-                    return "\(amount) \(token.symbol)"
+                    return "\(double) \(token.symbol)"
                 }
             case .ERC20Token(let token, _, _):
                 return "\(amount) \(token.symbol)"


### PR DESCRIPTION
Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/99874078-c4a9c200-2c1f-11eb-92c1-4e69e7d2219a.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/99874080-c7a4b280-2c1f-11eb-85e9-d8e7fc482d18.png'>