### PR TITLE
Rename TransferType -> TransactionType. Name was misleading for a long time

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		296105931FA2AA2100292494 /* UnsignedTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296105921FA2AA2100292494 /* UnsignedTransaction.swift */; };
 		296105951FA2DEF000292494 /* TransactionDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296105941FA2DEF000292494 /* TransactionDirection.swift */; };
 		296106CC1F776FD00006164B /* WalletCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296106CB1F776FD00006164B /* WalletCoordinatorTests.swift */; };
-		296106D01F778A8D0006164B /* TransferType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296106CF1F778A8D0006164B /* TransferType.swift */; };
+		296106D01F778A8D0006164B /* TransactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296106CF1F778A8D0006164B /* TransactionType.swift */; };
 		2961BD071FB146EB00C4B840 /* ChainState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2961BD061FB146EB00C4B840 /* ChainState.swift */; };
 		2961BD091FB14B6D00C4B840 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2961BD081FB14B6D00C4B840 /* Config.swift */; };
 		2963A2881FC401490095447D /* LocalizedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2963A2871FC401490095447D /* LocalizedOperation.swift */; };
@@ -884,7 +884,7 @@
 		296105921FA2AA2100292494 /* UnsignedTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsignedTransaction.swift; sourceTree = "<group>"; };
 		296105941FA2DEF000292494 /* TransactionDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDirection.swift; sourceTree = "<group>"; };
 		296106CB1F776FD00006164B /* WalletCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoordinatorTests.swift; sourceTree = "<group>"; };
-		296106CF1F778A8D0006164B /* TransferType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferType.swift; sourceTree = "<group>"; };
+		296106CF1F778A8D0006164B /* TransactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionType.swift; sourceTree = "<group>"; };
 		2961BD061FB146EB00C4B840 /* ChainState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainState.swift; sourceTree = "<group>"; };
 		2961BD081FB14B6D00C4B840 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		2963A2871FC401490095447D /* LocalizedOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedOperation.swift; sourceTree = "<group>"; };
@@ -2496,7 +2496,7 @@
 			isa = PBXGroup;
 			children = (
 				2963B6AE1F9823E6003063C1 /* UnconfirmedTransaction.swift */,
-				296106CF1F778A8D0006164B /* TransferType.swift */,
+				296106CF1F778A8D0006164B /* TransactionType.swift */,
 				29B6AED51F7CA4A700EC6DE3 /* TransactionConfiguration.swift */,
 				29B933F71F8609FF009FCABB /* PaymentFlow.swift */,
 				299B5E461FD2C87F0051361C /* ConfigureTransactionError.swift */,
@@ -4348,7 +4348,7 @@
 				29FC9BC61F830899000209CD /* MigrationInitializerForOneChainPerDatabase.swift in Sources */,
 				29AD8A091F93F8B2008E10E7 /* Session.swift in Sources */,
 				29BB94971F6FCD60009B09CC /* SendViewModel.swift in Sources */,
-				296106D01F778A8D0006164B /* TransferType.swift in Sources */,
+				296106D01F778A8D0006164B /* TransactionType.swift in Sources */,
 				29E14FDB1F7F4F3D00185568 /* Transaction.swift in Sources */,
 				BBF4F9B72029D0B3009E04C0 /* GasViewModel.swift in Sources */,
 				AA26C628204134C500318B9B /* TokenCardTableViewCellWithoutCheckbox.swift in Sources */,

