### PR TITLE
    Fix: Gas fee estimate in fiat should be displayed when editing custom gas for transaction on mainnet

### DIFF
--- a/AlphaWallet/Transfer/Types/CurrencyRate+Fee.swift
+++ b/AlphaWallet/Transfer/Types/CurrencyRate+Fee.swift
@@ -8,7 +8,8 @@ extension CurrencyRate {
         guard let feeInDouble = Double(fee) else {
             return nil
         }
-        guard let price = rates.filter({ $0.code == symbol }).first else {
+        let symbol = symbol.lowercased()
+        guard let price = rates.filter({ $0.code.lowercased() == symbol }).first else {
             return nil
         }
         let formattedFee = NumberFormatter.currency.string(from: price.price * feeInDouble)


### PR DESCRIPTION
Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/99876924-34767780-2c35-11eb-8488-de1f89aaa1d8.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/99876926-36d8d180-2c35-11eb-8631-f68d6b21cd07.png'>
