### PR TITLE
Provide rapid/fast/slow (in addition to average and custom) options in actionsheet for transaction confirmation

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		5E7C7648BFF9AE93CD97A1BE /* ConsoleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CF1465A1DCB44371BA9 /* ConsoleViewController.swift */; };
 		5E7C76696EF7F27EC0788CDD /* GenerateTransferMagicLinkViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7EEAAE9C23B68419E9F5 /* GenerateTransferMagicLinkViewControllerViewModel.swift */; };
 		5E7C7669BBE6255A2377E070 /* SetSellTokensCardExpiryDateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7962AE417E12F13FF58E /* SetSellTokensCardExpiryDateViewController.swift */; };
+		5E7C766B96C59C7893CF2CB4 /* EditedTransactionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F1F965C69B80A234F1F /* EditedTransactionConfiguration.swift */; };
 		5E7C76738DDAAD623C6FB4DC /* PromptBackupWalletAfterExceedingThresholdViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C77685B78D5372F6C7CB0 /* PromptBackupWalletAfterExceedingThresholdViewViewModel.swift */; };
 		5E7C767595F664FF33157ADF /* FunctionOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C72FABB78B9E1655A06A2 /* FunctionOrigin.swift */; };
 		5E7C767848E46E079557A039 /* SeedPhraseCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C717B39E95B653F384AA0 /* SeedPhraseCellViewModel.swift */; };
@@ -460,6 +461,7 @@
 		5E7C79E9A6A3DFB7FA680752 /* DappViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C793CDFA907BFDFECB6CB /* DappViewCell.swift */; };
 		5E7C79EB8A6EC89F6F033268 /* CreateInitialWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74A5B5B9D8AD0BD913C1 /* CreateInitialWalletViewController.swift */; };
 		5E7C79F32F7054020B2F835A /* ServerDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C77A1F1399FD7EE2812E8 /* ServerDictionary.swift */; };
+		5E7C79F491F80EDF6E6B9234 /* GasNowGasPriceEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C783A83452EF6921095C2 /* GasNowGasPriceEstimator.swift */; };
 		5E7C7A0B5FDADC60DC01F060 /* CallSmartContractFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C77C2844B3579A59C3F2F /* CallSmartContractFunction.swift */; };
 		5E7C7A13AB42B38C061D46C6 /* MnemonicLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C700AC0A7FFE95EC960FA /* MnemonicLengthRule.swift */; };
 		5E7C7A2DBFF7FB3B8B5DEB1B /* EventInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74822F5F71748184F6C1 /* EventInstance.swift */; };
@@ -495,6 +497,7 @@
 		5E7C7B4778FF36371701242E /* BrowserHistoryViewControllerHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79FA3E6A05845ECFCDCF /* BrowserHistoryViewControllerHeaderView.swift */; };
 		5E7C7B4C7DECBF4834B1E6A4 /* CreateInitialWalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73BA4FF25754ACB41255 /* CreateInitialWalletViewModel.swift */; };
 		5E7C7B4E3DEA90147A5A9E0A /* TokensDataStoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C71E355BD14E975AF7491 /* TokensDataStoreTest.swift */; };
+		5E7C7B7FDCF8EFC3083A147E /* GasNowPriceEstimates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78E0F20F882DD2136E29 /* GasNowPriceEstimates.swift */; };
 		5E7C7B8242E31B4DA0263BE5 /* EthTypedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7FC30FF22C3EA71451BC /* EthTypedData.swift */; };
 		5E7C7B89694C62A14CBE8105 /* FakeEventsDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C71A8BE594C1D126AB309 /* FakeEventsDataStore.swift */; };
 		5E7C7BAF922C3EB4D1B22C46 /* VerifySeedPhraseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C788ADDEA0609433B1FDF /* VerifySeedPhraseViewController.swift */; };
@@ -508,6 +511,7 @@
 		5E7C7C0D3181CD31A581AEBE /* EditMyDappViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F55495A6095B3E86248 /* EditMyDappViewController.swift */; };
 		5E7C7C0FAC500A6651E663FD /* TransferTokensCardQuantitySelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C703BA1D0E9ACB7399155 /* TransferTokensCardQuantitySelectionViewModel.swift */; };
 		5E7C7C0FBEF6206024FB355E /* ButtonsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C774238AE6861A7935EEE /* ButtonsBar.swift */; };
+		5E7C7C16DFF078FE84AB4903 /* TransactionConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78162DA41FF1AEF858E7 /* TransactionConfigurations.swift */; };
 		5E7C7C21E5CAF122AA4F6617 /* HowDoIGetMyMoneyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78B001F9F95F404D5FEF /* HowDoIGetMyMoneyInfoViewController.swift */; };
 		5E7C7C3C16408F4782523D8D /* AssetAttributeSyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7037994332AE52798488 /* AssetAttributeSyntax.swift */; };
 		5E7C7C5C350376B83D23154F /* MixpanelCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C758EB5C7B77A0EE6BC9E /* MixpanelCoordinator.swift */; };
@@ -515,6 +519,7 @@
 		5E7C7C91C5FF48F51134A7DA /* SegmentedControlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C799AF966DBF0D59DFB20 /* SegmentedControlViewModel.swift */; };
 		5E7C7C98EAF40E8110241DBD /* NonFungibleTokenViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */; };
 		5E7C7C9E89056069C8FEFA76 /* AlphaWalletSettingsSwitchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7534FB6BF4D199643246 /* AlphaWalletSettingsSwitchRow.swift */; };
