### PR TITLE
Expand hit test area for Recipient cell in actionsheet for transaction confirmation so that when it's expanded, tapping on the expanded area closes it too (like it does when tapping the upper half of the cell)

### DIFF
--- a/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
@@ -106,11 +106,9 @@ class TransactionConfirmationHeaderView: UIView {
             .spacer(height: ScreenChecker().isNarrowScreen ? 10 : 20)
         ]
 
-        for view in headerViews {
-            view.isUserInteractionEnabled = true
-            let tap = UITapGestureRecognizer(target: self, action: #selector(didTap))
-            view.addGestureRecognizer(tap)
-        }
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTap))
+        isUserInteractionEnabled = true
+        addGestureRecognizer(tap)
 
         let stackView = (headerViews + [childrenStackView]).asStackView(axis: .vertical)
 


### PR DESCRIPTION
The highlighted area didn't register tap before this PR:

<img width="287" alt="Screenshot 2020-12-04 at 4 02 41 PM" src="https://user-images.githubusercontent.com/56189/101138019-97f7a080-364a-11eb-9e26-b3b72b10b4f5.png">
