### PR TITLE
Refresh custom gas values in actionsheet txn while editing

### DIFF
--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -73,12 +73,12 @@ class ConfigureTransactionViewController: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
 
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
     }
 
     func configure(viewModel: ConfigureTransactionViewModel) {
         self.viewModel = viewModel
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
         tableView.reloadData()
     }
 
@@ -89,7 +89,7 @@ class ConfigureTransactionViewController: UIViewController {
         configuration.setEstimated(gasLimit: value)
         updatedViewModel.configurationToEdit = EditedTransactionConfiguration(configuration: configuration)
         viewModel = updatedViewModel
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
         tableView.reloadData()
     }
 
@@ -101,7 +101,7 @@ class ConfigureTransactionViewController: UIViewController {
         updatedViewModel.configurationToEdit = EditedTransactionConfiguration(configuration: configuration)
         updatedViewModel.configurations = configurator.configurations
         viewModel = updatedViewModel
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
         tableView.reloadData()
     }
 
@@ -113,7 +113,7 @@ class ConfigureTransactionViewController: UIViewController {
         updatedViewModel.configurationToEdit = EditedTransactionConfiguration(configuration: configuration)
         updatedViewModel.configurations = configurator.configurations
         viewModel = updatedViewModel
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
         tableView.reloadData()
     }
 
@@ -169,8 +169,12 @@ class ConfigureTransactionViewController: UIViewController {
         return footer
     }
 
-    private func recalculateTotalFee() {
+    private func recalculateTotalFeeForCustomGas() {
         cells.totalFee.value = viewModel.gasViewModel.feeText
+        let configurationTypes = viewModel.configurationTypes
+        if let indexPath = configurationTypes.index(of: .custom).flatMap { IndexPath(row: $0, section: ConfigureTransactionViewModel.Section.configurationTypes.rawValue) }, let cell = tableView.cellForRow(at: indexPath) as? GasSpeedTableViewCell {
+            cell.configure(viewModel: viewModel.gasSpeedViewModel(indexPath: indexPath))
+        }
     }
 
     @objc private func saveButtonSelected(_ sender: UIBarButtonItem) {
@@ -305,7 +309,7 @@ extension ConfigureTransactionViewController: SliderTableViewCellDelegate {
             cells.gasPrice.configureSliderRange(viewModel: viewModel.gasPriceSliderViewModel)
         }
 
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
     }
 
     func cell(_ cell: SliderTableViewCell, valueDidChange value: Int) {
@@ -315,7 +319,7 @@ extension ConfigureTransactionViewController: SliderTableViewCellDelegate {
             viewModel.configurationToEdit.gasPriceRawValue = value
         }
 
-        recalculateTotalFee()
+        recalculateTotalFeeForCustomGas()
     }
 }
 
@@ -405,7 +409,7 @@ extension ConfigureTransactionViewController: TextFieldDelegate {
 }
 
 extension UIBarButtonItem {
-    
+
     static func saveBarButton(_ target: AnyObject, selector: Selector) -> UIBarButtonItem {
         .init(title: R.string.localizable.save(), style: .plain, target: target, action: selector)
     }

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -247,7 +247,7 @@ extension ConfigureTransactionViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.numberOfSections(in: section)
+        viewModel.numberOfRowsInSections(in: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -8,7 +8,11 @@ struct ConfigureTransactionViewModel {
     let server: RPCServer
     let ethPrice: Subscribable<Double>
     let transactionType: TransactionType
-    var configurationToEdit: EditedTransactionConfiguration
+    var configurationToEdit: EditedTransactionConfiguration {
+        didSet {
+            configurations.custom = configurationToEdit.configuration
+        }
+    }
     var configurationTypes: [TransactionConfigurationType]
     var configurations: TransactionConfigurations {
         didSet {

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -109,7 +109,7 @@ struct ConfigureTransactionViewModel {
         return .init(placeholder: placeholder, value: gasViewModel.feeText, allowEditing: false)
     }
 
-    func numberOfSections(in section: Int) -> Int {
+    func numberOfRowsInSections(in section: Int) -> Int {
         switch sections[section] {
         case .configurationTypes:
             return configurationTypes.count


### PR DESCRIPTION
Fixes #2359 

If testing, note that Ethereum mainnet and others (especially testnets), have different number of gas options, so different index for the Custom cell which is being updated.