### PR TITLE
Show function names, args, and transaction value in actionsheet for TokenScript transactions

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -459,6 +459,7 @@
 "wallets.showSeedPhrase.subtitle.error" = "Do not share your backup. AlphaWallet team members will not ask for it.";
 "token.transactionConfirmation.gas.title" = "Speed (Gas)";
 "token.transactionConfirmation.contract.title" = "Contract";
+"token.transactionConfirmation.function.title" = "Function";
 "token.transactionConfirmation.default" = "Default";
 "token.transactionTransferConfirmation.title" = "Confirm Transfer?";
 "token.transactionPurchaseConfirmation.title" = "Confirm Purchase?";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -459,6 +459,7 @@
 "wallets.showSeedPhrase.subtitle.error" = "No compartas tu copia de seguridad. Los miembros del equipo de AlphaWallet nunca te la pedirán.";
 "token.transactionConfirmation.gas.title" = "Speed (Gas)";
 "token.transactionConfirmation.contract.title" = "Contract";
+"token.transactionConfirmation.function.title" = "Function";
 "token.transactionConfirmation.default" = "Default";
 "token.transactionTransferConfirmation.title" = "Confirm Transfer?";
 "token.transactionPurchaseConfirmation.title" = "Confirm Purchase?";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -459,6 +459,7 @@
 "wallets.showSeedPhrase.subtitle.error" = "バックアップを共有しないでください。 AlphaWalletチームのメンバーはそれを要求しません。";
 "token.transactionConfirmation.gas.title" = "Speed (Gas)";
 "token.transactionConfirmation.contract.title" = "Contract";
+"token.transactionConfirmation.function.title" = "Function";
 "token.transactionConfirmation.default" = "Default";
 "token.transactionTransferConfirmation.title" = "Confirm Transfer?";
 "token.transactionPurchaseConfirmation.title" = "Confirm Purchase?";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -459,6 +459,7 @@
 "wallets.showSeedPhrase.subtitle.error" = "백업을 공유하지 마십시오. AlphaWallet 팀원은 요청하지 않습니다.";
 "token.transactionConfirmation.gas.title" = "Speed (Gas)";
 "token.transactionConfirmation.contract.title" = "Contract";
+"token.transactionConfirmation.function.title" = "Function";
 "token.transactionConfirmation.default" = "Default";
 "token.transactionTransferConfirmation.title" = "Confirm Transfer?";
 "token.transactionPurchaseConfirmation.title" = "Confirm Purchase?";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -459,6 +459,7 @@
 "wallets.showSeedPhrase.subtitle.error" = "请勿将备份文件分享给他人。AlphaWallet 团队成员绝不会向您索要备份。";
 "token.transactionConfirmation.gas.title" = "Speed (Gas)";
 "token.transactionConfirmation.contract.title" = "Contract";
