### PR TITLE
Hotfix: Crash if tap camera button while importing a wallet while onboarding #2352

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -5376,7 +5376,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 365;
+				CURRENT_PROJECT_VERSION = 366;
 				DEVELOPMENT_TEAM = LRAW5PL536;
 				ENABLE_BITCODE = YES;
 				HEADER_SEARCH_PATHS = (
@@ -5418,7 +5418,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 365;
+				CURRENT_PROJECT_VERSION = 366;
 				DEVELOPMENT_TEAM = LRAW5PL536;
 				ENABLE_BITCODE = YES;
 				HEADER_SEARCH_PATHS = (
@@ -5535,7 +5535,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 365;
+				CURRENT_PROJECT_VERSION = 366;
 				DEVELOPMENT_TEAM = LRAW5PL536;
 				INFOPLIST_FILE = AlphaWalletShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -5560,7 +5560,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 365;
+				CURRENT_PROJECT_VERSION = 366;
 				DEVELOPMENT_TEAM = LRAW5PL536;
 				INFOPLIST_FILE = AlphaWalletShare/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
@@ -14,13 +14,14 @@ final class ScanQRCodeCoordinator: NSObject, Coordinator {
     private lazy var navigationController = UINavigationController(rootViewController: qrcodeController)
     private lazy var reader = QRCodeReader(metadataObjectTypes: [AVMetadataObject.ObjectType.qr])
     private lazy var qrcodeController: QRCodeReaderViewController = {
+        let shouldShowMyQRCodeButton = account != nil
         let controller = QRCodeReaderViewController(
             cancelButtonTitle: nil,
             codeReader: reader,
             startScanningAtLoad: true,
             showSwitchCameraButton: false,
             showTorchButton: true,
-            showMyQRCodeButton: true,
+            showMyQRCodeButton: shouldShowMyQRCodeButton,
             chooseFromPhotoLibraryButtonTitle: R.string.localizable.photos(),
             bordersColor: Colors.qrCodeRectBorders,
             messageText: R.string.localizable.qrCodeTitle(),
@@ -37,14 +38,14 @@ final class ScanQRCodeCoordinator: NSObject, Coordinator {
 
         return controller
     }()
-    private let account: Wallet
+    private let account: Wallet?
     private let server: RPCServer
 
     let parentNavigationController: UINavigationController
     var coordinators: [Coordinator] = []
     weak var delegate: ScanQRCodeCoordinatorDelegate?
 
-    init(navigationController: UINavigationController, account: Wallet, server: RPCServer) {
+    init(navigationController: UINavigationController, account: Wallet?, server: RPCServer) {
         self.account = account
         self.server = server
         self.parentNavigationController = navigationController
@@ -82,6 +83,8 @@ extension ScanQRCodeCoordinator: QRCodeReaderDelegate {
     }
 
     func reader(_ reader: QRCodeReaderViewController!, myQRCodeSelected sender: UIButton!) {
+        //Showing QR code functionality is not available if there's no account, specifically when importing wallet during onboarding
+        guard let account = account else { return }
         let coordinator = RequestCoordinator(account: account, server: server)
         coordinator.delegate = self
         coordinator.start()

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -168,7 +168,7 @@ extension WalletCoordinator: ImportWalletViewControllerDelegate {
 
     func openQRCode(in controller: ImportWalletViewController) {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.currentWallet, server: config.server)
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.recentlyUsedWallet, server: config.server)
         coordinator.delegate = self
 
         addCoordinator(coordinator)


### PR DESCRIPTION
Fixes #2352. This is based on the `3.11` (365) tag, which was submitted to the appstore (there's a number of commits to master since the submission)

Also disables the "Show My QR Code" button which is related to the crash. It shouldn't be displayed when importing a wallet during onboarding.

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/100822329-0db60d80-348d-11eb-8f3d-ecf59b248cec.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/100822333-10b0fe00-348d-11eb-8c0a-4e04fdddb87c.png'>

TODOs after merge into `3.11-appstore`:

- [ ] Submit again using `3.11-appstore`
- [ ] Delete `3.11`
- [ ] Tag `3.11-appstore` as `3.11`
- [ ] Push `3.11` and update https://github.com/AlphaWallet/alpha-wallet-ios/releases/tag/3.11
- [ ] Create PR to merge the first commit into master