--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -14,12 +14,12 @@ enum DappAction {
 }
 
 extension DappAction {
-    static func fromCommand(_ command: DappCommand, transfer: Transfer) -> DappAction {
+    static func fromCommand(_ command: DappCommand, server: RPCServer, transactionType: TransactionType) -> DappAction {
         switch command.name {
         case .signTransaction:
-            return .signTransaction(DappAction.makeUnconfirmedTransaction(command.object, transfer: transfer))
+            return .signTransaction(DappAction.makeUnconfirmedTransaction(command.object, server: server, transactionType: transactionType))
         case .sendTransaction:
-            return .sendTransaction(DappAction.makeUnconfirmedTransaction(command.object, transfer: transfer))
+            return .sendTransaction(DappAction.makeUnconfirmedTransaction(command.object, server: server, transactionType: transactionType))
         case .signMessage:
             let data = command.object["data"]?.value ?? ""
             return .signMessage(data)
@@ -34,7 +34,7 @@ extension DappAction {
         }
     }
 
-    private static func makeUnconfirmedTransaction(_ object: [String: DappCommandObjectValue], transfer: Transfer) -> UnconfirmedTransaction {
+    private static func makeUnconfirmedTransaction(_ object: [String: DappCommandObjectValue], server: RPCServer, transactionType: TransactionType) -> UnconfirmedTransaction {
         let to = AlphaWallet.Address(string: object["to"]?.value ?? "")
         let value = BigInt((object["value"]?.value ?? "0").drop0x, radix: 16) ?? BigInt()
         let nonce: BigInt? = {
@@ -51,7 +51,7 @@ extension DappAction {
         }()
         let data = Data(hex: object["data"]?.value ?? "0x")
         return UnconfirmedTransaction(
-            transferType: transfer.type,
+            transactionType: transactionType,
             value: value,
             recipient: nil,
             contract: to,

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -231,8 +231,7 @@ extension BrowserViewController: WKScriptMessageHandler {
         guard let command = DappAction.fromMessage(message) else { return }
         let requester = DAppRequester(title: webView.title, url: webView.url)
         let token = TokensDataStore.token(forServer: server)
-        let transfer = Transfer(server: server, type: .dapp(token, requester))
-        let action = DappAction.fromCommand(command, transfer: transfer)
+        let action = DappAction.fromCommand(command, server: server, transactionType: .dapp(token, requester))
 
         delegate?.didCall(action: action, callbackID: command.id, inBrowserViewController: self)
     }

--- a/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
+++ b/AlphaWallet/Core/Coordinators/CustomUrlSchemeCoordinator.swift
@@ -80,7 +80,7 @@ class CustomUrlSchemeCoordinator: Coordinator {
         } else {
             amountConsideringDecimals = ""
         }
-        let transferType = TransferType(token: tokenObject, recipient: recipient, amount: amountConsideringDecimals)
-        delegate?.openSendPaymentFlow(.send(type: transferType), server: server, inCoordinator: self)
+        let transactionType = TransactionType(token: tokenObject, recipient: recipient, amount: amountConsideringDecimals)
+        delegate?.openSendPaymentFlow(.send(type: transactionType), server: server, inCoordinator: self)
     }
 }

--- a/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
@@ -271,7 +271,7 @@ struct FunctionOrigin {
         }
         //TODO feels ike everything can just be in `.tokenScript`. But have to check dapp, it includes other parameters like gas
         return .success(UnconfirmedTransaction(
-                transferType: .tokenScript(tokenObject),
+                transactionType: .tokenScript(tokenObject),
                 value: BigInt(value),
                 recipient: nil,
                 contract: originContractOrRecipientAddress,

--- a/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
@@ -69,7 +69,7 @@ class ClaimPaidOrderCoordinator: Coordinator {
             case .success(let payload):
                 let account = strongSelf.session.account.address
                 let transaction = UnconfirmedTransaction(
-                        transferType: .claimPaidErc875MagicLink(strongSelf.tokenObject),
+                        transactionType: .claimPaidErc875MagicLink(strongSelf.tokenObject),
                         value: BigInt(strongSelf.signedOrder.order.price),
                         recipient: nil,
                         contract: strongSelf.signedOrder.order.contractAddress,

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -390,31 +390,31 @@ class SingleChainTokenCoordinator: Coordinator {
         return try! Realm(configuration: migration.config)
     }
 
-    func show(fungibleToken token: TokenObject, transferType: TransferType) {
+    func show(fungibleToken token: TokenObject, transactionType: TransactionType) {
         guard let transactionsStore = createTransactionsStore() else { return }
 
-        let viewController = TokenViewController(session: session, tokensDataStore: storage, assetDefinition: assetDefinitionStore, transferType: transferType, token: token)
+        let viewController = TokenViewController(session: session, tokensDataStore: storage, assetDefinition: assetDefinitionStore, transactionType: transactionType, token: token)
         viewController.delegate = self
-        let viewModel = TokenViewControllerViewModel(transferType: transferType, session: session, tokensStore: storage, transactionsStore: transactionsStore, assetDefinitionStore: assetDefinitionStore)
+        let viewModel = TokenViewControllerViewModel(transactionType: transactionType, session: session, tokensStore: storage, transactionsStore: transactionsStore, assetDefinitionStore: assetDefinitionStore)
         viewController.configure(viewModel: viewModel)
         viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(image: R.image.backWhite(), style: .plain, target: self, action: #selector(dismiss))
 
         navigationController.pushViewController(viewController, animated: true)
 
-        refreshTokenViewControllerUponAssetDefinitionChanges(viewController, forTransferType: transferType, transactionsStore: transactionsStore)
+        refreshTokenViewControllerUponAssetDefinitionChanges(viewController, forTransactionType: transactionType, transactionsStore: transactionsStore)
     }
 
-    private func refreshTokenViewControllerUponAssetDefinitionChanges(_ viewController: TokenViewController, forTransferType transferType: TransferType, transactionsStore: TransactionsStorage) {
+    private func refreshTokenViewControllerUponAssetDefinitionChanges(_ viewController: TokenViewController, forTransactionType transactionType: TransactionType, transactionsStore: TransactionsStorage) {
         assetDefinitionStore.subscribeToBodyChanges { [weak self] contract in
             guard let strongSelf = self else { return }
-            guard contract.sameContract(as: transferType.contract) else { return }
-            let viewModel = TokenViewControllerViewModel(transferType: transferType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)
+            guard contract.sameContract(as: transactionType.contract) else { return }
+            let viewModel = TokenViewControllerViewModel(transactionType: transactionType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)
             viewController.configure(viewModel: viewModel)
         }
         assetDefinitionStore.subscribeToSignatureChanges { [weak self] contract in
             guard let strongSelf = self else { return }
-            guard contract.sameContract(as: transferType.contract) else { return }
-            let viewModel = TokenViewControllerViewModel(transferType: transferType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)
+            guard contract.sameContract(as: transactionType.contract) else { return }
+            let viewModel = TokenViewControllerViewModel(transactionType: transactionType, session: strongSelf.session, tokensStore: strongSelf.storage, transactionsStore: transactionsStore, assetDefinitionStore: strongSelf.assetDefinitionStore)
             viewController.configure(viewModel: viewModel)
         }
     }
@@ -550,7 +550,7 @@ extension SingleChainTokenCoordinator: TokensCardCoordinatorDelegate {
     }
 }
 
-extension TransferType {
+extension TransactionType {
 
     func uniswapHolder(theme: UniswapHolder.Theme) -> UniswapHolder {
         switch self {
@@ -579,17 +579,17 @@ extension UITraitCollection {
 
 extension SingleChainTokenCoordinator: TokenViewControllerDelegate {
 
-    func didTapErc20ExchangeOnUniswap(forTransferType transferType: TransferType, inViewController viewController: TokenViewController) {
+    func didTapErc20ExchangeOnUniswap(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController) {
         let theme = viewController.traitCollection.uniswapTheme
 
-        delegate?.didPressErc20ExchangeOnUniswap(for: transferType.uniswapHolder(theme: theme), in: self)
+        delegate?.didPressErc20ExchangeOnUniswap(for: transactionType.uniswapHolder(theme: theme), in: self)
     }
 
-    func didTapSend(forTransferType transferType: TransferType, inViewController viewController: TokenViewController) {
-        delegate?.didPress(for: .send(type: transferType), inCoordinator: self)
+    func didTapSend(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController) {
+        delegate?.didPress(for: .send(type: transactionType), inCoordinator: self)
     }
 
-    func didTapReceive(forTransferType transferType: TransferType, inViewController viewController: TokenViewController) {
+    func didTapReceive(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController) {
         delegate?.didPress(for: .request, inCoordinator: self)
     }
 
@@ -597,9 +597,9 @@ extension SingleChainTokenCoordinator: TokenViewControllerDelegate {
         delegate?.didTap(transaction: transaction, inViewController: viewController, in: self)
     }
 
-    func didTap(action: TokenInstanceAction, transferType: TransferType, viewController: TokenViewController) {
+    func didTap(action: TokenInstanceAction, transactionType: TransactionType, viewController: TokenViewController) {
         let token: TokenObject
-        switch transferType {
+        switch transactionType {
         case .ERC20Token(let erc20Token, _, _):
             token = erc20Token
         case .dapp, .ERC721Token, .ERC875Token, .ERC875TokenOrder, .ERC721ForTicketToken, .tokenScript, .claimPaidErc875MagicLink:

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -184,9 +184,9 @@ extension TokensCoordinator: TokensViewControllerDelegate {
         guard let coordinator = singleChainTokenCoordinator(forServer: server) else { return }
         switch token.type {
         case .nativeCryptocurrency:
-            coordinator.show(fungibleToken: token, transferType: .nativeCryptocurrency(token, destination: .none, amount: nil))
+            coordinator.show(fungibleToken: token, transactionType: .nativeCryptocurrency(token, destination: .none, amount: nil))
         case .erc20:
-            coordinator.show(fungibleToken: token, transferType: .ERC20Token(token, destination: nil, amount: nil))
+            coordinator.show(fungibleToken: token, transactionType: .ERC20Token(token, destination: nil, amount: nil))
         case .erc721:
             coordinator.showTokenList(for: .send(type: .ERC721Token(token)), token: token)
         case .erc875, .erc721ForTickets:
@@ -240,10 +240,10 @@ extension TokensCoordinator: QRCodeResolutionCoordinatorDelegate {
         removeCoordinator(coordinator)
     }
 
-    func coordinator(_ coordinator: QRCodeResolutionCoordinator, didResolveTransferType transferType: TransferType, token: TokenObject) {
+    func coordinator(_ coordinator: QRCodeResolutionCoordinator, didResolveTransactionType transactionType: TransactionType, token: TokenObject) {
         removeCoordinator(coordinator)
 
-        let paymentFlow = PaymentFlow.send(type: transferType)
+        let paymentFlow = PaymentFlow.send(type: transactionType)
 
         delegate?.didPress(for: paymentFlow, server: token.server, in: self)
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
@@ -144,8 +144,8 @@ class TokenInstanceViewController: UIViewController, TokenVerifiableStatusViewCo
     }
 
     func transfer() {
-        let transferType = TransferType(token: tokenObject)
-        delegate?.didPressTransfer(token: tokenObject, tokenHolder: tokenHolder, forPaymentFlow: .send(type: transferType), in: self)
+        let transactionType = TransactionType(token: tokenObject)
+        delegate?.didPressTransfer(token: tokenObject, tokenHolder: tokenHolder, forPaymentFlow: .send(type: transactionType), in: self)
     }
 
     private func handle(action: TokenInstanceAction) {

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -6,27 +6,27 @@ import BigInt
 import PromiseKit
 
 protocol TokenViewControllerDelegate: class, CanOpenURL {
-    func didTapErc20ExchangeOnUniswap(forTransferType transferType: TransferType, inViewController viewController: TokenViewController)
-    func didTapSend(forTransferType transferType: TransferType, inViewController viewController: TokenViewController)
-    func didTapReceive(forTransferType transferType: TransferType, inViewController viewController: TokenViewController)
+    func didTapErc20ExchangeOnUniswap(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController)
+    func didTapSend(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController)
+    func didTapReceive(forTransactionType transactionType: TransactionType, inViewController viewController: TokenViewController)
     func didTap(transaction: Transaction, inViewController viewController: TokenViewController)
-    func didTap(action: TokenInstanceAction, transferType: TransferType, viewController: TokenViewController)
+    func didTap(action: TokenInstanceAction, transactionType: TransactionType, viewController: TokenViewController)
 }
 
 class TokenViewController: UIViewController {
     private let headerViewRefreshInterval: TimeInterval = 5.0
     private let roundedBackground = RoundedBackground()
     lazy private var header = {
-        return TokenViewControllerHeaderView(contract: transferType.contract)
+        return TokenViewControllerHeaderView(contract: transactionType.contract)
     }()
-    lazy private var headerViewModel = SendHeaderViewViewModel(server: session.server, token: token, transferType: transferType)
+    lazy private var headerViewModel = SendHeaderViewViewModel(server: session.server, token: token, transactionType: transactionType)
     private var viewModel: TokenViewControllerViewModel?
     private var tokenHolder: TokenHolder?
     private let token: TokenObject
     private let session: WalletSession
     private let tokensDataStore: TokensDataStore
     private let assetDefinitionStore: AssetDefinitionStore
-    private let transferType: TransferType
+    private let transactionType: TransactionType
     private let tableView = UITableView(frame: .zero, style: .plain)
     private let buttonsBar = ButtonsBar(configuration: .combined(buttons: 2))
     private lazy var tokenScriptFileStatusHandler = XMLHandler(token: token, assetDefinitionStore: assetDefinitionStore)
@@ -34,12 +34,12 @@ class TokenViewController: UIViewController {
 
     weak var delegate: TokenViewControllerDelegate?
 
-    init(session: WalletSession, tokensDataStore: TokensDataStore, assetDefinition: AssetDefinitionStore, transferType: TransferType, token: TokenObject) {
+    init(session: WalletSession, tokensDataStore: TokensDataStore, assetDefinition: AssetDefinitionStore, transactionType: TransactionType, token: TokenObject) {
         self.token = token
         self.session = session
         self.tokensDataStore = tokensDataStore
         self.assetDefinitionStore = assetDefinition
-        self.transferType = transferType
+        self.transactionType = transactionType
 
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
@@ -158,7 +158,7 @@ class TokenViewController: UIViewController {
     }
 
     private func configureBalanceViewModel() {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             session.balanceViewModel.subscribe { [weak self] viewModel in
                 guard let celf = self, let viewModel = viewModel else { return }
@@ -193,15 +193,15 @@ class TokenViewController: UIViewController {
     }
 
     @objc private func send() {
-        delegate?.didTapSend(forTransferType: transferType, inViewController: self)
+        delegate?.didTapSend(forTransactionType: transactionType, inViewController: self)
     }
 
     @objc private func receive() {
-        delegate?.didTapReceive(forTransferType: transferType, inViewController: self)
+        delegate?.didTapReceive(forTransactionType: transactionType, inViewController: self)
     }
 
     @objc private func erc20ExchangeOnUniswap() {
-        delegate?.didTapErc20ExchangeOnUniswap(forTransferType: transferType, inViewController: self)
+        delegate?.didTapErc20ExchangeOnUniswap(forTransactionType: transactionType, inViewController: self)
     }
 
     @objc private func actionButtonTapped(sender: UIButton) {
@@ -232,7 +232,7 @@ class TokenViewController: UIViewController {
                         //no-op shouldn't have reached here since the button should be disabled. So just do nothing to be safe
                     }
                 } else {
-                    delegate?.didTap(action: action, transferType: transferType, viewController: self)
+                    delegate?.didTap(action: action, transactionType: transactionType, viewController: self)
                 }
             }
             break

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -207,8 +207,8 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
 
     func transfer() {
         guard let selectedTokenHolder = selectedTokenHolder else { return }
-        let transferType = TransferType(token: viewModel.token)
-        delegate?.didPressTransfer(token: viewModel.token, tokenHolder: selectedTokenHolder, for: .send(type: transferType), tokenHolders: viewModel.tokenHolders, in: self)
+        let transactionType = TransactionType(token: viewModel.token)
+        delegate?.didPressTransfer(token: viewModel.token, tokenHolder: selectedTokenHolder, for: .send(type: transactionType), tokenHolders: viewModel.tokenHolders, in: self)
     }
 
     private func handle(action: TokenInstanceAction) {

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -6,14 +6,14 @@ import BigInt
 import PromiseKit
 
 struct TokenViewControllerViewModel {
-    private let transferType: TransferType
+    private let transactionType: TransactionType
     private let session: WalletSession
     private let tokensStore: TokensDataStore
     private let transactionsStore: TransactionsStorage
     private let assetDefinitionStore: AssetDefinitionStore
 
     var token: TokenObject? {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             //TODO might as well just make .nativeCryptocurrency hold the TokenObject instance too
             return TokensDataStore.etherToken(forServer: session.server)
@@ -101,7 +101,7 @@ struct TokenViewControllerViewModel {
     }
 
     var fungibleBalance: BigInt? {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             let string: String? = session.balanceViewModel.value?.amountShort
             return string.flatMap { EtherNumberFormatter.full.number(from: $0, decimals: session.server.decimals) }
@@ -112,14 +112,14 @@ struct TokenViewControllerViewModel {
         }
     }
 
-    init(transferType: TransferType, session: WalletSession, tokensStore: TokensDataStore, transactionsStore: TransactionsStorage, assetDefinitionStore: AssetDefinitionStore) {
-        self.transferType = transferType
+    init(transactionType: TransactionType, session: WalletSession, tokensStore: TokensDataStore, transactionsStore: TransactionsStorage, assetDefinitionStore: AssetDefinitionStore) {
+        self.transactionType = transactionType
         self.session = session
         self.tokensStore = tokensStore
         self.transactionsStore = transactionsStore
         self.assetDefinitionStore = assetDefinitionStore
 
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             self.recentTransactions = Array(transactionsStore.objects.lazy
                     .filter({ $0.state == .completed || $0.state == .pending })
@@ -143,7 +143,7 @@ struct TokenViewControllerViewModel {
     }
 
     var destinationAddress: AlphaWallet.Address {
-        return transferType.contract
+        return transactionType.contract
     }
 
     var backgroundColor: UIColor {

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -430,11 +430,10 @@ extension TokenInstanceWebView: WKScriptMessageHandler {
             return
         }
 
-        //TODO clean up this. Some of these are wrong, eg: Transfer(). They are only here so we can sign personal message
+        //TODO clean up this. Some of these are wrong, eg: transactionType. They are only here so we can sign personal message
         let requester = DAppRequester(title: webView.title, url: webView.url)
         let token = TokensDataStore.token(forServer: server)
-        let transfer = Transfer(server: server, type: .dapp(token, requester))
-        let action = DappAction.fromCommand(command, transfer: transfer)
+        let action = DappAction.fromCommand(command, server: server, transactionType: .dapp(token, requester))
 
         switch wallet.type {
         case .real(let account):

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -345,8 +345,8 @@ class TokensCardCoordinator: NSObject, Coordinator {
     private func sellViaActivitySheet(tokenHolder: TokenHolder, linkExpiryDate: Date, ethCost: Ether, paymentFlow: PaymentFlow, in viewController: UIViewController, sender: UIView) {
         let server: RPCServer
         switch paymentFlow {
-        case .send(let transferType):
-            server = transferType.server
+        case .send(let transactionType):
+            server = transactionType.server
         case .request:
             return
         }
@@ -373,8 +373,8 @@ class TokensCardCoordinator: NSObject, Coordinator {
     private func transferViaActivitySheet(tokenHolder: TokenHolder, linkExpiryDate: Date, paymentFlow: PaymentFlow, in viewController: UIViewController, sender: UIView) {
         let server: RPCServer
         switch paymentFlow {
-        case .send(let transferType):
-            server = transferType.server
+        case .send(let transactionType):
+            server = transactionType.server
         case .request:
             return
         }
@@ -655,8 +655,8 @@ extension TokensCardCoordinator: TransferTokensCardViaWalletAddressViewControlle
         case .real:
             switch paymentFlow {
             case .send:
-                if case .send(let transferType) = paymentFlow {
-                    let coordinator = TransferNFTCoordinator(navigationController: navigationController, transferType: transferType, tokenHolder: tokenHolder, recipient: recipient, keystore: keystore, session: session, ethPrice: ethPrice, analyticsCoordinator: analyticsCoordinator)
+                if case .send(let transactionType) = paymentFlow {
+                    let coordinator = TransferNFTCoordinator(navigationController: navigationController, transactionType: transactionType, tokenHolder: tokenHolder, recipient: recipient, keystore: keystore, session: session, ethPrice: ethPrice, analyticsCoordinator: analyticsCoordinator)
                     addCoordinator(coordinator)
                     coordinator.delegate = self
                     coordinator.start()

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -39,7 +39,7 @@ class TransactionConfigurator {
     }
 
     var toAddress: AlphaWallet.Address? {
-        switch transaction.transferType {
+        switch transaction.transactionType {
         case .nativeCryptocurrency:
             return transaction.recipient
         case .dapp, .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .tokenScript, .claimPaidErc875MagicLink:
@@ -49,7 +49,7 @@ class TransactionConfigurator {
 
     var value: BigInt {
         //TODO why not all `transaction.value`? Shouldn't the other types of transactions make sure their `transaction.value` is 0?
-        switch transaction.transferType {
+        switch transaction.transactionType {
         case .nativeCryptocurrency, .dapp: return transaction.value
         case .ERC20Token: return 0
         case .ERC875Token: return 0
@@ -211,7 +211,7 @@ class TransactionConfigurator {
 
     private static func createConfiguration(server: RPCServer, transaction: UnconfirmedTransaction, account: AlphaWallet.Address) -> TransactionConfiguration {
         do {
-            switch transaction.transferType {
+            switch transaction.transactionType {
             case .dapp:
                 return createConfiguration(server: server, transaction: transaction, gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit, data: transaction.data ?? .init())
             case .nativeCryptocurrency:

--- a/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
@@ -49,7 +49,7 @@ class PaymentCoordinator: Coordinator {
         switch (flow, session.account.type) {
         case (.send(let type), .real(let account)):
             let coordinator = SendCoordinator(
-                transferType: type,
+                transactionType: type,
                 navigationController: navigationController,
                 session: session,
                 keystore: keystore,

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -12,7 +12,7 @@ protocol SendCoordinatorDelegate: class, CanOpenURL {
 }
 
 class SendCoordinator: Coordinator {
-    private let transferType: TransferType
+    private let transactionType: TransactionType
     private let session: WalletSession
     private let account: AlphaWallet.Address
     private let keystore: Keystore
@@ -32,7 +32,7 @@ class SendCoordinator: Coordinator {
     weak var delegate: SendCoordinatorDelegate?
 
     init(
-            transferType: TransferType,
+            transactionType: TransactionType,
             navigationController: UINavigationController = UINavigationController(),
             session: WalletSession,
             keystore: Keystore,
@@ -43,7 +43,7 @@ class SendCoordinator: Coordinator {
             assetDefinitionStore: AssetDefinitionStore,
             analyticsCoordinator: AnalyticsCoordinator?
     ) {
-        self.transferType = transferType
+        self.transactionType = transactionType
         self.navigationController = navigationController
         self.navigationController.modalPresentationStyle = .formSheet
         self.session = session
@@ -58,7 +58,7 @@ class SendCoordinator: Coordinator {
 
     func start() {
         sendViewController.configure(viewModel:
-                .init(transferType: sendViewController.transferType,
+                .init(transactionType: sendViewController.transactionType,
                         session: session,
                         storage: sendViewController.storage
                         )
@@ -78,7 +78,7 @@ class SendCoordinator: Coordinator {
             session: session,
             storage: storage,
             account: account,
-            transferType: transferType,
+            transactionType: transactionType,
             cryptoPrice: ethPrice,
             assetDefinitionStore: assetDefinitionStore
         )
@@ -86,7 +86,7 @@ class SendCoordinator: Coordinator {
         if navigationController.viewControllers.isEmpty {
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(title: R.string.localizable.cancel(), style: .plain, target: self, action: #selector(dismiss))
         }
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency(_, let destination, let amount):
             controller.targetAddressTextField.value = destination?.stringValue ?? ""
             if let amount = amount {

--- a/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
@@ -11,7 +11,7 @@ protocol TransferNFTCoordinatorDelegate: class {
 
 class TransferNFTCoordinator: Coordinator {
     private let navigationController: UINavigationController
-    private let transferType: TransferType
+    private let transactionType: TransactionType
     private let tokenHolder: TokenHolder
     private let recipient: AlphaWallet.Address
     private let keystore: Keystore
@@ -21,9 +21,9 @@ class TransferNFTCoordinator: Coordinator {
     var coordinators: [Coordinator] = []
     weak var delegate: TransferNFTCoordinatorDelegate?
 
-    init(navigationController: UINavigationController, transferType: TransferType, tokenHolder: TokenHolder, recipient: AlphaWallet.Address, keystore: Keystore, session: WalletSession, ethPrice: Subscribable<Double>, analyticsCoordinator: AnalyticsCoordinator?) {
+    init(navigationController: UINavigationController, transactionType: TransactionType, tokenHolder: TokenHolder, recipient: AlphaWallet.Address, keystore: Keystore, session: WalletSession, ethPrice: Subscribable<Double>, analyticsCoordinator: AnalyticsCoordinator?) {
         self.navigationController = navigationController
-        self.transferType = transferType
+        self.transactionType = transactionType
         self.tokenHolder = tokenHolder
         self.recipient = recipient
         self.keystore = keystore
@@ -34,7 +34,7 @@ class TransferNFTCoordinator: Coordinator {
 
     func start() {
         let transaction = UnconfirmedTransaction(
-                transferType: transferType,
+                transactionType: transactionType,
                 value: BigInt(0),
                 recipient: recipient,
                 contract: tokenHolder.contractAddress,

--- a/AlphaWallet/Transfer/Types/PaymentFlow.swift
+++ b/AlphaWallet/Transfer/Types/PaymentFlow.swift
@@ -3,6 +3,6 @@
 import Foundation
 
 enum PaymentFlow {
-    case send(type: TransferType)
+    case send(type: TransactionType)
     case request
 }

--- a/AlphaWallet/Transfer/Types/TransactionType.swift
+++ b/AlphaWallet/Transfer/Types/TransactionType.swift
@@ -3,12 +3,7 @@
 import Foundation
 import BigInt
 
-struct Transfer {
-    let server: RPCServer
-    let type: TransferType
-}
-
-enum TransferType {
+enum TransactionType {
     init(token: TokenObject, recipient: AddressOrEnsName? = nil, amount: String? = nil) {
         self = {
             switch token.type {
@@ -49,7 +44,7 @@ enum TransferType {
     }
 }
 
-extension TransferType {
+extension TransactionType {
 
     var symbol: String {
         switch self {

--- a/AlphaWallet/Transfer/Types/UnconfirmedTransaction.swift
+++ b/AlphaWallet/Transfer/Types/UnconfirmedTransaction.swift
@@ -4,7 +4,7 @@ import Foundation
 import BigInt
 
 struct UnconfirmedTransaction {
-    let transferType: TransferType
+    let transactionType: TransactionType
     let value: BigInt
     let recipient: AlphaWallet.Address?
     let contract: AlphaWallet.Address?
@@ -24,7 +24,7 @@ struct UnconfirmedTransaction {
     let indices: [UInt16]?
 
     init(
-        transferType: TransferType,
+        transactionType: TransactionType,
         value: BigInt,
         recipient: AlphaWallet.Address?,
         contract: AlphaWallet.Address?,
@@ -35,7 +35,7 @@ struct UnconfirmedTransaction {
         gasPrice: BigInt? = nil,
         nonce: BigInt? = nil
     ) {
-        self.transferType = transferType
+        self.transactionType = transactionType
         self.value = value
         self.recipient = recipient
         self.contract = contract

--- a/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
@@ -186,7 +186,7 @@ class TransactionConfirmationViewController: UIViewController {
                 strongSelf.generateSubviews()
             }
 
-            switch sendFungiblesViewModel.transferType {
+            switch sendFungiblesViewModel.transactionType {
             case .nativeCryptocurrency:
                 sendFungiblesViewModel.session.balanceViewModel.subscribe { [weak self] balanceBaseViewModel in
                     guard let strongSelf = self else { return }

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -7,7 +7,7 @@ struct ConfigureTransactionViewModel {
     var selectedConfigurationType: TransactionConfigurationType
     let server: RPCServer
     let ethPrice: Subscribable<Double>
-    let transferType: TransferType
+    let transactionType: TransactionType
     var configurationToEdit: EditedTransactionConfiguration
     var configurationTypes: [TransactionConfigurationType]
     var configurations: TransactionConfigurations {
@@ -24,7 +24,7 @@ struct ConfigureTransactionViewModel {
         self.configurationTypes = ConfigureTransactionViewModel.sortedConfigurationTypes(fromConfigurations: configurations)
         self.configurations = configurations
         self.currencyRate = currencyRate
-        transferType = configurator.transaction.transferType
+        transactionType = configurator.transaction.transactionType
         selectedConfigurationType = configurator.selectedConfigurationType
         configurationToEdit = EditedTransactionConfiguration(configuration: configurator.configurations.custom)
     }
@@ -48,7 +48,7 @@ struct ConfigureTransactionViewModel {
     }
 
     var isDataInputHidden: Bool {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency, .dapp, .tokenScript, .claimPaidErc875MagicLink:
             return false
         case .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken:

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -4,17 +4,17 @@ import UIKit
 
 struct SendHeaderViewViewModel {
     private let token: TokenObject
-    private let transferType: TransferType
+    private let transactionType: TransactionType
     let server: RPCServer
     var title: String
     var ticker: CoinTicker?
     var currencyAmount: String?
     var isShowingValue: Bool = true
 
-    init(server: RPCServer, token: TokenObject, transferType: TransferType) {
+    init(server: RPCServer, token: TokenObject, transactionType: TransactionType) {
         self.server = server
         self.token = token
-        self.transferType = transferType
+        self.transactionType = transactionType
         title = ""
         ticker = nil
         currencyAmount = nil
@@ -54,7 +54,7 @@ struct SendHeaderViewViewModel {
         if server.isTestnet {
             return nil
         } else {
-            switch transferType {
+            switch transactionType {
             case .nativeCryptocurrency:
                 if isShowingValue {
                     return tokenValueAttributedString

--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -8,16 +8,16 @@ struct SendViewModel {
     private let session: WalletSession
     private let storage: TokensDataStore
 
-    let transferType: TransferType
+    let transactionType: TransactionType
 
-    init(transferType: TransferType, session: WalletSession, storage: TokensDataStore) {
-        self.transferType = transferType
+    init(transactionType: TransactionType, session: WalletSession, storage: TokensDataStore) {
+        self.transactionType = transactionType
         self.session = session
         self.storage = storage
     }
 
     var destinationAddress: AlphaWallet.Address {
-        return transferType.contract
+        return transactionType.contract
     }
 
     var backgroundColor: UIColor {
@@ -25,7 +25,7 @@ struct SendViewModel {
     }
 
     var token: TokenObject? {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             return nil
         case .ERC20Token(let token, _, _):
@@ -63,11 +63,11 @@ struct SendViewModel {
     }
 
     var amountTextFieldPair: AmountTextField.Pair {
-        return AmountTextField.Pair(left: .cryptoCurrency(transferType.tokenObject), right: .usd)
+        return AmountTextField.Pair(left: .cryptoCurrency(transactionType.tokenObject), right: .usd)
     }
 
     var selectCurrencyButtonHidden: Bool {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             guard let currentTokenInfo = storage.tickers?[destinationAddress], currentTokenInfo.price_usd > 0 else {
                 return true
@@ -79,7 +79,7 @@ struct SendViewModel {
     }
 
     var currencyButtonHidden: Bool {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency, .ERC20Token:
             return false
         case .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .dapp, .tokenScript, .claimPaidErc875MagicLink:
@@ -88,15 +88,15 @@ struct SendViewModel {
     }
 
     var availableLabelText: String? {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             if let balance = session.balance {
                 let value = EtherNumberFormatter.plain.string(from: balance.value)
-                return R.string.localizable.sendAvailable("\(value) \(transferType.symbol)")
+                return R.string.localizable.sendAvailable("\(value) \(transactionType.symbol)")
             }
         case .ERC20Token(let token, _, _):
             let value = EtherNumberFormatter.plain.string(from: token.valueBigInt, decimals: token.decimals)
-            return R.string.localizable.sendAvailable("\(value) \(transferType.symbol)")
+            return R.string.localizable.sendAvailable("\(value) \(transactionType.symbol)")
         case .dapp, .ERC721ForTicketToken, .ERC721Token, .ERC875Token, .ERC875TokenOrder, .tokenScript, .claimPaidErc875MagicLink:
             break
         }
@@ -105,7 +105,7 @@ struct SendViewModel {
     }
 
     var availableTextHidden: Bool {
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             return session.balance == nil
         case .ERC20Token(let token, _, _):
@@ -119,7 +119,7 @@ struct SendViewModel {
 
     func validatedAmount(value amountString: String, checkIfGreaterThanZero: Bool = true) -> BigInt? {
         let parsedValue: BigInt? = {
-            switch transferType {
+            switch transactionType {
             case .nativeCryptocurrency, .dapp, .tokenScript, .claimPaidErc875MagicLink:
                 return EtherNumberFormatter.full.number(from: amountString, units: .ether)
             case .ERC20Token(let token, _, _):
@@ -139,7 +139,7 @@ struct SendViewModel {
             return nil
         }
 
-        switch transferType {
+        switch transactionType {
         case .nativeCryptocurrency:
             if let balance = session.balance, balance.value < value {
                 return nil

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -130,7 +130,7 @@ extension TransactionConfirmationViewModel {
         var ensName: String? { recipientResolver.ensName }
         var addressString: String? { recipientResolver.address?.eip55String }
         var openedSections = Set<Int>()
-        let transferType: TransferType
+        let transactionType: TransactionType
         let session: WalletSession
         let recipientResolver: RecipientResolver
         let ethPrice: Subscribable<Double>
@@ -141,7 +141,7 @@ extension TransactionConfirmationViewModel {
 
         init(configurator: TransactionConfigurator, assetDefinitionStore: AssetDefinitionStore, recipientResolver: RecipientResolver, amount: String, ethPrice: Subscribable<Double>) {
             self.configurator = configurator
-            self.transferType = configurator.transaction.transferType
+            self.transactionType = configurator.transaction.transactionType
             self.session = configurator.session
             self.assetDefinitionStore = assetDefinitionStore
             self.recipientResolver = recipientResolver
@@ -170,7 +170,7 @@ extension TransactionConfirmationViewModel {
         }
 
         var formattedAmountValue: String {
-            switch transferType {
+            switch transactionType {
             case .nativeCryptocurrency(let token, _, _):
                 let cryptoToDollarSymbol = Constants.Currency.usd
                 let double = Double(amount) ?? 0
@@ -370,7 +370,7 @@ extension TransactionConfirmationViewModel {
         }
 
         private let configurator: TransactionConfigurator
-        private let transferType: TransferType
+        private let transactionType: TransactionType
         private let session: WalletSession
         private let tokenInstanceName: String?
 
@@ -390,7 +390,7 @@ extension TransactionConfirmationViewModel {
 
         init(configurator: TransactionConfigurator, recipientResolver: RecipientResolver, ethPrice: Subscribable<Double>, tokenInstanceName: String?) {
             self.configurator = configurator
-            self.transferType = configurator.transaction.transferType
+            self.transactionType = configurator.transaction.transactionType
             self.session = configurator.session
             self.recipientResolver = recipientResolver
             self.ethPrice = ethPrice

--- a/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
@@ -8,7 +8,7 @@ class SendCoordinatorTests: XCTestCase {
 
     func testRootViewController() {
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(TokenObject(), destination: .none, amount: nil),
+            transactionType: .nativeCryptocurrency(TokenObject(), destination: .none, amount: nil),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),
@@ -27,7 +27,7 @@ class SendCoordinatorTests: XCTestCase {
     func testDestination() {
         let address: AlphaWallet.Address = .make()
         let coordinator = SendCoordinator(
-            transferType: .nativeCryptocurrency(TokenObject(), destination: .init(address: address), amount: nil),
+            transactionType: .nativeCryptocurrency(TokenObject(), destination: .init(address: address), amount: nil),
             navigationController: FakeNavigationController(),
             session: .make(),
             keystore: FakeKeystore(),

--- a/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
+++ b/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
@@ -6,7 +6,7 @@ import BigInt
 
 extension UnconfirmedTransaction {
     static func make(
-        transferType: TransferType = .nativeCryptocurrency(TokenObject(), destination: .none, amount: nil),
+        transactionType: TransactionType = .nativeCryptocurrency(TokenObject(), destination: .none, amount: nil),
         value: BigInt = BigInt(1),
         to: AlphaWallet.Address = .make(),
         data: Data = Data(),
@@ -15,7 +15,7 @@ extension UnconfirmedTransaction {
         nonce: BigInt? = BigInt(1)
     ) -> UnconfirmedTransaction {
         return UnconfirmedTransaction(
-            transferType: transferType,
+            transactionType: transactionType,
             value: value,
             recipient: nil,
             contract: to,


### PR DESCRIPTION
Normally wouldn't unnecessarily rename, but the name is just wrong.