+"token.transactionConfirmation.function.title" = "Function";
 "token.transactionConfirmation.default" = "Default";
 "token.transactionTransferConfirmation.title" = "Confirm Transfer?";
 "token.transactionPurchaseConfirmation.title" = "Confirm Purchase?";

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -660,8 +660,8 @@ extension SingleChainTokenCoordinator: TransactionConfirmationCoordinatorDelegat
 extension SingleChainTokenCoordinator: TokenInstanceActionViewControllerDelegate {
     func confirmTransactionSelected(in viewController: TokenInstanceActionViewController, tokenObject: TokenObject, contract: AlphaWallet.Address, tokenId: TokenId, values: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue], server: RPCServer, session: WalletSession, keystore: Keystore, transactionFunction: FunctionOrigin) {
         switch transactionFunction.makeUnConfirmedTransaction(withTokenObject: tokenObject, tokenId: tokenId, attributeAndValues: values, localRefs: localRefs, server: server, session: session) {
-        case .success(let transaction):
-            let coordinator = TransactionConfirmationCoordinator(navigationController: navigationController, session: session, transaction: transaction, configuration: .tokenScriptTransaction(confirmType: .signThenSend, contract: contract, keystore: keystore, ethPrice: cryptoPrice), analyticsCoordinator: analyticsCoordinator)
+        case .success(let transaction, let functionCallMetaData):
+            let coordinator = TransactionConfirmationCoordinator(navigationController: navigationController, session: session, transaction: transaction, configuration: .tokenScriptTransaction(confirmType: .signThenSend, contract: contract, keystore: keystore, functionCallMetaData: functionCallMetaData, ethPrice: cryptoPrice), analyticsCoordinator: analyticsCoordinator)
             coordinator.delegate = self
             addCoordinator(coordinator)
             coordinator.start()

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -697,8 +697,8 @@ extension TokensCardCoordinator: StaticHTMLViewControllerDelegate {
 extension TokensCardCoordinator: TokenInstanceActionViewControllerDelegate {
     func confirmTransactionSelected(in viewController: TokenInstanceActionViewController, tokenObject: TokenObject, contract: AlphaWallet.Address, tokenId: TokenId, values: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue], server: RPCServer, session: WalletSession, keystore: Keystore, transactionFunction: FunctionOrigin) {
         switch transactionFunction.makeUnConfirmedTransaction(withTokenObject: tokenObject, tokenId: tokenId, attributeAndValues: values, localRefs: localRefs, server: server, session: session) {
-        case .success(let transaction):
-            let coordinator = TransactionConfirmationCoordinator(navigationController: navigationController, session: session, transaction: transaction, configuration: .tokenScriptTransaction(confirmType: .signThenSend, contract: contract, keystore: keystore, ethPrice: ethPrice), analyticsCoordinator: analyticsCoordinator)
+        case .success(let transaction, let functionCallMetaData):
+            let coordinator = TransactionConfirmationCoordinator(navigationController: navigationController, session: session, transaction: transaction, configuration: .tokenScriptTransaction(confirmType: .signThenSend, contract: contract, keystore: keystore, functionCallMetaData: functionCallMetaData, ethPrice: ethPrice), analyticsCoordinator: analyticsCoordinator)
             coordinator.delegate = self
             addCoordinator(coordinator)
             coordinator.start()

--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -11,28 +11,28 @@ import PromiseKit
 import Result
 
 enum TransactionConfirmationConfiguration {
-    case tokenScriptTransaction(confirmType: ConfirmType, contract: AlphaWallet.Address, keystore: Keystore, ethPrice: Subscribable<Double>)
+    case tokenScriptTransaction(confirmType: ConfirmType, contract: AlphaWallet.Address, keystore: Keystore, functionCallMetaData: FunctionCallMetaData, ethPrice: Subscribable<Double>)
     case dappTransaction(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>)
     case sendFungiblesTransaction(confirmType: ConfirmType, keystore: Keystore, assetDefinitionStore: AssetDefinitionStore, amount: String, ethPrice: Subscribable<Double>)
     case sendNftTransaction(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>, tokenInstanceName: String?)
     case claimPaidErc875MagicLink(confirmType: ConfirmType, keystore: Keystore, price: BigUInt, ethPrice: Subscribable<Double>, numberOfTokens: UInt)
     var confirmType: ConfirmType {
         switch self {
-        case .dappTransaction(let confirmType, _, _), .sendFungiblesTransaction(let confirmType, _, _, _, _), .sendNftTransaction(let confirmType, _, _, _), .tokenScriptTransaction(let confirmType, _, _, _), .claimPaidErc875MagicLink(let confirmType, _, _, _, _):
+        case .dappTransaction(let confirmType, _, _), .sendFungiblesTransaction(let confirmType, _, _, _, _), .sendNftTransaction(let confirmType, _, _, _), .tokenScriptTransaction(let confirmType, _, _, _, _), .claimPaidErc875MagicLink(let confirmType, _, _, _, _):
             return confirmType
         }
     }
 
     var keystore: Keystore {
         switch self {
-        case .dappTransaction(_, let keystore, _), .sendFungiblesTransaction(_, let keystore, _, _, _), .sendNftTransaction(_, let keystore, _, _), .tokenScriptTransaction(_, _, let keystore, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _):
+        case .dappTransaction(_, let keystore, _), .sendFungiblesTransaction(_, let keystore, _, _, _), .sendNftTransaction(_, let keystore, _, _), .tokenScriptTransaction(_, _, let keystore, _, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _):
             return keystore
         }
     }
 
     var ethPrice: Subscribable<Double> {
         switch self {
-        case .dappTransaction(_, _, let ethPrice), .sendFungiblesTransaction(_, _, _, _, let ethPrice), .sendNftTransaction(_, _, let ethPrice, _), .tokenScriptTransaction(_, _, _, let ethPrice), .claimPaidErc875MagicLink(_, _, _, let ethPrice, _):
+        case .dappTransaction(_, _, let ethPrice), .sendFungiblesTransaction(_, _, _, _, let ethPrice), .sendNftTransaction(_, _, let ethPrice, _), .tokenScriptTransaction(_, _, _, _, let ethPrice), .claimPaidErc875MagicLink(_, _, _, let ethPrice, _):
             return ethPrice
         }
     }

--- a/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
@@ -467,12 +467,25 @@ extension TransactionConfirmationViewController {
             for (sectionIndex, section) in viewModel.sections.enumerated() {
                 let header = TransactionConfirmationHeaderView(viewModel: viewModel.headerViewModel(section: sectionIndex))
                 header.delegate = self
+                var children: [UIView] = []
                 switch section {
                 case .gas:
                     header.setEditButton(section: sectionIndex, self, selector: #selector(editTransactionButtonTapped))
-                case .contract:
+                case .function:
+                    let isSubViewsHidden = viewModel.isSubviewsHidden(section: sectionIndex)
+                    let view = TransactionConfirmationRowInfoView(viewModel: .init(title: "\(viewModel.functionCallMetaData.name)()", subtitle: ""))
+                    view.isHidden = isSubViewsHidden
+                    children.append(view)
+
+                    for (type, value) in viewModel.functionCallMetaData.arguments {
+                        let view = TransactionConfirmationRowInfoView(viewModel: .init(title: type.description, subtitle: value.description))
+                        view.isHidden = isSubViewsHidden
+                        children.append(view)
+                    }
+                case .contract, .amount:
                     break
                 }
+                header.childrenStackView.addArrangedSubviews(children)
                 views.append(header)
             }
         case .sendFungiblesTransaction(let viewModel):


### PR DESCRIPTION
"Enable" Before PR:

<img width='200' src='https://user-images.githubusercontent.com/56189/100177266-b3590200-2f0c-11eb-92f9-845720f3d120.png'>

"Enable" After PR|"Enable" After PR (expanded)
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100177768-a7ba0b00-2f0d-11eb-835a-b9ed23a2a385.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100177777-abe62880-2f0d-11eb-88bb-ac6b93855fc4.png'>

Wrap WETH After PR|Wrap WETH After PR (expanded)
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100177846-ca4c2400-2f0d-11eb-8831-69e0f2488561.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100177856-cd471480-2f0d-11eb-9da1-3f3343294b24.png'>

Unwrap WETH after PR|Unwrap WETH after PR (expanded)
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100178014-18612780-2f0e-11eb-9d0b-bf1aa11c291a.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100177897-e223a800-2f0d-11eb-898c-89626b558e7f.png'>
