### PR TITLE
Tweak gas label in actionsheet for transaction confirmation

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -494,9 +494,9 @@
 "transactionConfiguration.Type.fast" = "Fast";
 "transactionConfiguration.Type.rapid" = "Rapid";
 "transactionConfiguration.Type.custom" = "Custom (set your own)";
-"transactionConfiguration.Type.slow.time" = "> 10 minutes";
-"transactionConfiguration.Type.average.time" = "< 5 minutes";
-"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.slow.time" = "> 10 min";
+"transactionConfiguration.Type.average.time" = "< 5 min";
+"transactionConfiguration.Type.fast.time" = "< 2 min";
 "transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -494,9 +494,9 @@
 "transactionConfiguration.Type.fast" = "Fast";
 "transactionConfiguration.Type.rapid" = "Rapid";
 "transactionConfiguration.Type.custom" = "Custom (set your own)";
-"transactionConfiguration.Type.slow.time" = "> 10 minutes";
-"transactionConfiguration.Type.average.time" = "< 5 minutes";
-"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.slow.time" = "> 10 min";
+"transactionConfiguration.Type.average.time" = "< 5 min";
+"transactionConfiguration.Type.fast.time" = "< 2 min";
 "transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -494,9 +494,9 @@
 "transactionConfiguration.Type.fast" = "Fast";
 "transactionConfiguration.Type.rapid" = "Rapid";
 "transactionConfiguration.Type.custom" = "Custom (set your own)";
-"transactionConfiguration.Type.slow.time" = "> 10 minutes";
-"transactionConfiguration.Type.average.time" = "< 5 minutes";
-"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.slow.time" = "> 10 min";
+"transactionConfiguration.Type.average.time" = "< 5 min";
+"transactionConfiguration.Type.fast.time" = "< 2 min";
 "transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -494,9 +494,9 @@
 "transactionConfiguration.Type.fast" = "Fast";
 "transactionConfiguration.Type.rapid" = "Rapid";
 "transactionConfiguration.Type.custom" = "Custom (set your own)";
-"transactionConfiguration.Type.slow.time" = "> 10 minutes";
-"transactionConfiguration.Type.average.time" = "< 5 minutes";
-"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.slow.time" = "> 10 min";
+"transactionConfiguration.Type.average.time" = "< 5 min";
+"transactionConfiguration.Type.fast.time" = "< 2 min";
 "transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -494,9 +494,9 @@
 "transactionConfiguration.Type.fast" = "Fast";
 "transactionConfiguration.Type.rapid" = "Rapid";
 "transactionConfiguration.Type.custom" = "Custom (set your own)";
-"transactionConfiguration.Type.slow.time" = "> 10 minutes";
-"transactionConfiguration.Type.average.time" = "< 5 minutes";
-"transactionConfiguration.Type.fast.time" = "< 2 minutes";
+"transactionConfiguration.Type.slow.time" = "> 10 min";
+"transactionConfiguration.Type.average.time" = "< 5 min";
+"transactionConfiguration.Type.fast.time" = "< 2 min";
 "transactionConfiguration.Type.rapid.time" = "ASAP";
 "transactionConfirmation.Row.title.ens" = "ENS";
 "transactionConfirmation.Row.title.wallet" = "Wallet Address";

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -106,7 +106,7 @@ extension TransactionConfirmationViewModel {
             var title: String {
                 switch self {
                 case .gas:
-                    return R.string.localizable.transactionConfirmationSendSectionGasTitle()
+                    return R.string.localizable.tokenTransactionConfirmationGasTitle()
                 case .balance:
                     return R.string.localizable.transactionConfirmationSendSectionBalanceTitle()
                 case .amount:
@@ -249,7 +249,7 @@ extension TransactionConfirmationViewModel {
             var title: String {
                 switch self {
                 case .gas:
-                    return R.string.localizable.transactionConfirmationSendSectionGasTitle()
+                    return R.string.localizable.tokenTransactionConfirmationGasTitle()
                 case .amount:
                     return R.string.localizable.transactionConfirmationSendSectionAmountTitle()
                 }
@@ -360,7 +360,7 @@ extension TransactionConfirmationViewModel {
             var title: String {
                 switch self {
                 case .gas:
-                    return R.string.localizable.transactionConfirmationSendSectionGasTitle()
+                    return R.string.localizable.tokenTransactionConfirmationGasTitle()
                 case .recipient:
                     return R.string.localizable.transactionConfirmationSendSectionRecipientTitle()
                 case .tokenId:
@@ -456,7 +456,7 @@ extension TransactionConfirmationViewModel {
             var title: String {
                 switch self {
                 case .gas:
-                    return R.string.localizable.transactionConfirmationSendSectionGasTitle()
+                    return R.string.localizable.tokenTransactionConfirmationGasTitle()
                 case .amount:
                     return R.string.localizable.transactionConfirmationSendSectionAmountTitle()
                 case .numberOfTokens:

--- a/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
@@ -120,7 +120,7 @@ class TransactionConfirmationHeaderView: UIView {
             trailingStackView.heightAnchor.constraint(equalTo: row0.heightAnchor),
             placeholderLabel.topAnchor.constraint(equalTo: v1.topAnchor, constant: 5),
             placeholderLabel.leadingAnchor.constraint(equalTo: v1.leadingAnchor),
-            placeholderLabel.widthAnchor.constraint(equalToConstant: 60),
+            placeholderLabel.widthAnchor.constraint(equalToConstant: 80),
 
             titleLabel.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
 


### PR DESCRIPTION
Make the label "Speed (gas)" the same for all transaction types, and fix word wrap

Before PR (TokenScript transactions)|Before PR (others)|After PR (all transactions)
-|-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100072116-cf11c900-2e76-11eb-8a36-98bc674c314e.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100072090-c8835180-2e76-11eb-8560-1d0046b5cb9c.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100072121-d042f600-2e76-11eb-9206-be518f0a1ce9.png'>