+		5E7C7CA66F3086000BA3E72C /* GasEstimates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B19FDDF5D0535243682 /* GasEstimates.swift */; };
 		5E7C7CA7562FD8352967EFBD /* PromptBackupWalletAfterReceivingEtherViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F6C71DDC98D7DF754B2 /* PromptBackupWalletAfterReceivingEtherViewViewModel.swift */; };
 		5E7C7CCA2D436A940E874D47 /* VerifySeedPhraseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C739774984CDE1D3D7555 /* VerifySeedPhraseViewModel.swift */; };
 		5E7C7CCA357CB7BF12E1F2B4 /* UIStackView+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73ED9226646D562B5A3C /* UIStackView+Array.swift */; };
@@ -1213,9 +1218,11 @@
 		5E7C77EEE333F036B2C3DBD4 /* AssetAttributeSyntaxValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetAttributeSyntaxValue.swift; sourceTree = "<group>"; };
 		5E7C7809B67CC2D8D6AA31C4 /* KeystoreBackupIntroductionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeystoreBackupIntroductionViewModel.swift; sourceTree = "<group>"; };
 		5E7C7812E27A6638E036BBB1 /* EventSourceCoordinatorForActivities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSourceCoordinatorForActivities.swift; sourceTree = "<group>"; };
+		5E7C78162DA41FF1AEF858E7 /* TransactionConfigurations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionConfigurations.swift; sourceTree = "<group>"; };
 		5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportMagicTokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7828BD821B6F04B71C00 /* SendHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendHeaderView.swift; sourceTree = "<group>"; };
 		5E7C78302634885C93D9B6FA /* TokenIdOrEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenIdOrEvent.swift; sourceTree = "<group>"; };
+		5E7C783A83452EF6921095C2 /* GasNowGasPriceEstimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GasNowGasPriceEstimator.swift; sourceTree = "<group>"; };
 		5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonFungibleTokenViewCell.swift; sourceTree = "<group>"; };
 		5E7C78402B975F69A72E8C04 /* TokensViewControllerTableViewHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensViewControllerTableViewHeader.swift; sourceTree = "<group>"; };
 		5E7C78421F01D14741DDF5BF /* ConfirmSignMessageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageViewController.swift; sourceTree = "<group>"; };
@@ -1235,6 +1242,7 @@
 		5E7C78C073F380B48D5BE94C /* LayoutConstraintsWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutConstraintsWrapper.swift; sourceTree = "<group>"; };
 		5E7C78CDFEB86A8356EA5818 /* TokenCardRowViewProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenCardRowViewProtocol.swift; path = Views/TokenCardRowViewProtocol.swift; sourceTree = "<group>"; };
 		5E7C78CF45AA54EF8647C44B /* SeedPhraseBackupIntroductionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedPhraseBackupIntroductionViewController.swift; sourceTree = "<group>"; };
+		5E7C78E0F20F882DD2136E29 /* GasNowPriceEstimates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GasNowPriceEstimates.swift; sourceTree = "<group>"; };
 		5E7C78E5C8FAEA752B32626D /* UIActivityViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityViewController.swift; sourceTree = "<group>"; };
 		5E7C78EFAF641C41F06C46BF /* ServersCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServersCoordinatorTests.swift; sourceTree = "<group>"; };
 		5E7C78FAB9070B10A476DB29 /* AssetImplicitAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetImplicitAttributes.swift; sourceTree = "<group>"; };
@@ -1288,6 +1296,7 @@
 		5E7C7B06D3FBE83BBC00555F /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		5E7C7B080E387A79058430B9 /* ConfirmSignMessageTableViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7B089FD4C96810DD10FD /* HelpContentsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelpContentsViewController.swift; sourceTree = "<group>"; };
+		5E7C7B19FDDF5D0535243682 /* GasEstimates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GasEstimates.swift; sourceTree = "<group>"; };
 		5E7C7B1FB2702A2A8A4EBD76 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7B211FF0FE5BE98BB7D0 /* aETH.tsml */ = {isa = PBXFileReference; lastKnownFileType = file.tsml; path = aETH.tsml; sourceTree = "<group>"; };
 		5E7C7B29A9E728402D144C05 /* AppLocale.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLocale.swift; sourceTree = "<group>"; };
@@ -1389,6 +1398,7 @@
 		5E7C7EEAAE9C23B68419E9F5 /* GenerateTransferMagicLinkViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateTransferMagicLinkViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C7F1B07B1403E6382B21F /* PromptBackupWalletAfterIntervalViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromptBackupWalletAfterIntervalViewViewModel.swift; sourceTree = "<group>"; };
 		5E7C7F1B66DB15E6167416F8 /* SearchEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngine.swift; sourceTree = "<group>"; };
+		5E7C7F1F965C69B80A234F1F /* EditedTransactionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditedTransactionConfiguration.swift; sourceTree = "<group>"; };
 		5E7C7F21FA7A02F6341FB58D /* AssetDefinitionsOverridesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionsOverridesViewController.swift; sourceTree = "<group>"; };
 		5E7C7F3DD81D44A996789FC4 /* UniversalLinkInPasteboardCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalLinkInPasteboardCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7F54FD247553A7427881 /* TokensViewControllerCollectiblesCollectionViewHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensViewControllerCollectiblesCollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -1727,6 +1737,7 @@
 				5E7C7429614BD6865E3C63C5 /* KeyManagement */,
 				5E7C7493B40E287B7FDF9317 /* Analytics */,
 				5E7C7EF382294C8C3357E9EC /* Activities */,
+				5E7C72373620D0B5825AA69C /* Gas */,
 			);
 			path = AlphaWallet;
 			sourceTree = "<group>";
@@ -2476,6 +2487,7 @@
 				87E2555124F52E5700F025F7 /* SliderTableViewCellViewModel.swift */,
 				87E2555524F52EAA00F025F7 /* GasSpeedTableViewHeaderViewModel.swift */,
 				87E2555724F52EBF00F025F7 /* GasSpeedTableViewCellViewModel.swift */,
+				5E7C7F1F965C69B80A234F1F /* EditedTransactionConfiguration.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -2496,6 +2508,7 @@
 				5E7C778A54D7D3E196BC5542 /* DAppRequster.swift */,
 				76F1DE9EF8E265016BF02659 /* GasLimitConfiguration.swift */,
 				8750F91624EE5AE100E19DFF /* RecipientResolver.swift */,
+				5E7C78162DA41FF1AEF858E7 /* TransactionConfigurations.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -2965,6 +2978,14 @@
 			path = Browser;
 			sourceTree = "<group>";
 		};
+		5E7C72373620D0B5825AA69C /* Gas */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C7912EB06F369ED15F733 /* Models */,
+			);
+			path = Gas;
+			sourceTree = "<group>";
+		};
 		5E7C7254740FFAE67AE9ECE6 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3189,6 +3210,16 @@
 				5E7C76AB57FE8E8E084CF4A8 /* Coordinators */,
 			);
 			path = Tokens;
+			sourceTree = "<group>";
+		};
+		5E7C7912EB06F369ED15F733 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C783A83452EF6921095C2 /* GasNowGasPriceEstimator.swift */,
+				5E7C78E0F20F882DD2136E29 /* GasNowPriceEstimates.swift */,
+				5E7C7B19FDDF5D0535243682 /* GasEstimates.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		5E7C79B61997F5903F0C6D70 /* Coordinators */ = {
@@ -4933,6 +4964,11 @@
 				5E7C78F7C4848D484AD4183A /* DefaultActivityView.swift in Sources */,
 				5E7C710F30F8EAC43A706500 /* DefaultActivityViewModel.swift in Sources */,
 				5E7C7270EA33CF6A99701454 /* GetWalletNameCoordinator.swift in Sources */,
+				5E7C79F491F80EDF6E6B9234 /* GasNowGasPriceEstimator.swift in Sources */,
+				5E7C7B7FDCF8EFC3083A147E /* GasNowPriceEstimates.swift in Sources */,
+				5E7C7C16DFF078FE84AB4903 /* TransactionConfigurations.swift in Sources */,
+				5E7C7CA66F3086000BA3E72C /* GasEstimates.swift in Sources */,
+				5E7C766B96C59C7893CF2CB4 /* EditedTransactionConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -10,6 +10,7 @@ enum AlphaWalletService {
     case register(config: Config, device: PushDevice)
     case unregister(config: Config, device: PushDevice)
     case marketplace(config: Config, server: RPCServer)
+    case gasPriceEstimate
 
     enum SortOrder: String {
         case asc
@@ -28,6 +29,8 @@ extension AlphaWalletService: TargetType {
             return config.priceInfoEndpoints
         case .marketplace(let config, _):
             return config.priceInfoEndpoints
+        case .gasPriceEstimate:
+            return URL(string: Constants.gasNowEndpointBaseUrl)!
         }
     }
 
@@ -43,11 +46,13 @@ extension AlphaWalletService: TargetType {
         case .unregister:
             return "/push/unregister"
         case .priceOfEth:
-            return "/api/v3/coins/markets" 
+            return "/api/v3/coins/markets"
         case .priceOfDai:
             return "/api/v3/coins/markets"
         case .marketplace:
             return "/marketplace"
+        case .gasPriceEstimate:
+            return "/api/v3/gas/price"
         }
     }
 
@@ -59,6 +64,7 @@ extension AlphaWalletService: TargetType {
         case .priceOfEth: return .get
         case .priceOfDai: return .get
         case .marketplace: return .get
+        case .gasPriceEstimate: return .get
         }
     }
 
@@ -92,16 +98,18 @@ extension AlphaWalletService: TargetType {
             return .requestJSONEncodable(device)
         case .priceOfEth:
             return .requestParameters(parameters: [
-                "vs_currency": "USD", 
+                "vs_currency": "USD",
                 "ids": "ethereum",
             ], encoding: URLEncoding())
         case .priceOfDai:
             return .requestParameters(parameters: [
-                "vs_currency": "USD", 
+                "vs_currency": "USD",
                 "ids": "dai",
             ], encoding: URLEncoding())
         case .marketplace(_, let server):
             return .requestParameters(parameters: ["chainID": server.chainID], encoding: URLEncoding())
+        case .gasPriceEstimate:
+            return .requestPlain
         }
     }
 
@@ -120,7 +128,7 @@ extension AlphaWalletService: TargetType {
                     "client-build": Bundle.main.buildNumber ?? "",
                 ]
             }
-        case .priceOfEth, .priceOfDai, .register, .unregister, .marketplace:
+        case .priceOfEth, .priceOfDai, .register, .unregister, .marketplace, .gasPriceEstimate:
             return [
                 "Content-type": "application/json",
                 "client": Bundle.main.bundleIdentifier ?? "",

--- a/AlphaWallet/Gas/Models/GasEstimates.swift
+++ b/AlphaWallet/Gas/Models/GasEstimates.swift
@@ -1,0 +1,40 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+import BigInt
+
+struct GasEstimates {
+    private var others: [TransactionConfigurationType: BigInt]
+
+    var standard: BigInt
+
+    subscript(configurationType: TransactionConfigurationType) -> BigInt? {
+        get {
+            switch configurationType {
+            case .standard:
+                return standard
+            case .fast, .rapid, .slow:
+                return others[configurationType]
+            case .custom:
+                return nil
+            }
+        }
+        set(config) {
+            switch configurationType {
+            case .standard:
+                //Better crash here than elsewhere or worse: hiding it
+                standard = config!
+            case .fast, .rapid, .slow:
+                others[configurationType] = config
+            case .custom:
+                //Should not reach here
+                break
+            }
+        }
+    }
+
+    init(standard: BigInt, others: [TransactionConfigurationType: BigInt] = .init()) {
+        self.others = others
+        self.standard = standard
+    }
+}

--- a/AlphaWallet/Gas/Models/GasNowGasPriceEstimator.swift
+++ b/AlphaWallet/Gas/Models/GasNowGasPriceEstimator.swift
@@ -1,0 +1,25 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+import PromiseKit
+
+class GasNowGasPriceEstimator {
+    func fetch() -> Promise<GasNowPriceEstimates> {
+        Promise { seal in
+            let alphaWalletProvider = AlphaWalletProviderFactory.makeProvider()
+            alphaWalletProvider.request(.gasPriceEstimate) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let estimates = try response.map(GasNowPriceEstimates.self)
+                        seal.fulfill(estimates)
+                    } catch {
+                        seal.reject(error)
+                    }
+                case .failure(let error):
+                    seal.reject(error)
+                }
+            }
+        }
+    }
+}

--- a/AlphaWallet/Gas/Models/GasNowPriceEstimates.swift
+++ b/AlphaWallet/Gas/Models/GasNowPriceEstimates.swift
@@ -1,0 +1,40 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+
+struct GasNowPriceEstimates: Decodable {
+    struct Data: Decodable {
+        let slow: Int
+        let standard: Int
+        let fast: Int
+        let rapid: Int
+
+        enum CodingKeys: String, CodingKey {
+            case slow
+            case fast
+            case standard
+            case rapid
+        }
+    }
+
+    let data: Data
+    let code: Int
+
+    var slow: Int {
+        data.slow
+    }
+    var fast: Int {
+        data.fast
+    }
+    var standard: Int {
+        data.standard
+    }
+    var rapid: Int {
+        data.rapid
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case code
+    }
+}

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -492,7 +492,12 @@
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";
-"transactionConfiguration.Type.custom" = "Custom"; 
+"transactionConfiguration.Type.rapid" = "Rapid";
+"transactionConfiguration.Type.custom" = "Custom (set your own)";
+"transactionConfiguration.Type.slow.time" = "> 10 minutes";
+"transactionConfiguration.Type.average.time" = "< 5 minutes";
+"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";
 "transactionConfirmation.Send.Section.Gas.title" = "Gas";

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -508,3 +508,4 @@
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
+"transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -492,7 +492,12 @@
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";
-"transactionConfiguration.Type.custom" = "Custom";
+"transactionConfiguration.Type.rapid" = "Rapid";
+"transactionConfiguration.Type.custom" = "Custom (set your own)";
+"transactionConfiguration.Type.slow.time" = "> 10 minutes";
+"transactionConfiguration.Type.average.time" = "< 5 minutes";
+"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";
 "transactionConfirmation.Send.Section.Gas.title" = "Gas";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -508,3 +508,4 @@
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
+"transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -492,7 +492,12 @@
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";
-"transactionConfiguration.Type.custom" = "Custom";
+"transactionConfiguration.Type.rapid" = "Rapid";
+"transactionConfiguration.Type.custom" = "Custom (set your own)";
+"transactionConfiguration.Type.slow.time" = "> 10 minutes";
+"transactionConfiguration.Type.average.time" = "< 5 minutes";
+"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";
 "transactionConfirmation.Send.Section.Gas.title" = "Gas";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -508,3 +508,4 @@
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
+"transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -492,7 +492,12 @@
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";
-"transactionConfiguration.Type.custom" = "Custom";
+"transactionConfiguration.Type.rapid" = "Rapid";
+"transactionConfiguration.Type.custom" = "Custom (set your own)";
+"transactionConfiguration.Type.slow.time" = "> 10 minutes";
+"transactionConfiguration.Type.average.time" = "< 5 minutes";
+"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";
 "transactionConfirmation.Send.Section.Gas.title" = "Gas";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -508,3 +508,4 @@
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
+"transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -492,7 +492,12 @@
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";
-"transactionConfiguration.Type.custom" = "Custom";
+"transactionConfiguration.Type.rapid" = "Rapid";
+"transactionConfiguration.Type.custom" = "Custom (set your own)";
+"transactionConfiguration.Type.slow.time" = "> 10 minutes";
+"transactionConfiguration.Type.average.time" = "< 5 minutes";
+"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";
 "transactionConfirmation.Send.Section.Gas.title" = "Gas";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -508,3 +508,4 @@
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
+"transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -124,6 +124,8 @@ public struct Constants {
     static let ENSRegistrarRinkeby = ENSRegistrarAddress
     static let ENSRegistrarGoerli = ENSRegistrarAddress
 
+    static let gasNowEndpointBaseUrl = "https://www.gasnow.org"
+
     //Misc
     public static let etherReceivedNotificationIdentifier = "etherReceivedNotificationIdentifier"
     static let legacy875Addresses = [AlphaWallet.Address(string: "0x830e1650a87a754e37ca7ed76b700395a7c61614")!,

--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -16,7 +16,6 @@ enum TransactionConfirmationConfiguration {
     case sendFungiblesTransaction(confirmType: ConfirmType, keystore: Keystore, assetDefinitionStore: AssetDefinitionStore, amount: String, ethPrice: Subscribable<Double>)
     case sendNftTransaction(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>, tokenInstanceName: String?)
     case claimPaidErc875MagicLink(confirmType: ConfirmType, keystore: Keystore, price: BigUInt, ethPrice: Subscribable<Double>, numberOfTokens: UInt)
-
     var confirmType: ConfirmType {
         switch self {
         case .dappTransaction(let confirmType, _, _), .sendFungiblesTransaction(let confirmType, _, _, _, _), .sendNftTransaction(let confirmType, _, _, _), .tokenScriptTransaction(let confirmType, _, _, _), .claimPaidErc875MagicLink(let confirmType, _, _, _, _):

--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -29,6 +29,13 @@ enum TransactionConfirmationConfiguration {
             return keystore
         }
     }
+
+    var ethPrice: Subscribable<Double> {
+        switch self {
+        case .dappTransaction(_, _, let ethPrice), .sendFungiblesTransaction(_, _, _, _, let ethPrice), .sendNftTransaction(_, _, let ethPrice, _), .tokenScriptTransaction(_, _, _, let ethPrice), .claimPaidErc875MagicLink(_, _, _, let ethPrice, _):
+            return ethPrice
+        }
+    }
 }
 
 enum TransactionConfirmationResult {
@@ -167,7 +174,7 @@ extension TransactionConfirmationCoordinator: TransactionConfirmationViewControl
     }
 
     private func showConfigureTransactionViewController(_ configurator: TransactionConfigurator, session: WalletSession) {
-        let controller = ConfigureTransactionViewController(viewModel: .init(server: session.server, configurator: configurator, currencyRate: session.balanceCoordinator.currencyRate))
+        let controller = ConfigureTransactionViewController(viewModel: .init(server: session.server, configurator: configurator, ethPrice: configuration.ethPrice, currencyRate: session.balanceCoordinator.currencyRate))
         controller.delegate = self
         navigationController.pushViewController(controller, animated: true)
         configureTransactionViewController = controller
@@ -175,8 +182,8 @@ extension TransactionConfirmationCoordinator: TransactionConfirmationViewControl
 }
 
 extension TransactionConfirmationCoordinator: ConfigureTransactionViewControllerDelegate {
-    func didSavedToUseDefaultConfiguration(in viewController: ConfigureTransactionViewController) {
-        configurator.chooseDefaultConfiguration()
+    func didSavedToUseDefaultConfigurationType(_ configurationType: TransactionConfigurationType, in viewController: ConfigureTransactionViewController) {
+        configurator.chooseDefaultConfigurationType(configurationType)
         navigationController.popViewController(animated: true)
     }
 
@@ -196,6 +203,6 @@ extension TransactionConfirmationCoordinator: TransactionConfiguratorDelegate {
     }
 
     func gasPriceEstimateUpdated(to estimate: BigInt, in configurator: TransactionConfigurator) {
-        configureTransactionViewController?.configure(withEstimatedGasPrice: estimate)
+        configureTransactionViewController?.configure(withEstimatedGasPrice: estimate, configurator: configurator)
     }
 }

--- a/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/TransactionConfiguration.swift
@@ -40,15 +40,39 @@ struct TransactionConfiguration {
 }
 
 enum TransactionConfigurationType: Int, CaseIterable {
-    case `default`
+    case slow
+    case standard
+    case fast
+    case rapid
     case custom
 
     var title: String {
         switch self {
-        case .default:
-            return R.string.localizable.tokenTransactionConfirmationDefault()
+        case .standard:
+            return R.string.localizable.transactionConfigurationTypeAverage()
+        case .slow:
+            return R.string.localizable.transactionConfigurationTypeSlow()
+        case .fast:
+            return R.string.localizable.transactionConfigurationTypeFast()
+        case .rapid:
+            return R.string.localizable.transactionConfigurationTypeRapid()
         case .custom:
             return R.string.localizable.transactionConfigurationTypeCustom()
+        }
+    }
+
+    var estimatedProcessingTime: String {
+        switch self {
+        case .standard:
+            return R.string.localizable.transactionConfigurationTypeAverageTime()
+        case .slow:
+            return R.string.localizable.transactionConfigurationTypeSlowTime()
+        case .fast:
+            return R.string.localizable.transactionConfigurationTypeFastTime()
+        case .rapid:
+            return R.string.localizable.transactionConfigurationTypeRapidTime()
+        case .custom:
+            return ""
         }
     }
 }

--- a/AlphaWallet/Transfer/Types/TransactionConfigurations.swift
+++ b/AlphaWallet/Transfer/Types/TransactionConfigurations.swift
@@ -1,0 +1,45 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+
+struct TransactionConfigurations {
+    private var others: [TransactionConfigurationType: TransactionConfiguration]
+
+    var standard: TransactionConfiguration
+    var custom: TransactionConfiguration
+
+    var types: [TransactionConfigurationType] {
+        others.keys + [.standard, .custom]
+    }
+
+    subscript(configurationType: TransactionConfigurationType) -> TransactionConfiguration? {
+        get {
+            switch configurationType {
+            case .standard:
+                return standard
+            case .custom:
+                return custom
+            case .fast, .rapid, .slow:
+                return others[configurationType]
+            }
+        }
+        set(config) {
+            switch configurationType {
+            case .standard:
+                //Better crash here than elsewhere or worse: hiding it
+                standard = config!
+            case .custom:
+                //Better crash here than elsewhere or worse: hiding it
+                custom = config!
+            case .fast, .rapid, .slow:
+                others[configurationType] = config
+            }
+        }
+    }
+
+    init(standard: TransactionConfiguration) {
+        self.others = .init()
+        self.standard = standard
+        self.custom = standard
+    }
+}

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -27,10 +27,9 @@ class ConfigureTransactionViewController: UIViewController {
         let tableView = UITableView()
         tableView.register(GasSpeedTableViewCell.self)
         tableView.registerHeaderFooterView(GasSpeedTableViewHeaderView.self)
-        tableView.tableFooterView = UIView.tableFooterToRemoveEmptyCellSeparators()
+        tableView.tableFooterView = createTableInformationFooter()
         tableView.separatorStyle = .none
         tableView.allowsSelection = true
-
         return tableView
     }()
 
@@ -140,6 +139,22 @@ class ConfigureTransactionViewController: UIViewController {
         }, completion: { _ in
 
         })
+    }
+
+    private func createTableInformationFooter() -> UIView {
+        let footer = UIView(frame: .init(x: 0, y: 0, width: 0, height: 100))
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = Fonts.regular(size: 12)
+        label.textColor = R.color.dove()
+        label.text = R.string.localizable.transactionConfirmationFeeFooterText()
+        footer.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.anchorsConstraint(to: footer, edgeInsets: UIEdgeInsets(top: 0, left: 32, bottom: 0, right: 32)),
+        ])
+        return footer
     }
 
     private func recalculateTotalFee() {

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 import BigInt
 
 protocol ConfigureTransactionViewControllerDelegate: class {
-    func didSavedToUseDefaultConfiguration(in viewController: ConfigureTransactionViewController)
+    func didSavedToUseDefaultConfigurationType(_ configurationType: TransactionConfigurationType, in viewController: ConfigureTransactionViewController)
     func didSaved(customConfiguration: TransactionConfiguration, in viewController: ConfigureTransactionViewController)
 }
 
@@ -94,12 +94,13 @@ class ConfigureTransactionViewController: UIViewController {
         tableView.reloadData()
     }
 
-    func configure(withEstimatedGasPrice value: BigInt) {
+    func configure(withEstimatedGasPrice value: BigInt, configurator: TransactionConfigurator) {
         var updatedViewModel = viewModel
         var configuration = makeConfigureSuitableForSaving(from: updatedViewModel.configurationToEdit.configuration)
         guard configuration.gasPrice != value else { return }
         configuration.setEstimated(gasPrice: value)
         updatedViewModel.configurationToEdit = EditedTransactionConfiguration(configuration: configuration)
+        updatedViewModel.configurations = configurator.configurations
         viewModel = updatedViewModel
         recalculateTotalFee()
         tableView.reloadData()
@@ -187,8 +188,8 @@ class ConfigureTransactionViewController: UIViewController {
 
             let configuration = makeConfigureSuitableForSaving(from: viewModel.configurationToEdit.configuration)
             delegate.didSaved(customConfiguration: configuration, in: self)
-        case .default:
-            delegate.didSavedToUseDefaultConfiguration(in: self)
+        case .standard, .slow, .fast, .rapid:
+            delegate.didSavedToUseDefaultConfigurationType(viewModel.selectedConfigurationType, in: self)
         }
     }
 

--- a/AlphaWallet/Transfer/ViewModels/EditedTransactionConfiguration.swift
+++ b/AlphaWallet/Transfer/ViewModels/EditedTransactionConfiguration.swift
@@ -1,0 +1,105 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import Foundation
+import BigInt
+
+struct EditedTransactionConfiguration {
+    private let formatter = EtherNumberFormatter.full
+
+    var gasPrice: BigInt {
+        return formatter.number(from: String(gasPriceRawValue), units: UnitConfiguration.gasPriceUnit) ?? BigInt()
+    }
+
+    var gasLimit: BigInt {
+        BigInt(String(gasLimitRawValue), radix: 10) ?? BigInt()
+    }
+
+    var data: Data {
+        if dataRawValue.isEmpty {
+            return .init()
+        } else {
+            return .init(hex: dataRawValue.drop0x)
+        }
+    }
+
+    var gasPriceRawValue: Int
+    var gasLimitRawValue: Int
+    var dataRawValue: String
+    var nonceRawValue: Int?
+
+    var overridenMaxGasPrice: Int?
+    var overridenMaxGasLimit: Int?
+
+    let defaultMinGasLimit = Int(GasLimitConfiguration.minGasLimit)
+    let defaultMinGasPrice = Int(GasPriceConfiguration.minPrice / BigInt(UnitConfiguration.gasPriceUnit.rawValue))
+
+    private let defaultMaxGasLimit: Int = Int(GasLimitConfiguration.maxGasLimit)
+    private let defaultMaxGasPrice: Int = Int(GasPriceConfiguration.maxPrice / BigInt(UnitConfiguration.gasPriceUnit.rawValue))
+
+    var maxGasPrice: Int {
+        if let overridenValue = overridenMaxGasPrice {
+            return overridenValue
+        } else {
+            return defaultMaxGasPrice
+        }
+    }
+
+    var maxGasLimit: Int {
+        if let overridenValue = overridenMaxGasLimit {
+            return overridenValue
+        } else {
+            return defaultMaxGasLimit
+        }
+    }
+
+    mutating func updateMaxGasLimitIfNeeded(_ value: Int) {
+        if value > defaultMaxGasLimit {
+            overridenMaxGasLimit = value
+        } else if value < defaultMinGasLimit {
+            overridenMaxGasLimit = nil
+        }
+    }
+
+    mutating func updateMaxGasPriceIfNeeded(_ value: Int) {
+        if value > defaultMaxGasPrice {
+            overridenMaxGasPrice = value
+        } else if value < defaultMaxGasPrice {
+            overridenMaxGasPrice = nil
+        }
+    }
+
+    init(configuration: TransactionConfiguration) {
+        gasLimitRawValue = Int(configuration.gasLimit.description) ?? 21000
+        gasPriceRawValue = formatter.string(from: configuration.gasPrice, units: UnitConfiguration.gasPriceUnit).numberValue?.intValue ?? 1
+        nonceRawValue = Int(configuration.nonce.flatMap { String($0) } ?? "")
+        dataRawValue = configuration.data.hexEncoded.add0x
+
+        updateMaxGasLimitIfNeeded(gasLimitRawValue)
+        updateMaxGasPriceIfNeeded(gasPriceRawValue)
+    }
+
+    var configuration: TransactionConfiguration {
+        return .init(gasPrice: gasPrice, gasLimit: gasLimit, data: data, nonce: nonceRawValue)
+    }
+
+    var isGasPriceValid: Bool {
+        return gasPrice >= 0
+    }
+
+    var isGasLimitValid: Bool {
+        return gasLimit <= ConfigureTransaction.gasLimitMax && gasLimit >= 0
+    }
+
+    var totalFee: BigInt {
+        return gasPrice * gasLimit
+    }
+
+    var isTotalFeeValid: Bool {
+        return totalFee <= ConfigureTransaction.gasFeeMax && totalFee >= 0
+    }
+
+    var isNonceValid: Bool {
+        guard let nonce = nonceRawValue else { return true }
+        return nonce >= 0
+    }
+}

--- a/AlphaWallet/Transfer/ViewModels/GasSpeedTableViewCellViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/GasSpeedTableViewCellViewModel.swift
@@ -8,39 +8,66 @@
 import UIKit
 
 struct GasSpeedTableViewCellViewModel {
-    var speed: String?
-    var estimatedTime: String?
-    var details: String?
+    let configuration: TransactionConfiguration
+    let configurationType: TransactionConfigurationType
+    let cryptoToDollarRate: Double?
+    let symbol: String
+    var title: String
     let isSelected: Bool
+
+    private var gasFeeString: String {
+        let fee = configuration.gasPrice * configuration.gasLimit
+        let feeString = EtherNumberFormatter.short.string(from: fee)
+        let cryptoToDollarSymbol = Constants.Currency.usd
+        let costs: String
+        if let cryptoToDollarRate = cryptoToDollarRate {
+            let cryptoToDollarValue = StringFormatter().currency(with: Double(fee) * cryptoToDollarRate / Double(EthereumUnit.ether.rawValue), and: cryptoToDollarSymbol)
+            return  "< ~\(feeString) \(symbol) (\(cryptoToDollarValue) \(cryptoToDollarSymbol))"
+        } else {
+            return "< ~\(feeString) \(symbol)"
+        }
+    }
+
+    private var estimatedTime: String? {
+        let estimatedProcessingTime = configurationType.estimatedProcessingTime
+        if estimatedProcessingTime.isEmpty {
+            return nil
+        } else {
+            return estimatedProcessingTime
+        }
+    }
 
     var accessoryType: UITableViewCell.AccessoryType {
         return isSelected ? .checkmark : .none
     }
 
-    var speedAttributedString: NSAttributedString? {
-        guard let speed = speed else { return nil }
-
-        return NSAttributedString(string: speed, attributes: [
-            .foregroundColor: Colors.black,
-            .font: Fonts.regular(size: 17)!
-        ])
+    var titleAttributedString: NSAttributedString? {
+        if isSelected {
+            return NSAttributedString(string: title, attributes: [
+                .foregroundColor: Colors.black,
+                .font: Fonts.semibold(size: 17)!
+            ])
+        } else {
+            return NSAttributedString(string: title, attributes: [
+                .foregroundColor: Colors.black,
+                .font: Fonts.regular(size: 17)!
+            ])
+        }
     }
 
     var estimatedTimeAttributedString: NSAttributedString? {
         guard let estimatedTime = estimatedTime else { return nil }
 
         return NSAttributedString(string: estimatedTime, attributes: [
-            .foregroundColor: R.color.dove()!,
-            .font: Fonts.regular(size: 13)!
+            .foregroundColor: R.color.mine()!,
+            .font: Fonts.regular(size: 15)!
         ])
     }
 
     var detailsAttributedString: NSAttributedString? {
-        guard let details = details else { return nil }
-
-        return NSAttributedString(string: details, attributes: [
+        return NSAttributedString(string: gasFeeString, attributes: [
             .foregroundColor: R.color.dove()!,
-            .font: Fonts.regular(size: 13)!
+            .font: Fonts.regular(size: 12)!
         ])
     }
 
@@ -48,4 +75,3 @@ struct GasSpeedTableViewCellViewModel {
         return Colors.appBackground
     }
 }
-

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -77,14 +77,22 @@ enum UpdateBalanceValue {
 extension TransactionConfirmationViewModel {
     private static func gasFeeString(withConfigurator configurator: TransactionConfigurator, cryptoToDollarRate: Double?) -> String {
         let fee = configurator.currentConfiguration.gasPrice * configurator.currentConfiguration.gasLimit
+        let estimatedProcessingTime = configurator.selectedConfigurationType.estimatedProcessingTime
         let symbol = configurator.session.server.symbol
         let feeString = EtherNumberFormatter.short.string(from: fee)
         let cryptoToDollarSymbol = Constants.Currency.usd
+        let costs: String
         if let cryptoToDollarRate = cryptoToDollarRate {
             let cryptoToDollarValue = StringFormatter().currency(with: Double(fee) * cryptoToDollarRate / Double(EthereumUnit.ether.rawValue), and: cryptoToDollarSymbol)
-            return "< ~\(feeString) \(symbol) (\(cryptoToDollarValue) \(cryptoToDollarSymbol))"
+            costs =  "< ~\(feeString) \(symbol) (\(cryptoToDollarValue) \(cryptoToDollarSymbol))"
         } else {
-            return "< ~\(feeString) \(symbol)"
+            costs = "< ~\(feeString) \(symbol)"
+        }
+
+        if estimatedProcessingTime.isEmpty {
+            return costs
+        } else {
+            return "\(costs) \(estimatedProcessingTime)"
         }
     }
 

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -482,14 +482,6 @@ extension TransactionConfirmationViewModel {
             self.numberOfTokens = numberOfTokens
         }
 
-        func isSubviewHidden(section: Int, row: Int) -> Bool {
-            let _ = openedSections.contains(section)
-            switch sections[section] {
-            case .gas, .amount, .numberOfTokens:
-                return true
-            }
-        }
-
         func headerViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
             let configuration: TransactionConfirmationHeaderView.Configuration = .init(
                     isOpened: openedSections.contains(section),

--- a/AlphaWallet/Transfer/Views/GasSpeedTableViewCell.swift
+++ b/AlphaWallet/Transfer/Views/GasSpeedTableViewCell.swift
@@ -64,7 +64,11 @@ class GasSpeedTableViewCell: UITableViewCell {
             separator.leadingAnchor.constraint(equalTo: leadingAnchor),
             separator.trailingAnchor.constraint(equalTo: trailingAnchor),
             separator.bottomAnchor.constraint(equalTo: bottomAnchor),
-            stackView.anchorsConstraint(to: contentView, edgeInsets: .init(top: 0, left: 0, bottom: 1, right: 0))
+
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 0),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 0),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 1)
         ])
     }
 
@@ -75,9 +79,9 @@ class GasSpeedTableViewCell: UITableViewCell {
     func configure(viewModel: GasSpeedTableViewCellViewModel) {
         backgroundColor = viewModel.backgroundColor
 
-        speedLabel.attributedText = viewModel.speedAttributedString
-        speedLabel.isHidden = speedLabel.attributedText == nil
+        speedLabel.attributedText = viewModel.titleAttributedString
 
+        estimatedTimeLabel.textAlignment = .right
         estimatedTimeLabel.attributedText = viewModel.estimatedTimeAttributedString
         estimatedTimeLabel.isHidden = estimatedTimeLabel.attributedText == nil
 

--- a/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
+++ b/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
@@ -8,23 +8,23 @@ class TransactionConfiguratorTests: XCTestCase {
     func testAdjustGasPrice() {
         let gasPrice = BigInt(1000000000)
         let configurator = TransactionConfigurator(session: .make(), transaction: .make(gasPrice: gasPrice))
-        XCTAssertEqual(gasPrice, configurator.customConfiguration.gasPrice)
+        XCTAssertEqual(gasPrice, configurator.currentConfiguration.gasPrice)
     }
 
     func testMinGasPrice() {
         let configurator = TransactionConfigurator(session: .make(), transaction: .make(gasPrice: BigInt(1)))
-        XCTAssertEqual(GasPriceConfiguration.minPrice, configurator.customConfiguration.gasPrice)
+        XCTAssertEqual(GasPriceConfiguration.minPrice, configurator.currentConfiguration.gasPrice)
     }
 
     func testMaxGasPrice() {
         let configurator = TransactionConfigurator(session: .make(), transaction: .make(gasPrice: BigInt(990000000000)))
-        XCTAssertEqual(GasPriceConfiguration.maxPrice, configurator.customConfiguration.gasPrice)
+        XCTAssertEqual(GasPriceConfiguration.maxPrice, configurator.currentConfiguration.gasPrice)
     }
 
     func testSendEtherGasPriceAndLimit() {
         let configurator = TransactionConfigurator(session: .make(), transaction: .make(gasLimit: nil, gasPrice: nil))
-        XCTAssertEqual(BigInt(GasPriceConfiguration.defaultPrice), configurator.customConfiguration.gasPrice)
+        XCTAssertEqual(BigInt(GasPriceConfiguration.defaultPrice), configurator.currentConfiguration.gasPrice)
         //gas limit is always 21k for native ether transfers
-        XCTAssertEqual(BigInt(21000), configurator.customConfiguration.gasLimit)
+        XCTAssertEqual(BigInt(21000), configurator.currentConfiguration.gasLimit)
     }
 }


### PR DESCRIPTION
Closes #2242

* Fetch and show gas estimates from https://www.gasnow.org/api/v3/gas/price
* Show informational footer about gas fee in configure gas/nonce screen

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100048741-82b39280-2e50-11eb-8272-3ca6a6373309.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100048745-86471980-2e50-11eb-91d6-719e95412330.png'>
<img width='200' src='https://user-images.githubusercontent.com/56189/100048736-80513880-2e50-11eb-8bc3-8a4d80626424.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100048742-8515ec80-2e50-11eb-832a-fcde04a74308.png'>
