### PR TITLE
Make gas limit and gas fee exceed threshold error messages appear immediately rather than wait until user taps Save button

### DIFF
--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -50,6 +50,22 @@ class TransactionConfigurator {
         }
     }
 
+    enum GasLimitWarning {
+        case tooHighCustomGasLimit
+
+        var description: String {
+            ConfigureTransactionError.gasLimitTooHigh.localizedDescription
+        }
+    }
+
+    enum GasFeeWarning {
+        case tooHighGasFee
+
+        var description: String {
+            ConfigureTransactionError.gasFeeTooHigh.localizedDescription
+        }
+    }
+
     private let account: AlphaWallet.Address
 
     private var isGasLimitSpecifiedByTransaction: Bool {
@@ -222,6 +238,20 @@ class TransactionConfigurator {
         }.recover { _ in
             .value(GasEstimates(standard: GasPriceConfiguration.defaultPrice))
         }
+    }
+
+    func gasLimitWarning(forConfiguration configuration: TransactionConfiguration) -> GasLimitWarning? {
+        if configuration.gasLimit > ConfigureTransaction.gasLimitMax {
+            return .tooHighCustomGasLimit
+        }
+        return nil
+    }
+
+    func gasFeeWarning(forConfiguration configuration: TransactionConfiguration) -> GasFeeWarning? {
+        if (configuration.gasPrice * configuration.gasLimit) > ConfigureTransaction.gasFeeMax {
+            return .tooHighGasFee
+        }
+        return nil
     }
 
     func gasPriceWarning(forConfiguration configuration: TransactionConfiguration) -> GasPriceWarning? {

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -248,6 +248,8 @@ class ConfigureTransactionViewController: UIViewController {
             cell.configure(viewModel: viewModel.gasSpeedViewModel(indexPath: indexPath))
         }
         showGasPriceWarning()
+        showGasLimitWarning()
+        showGasFeeWarning()
         tableView.tableFooterView = createTableFooter()
     }
 
@@ -256,6 +258,34 @@ class ConfigureTransactionViewController: UIViewController {
             cells.gasPrice.textField.status = .none
         } else {
             cells.gasPrice.textField.status = .error("")
+        }
+    }
+
+    private func showGasLimitWarning() {
+        if let warning = viewModel.gasLimitWarning {
+            cells.gasLimit.textField.status = .error(warning.description)
+        } else {
+            cells.gasLimit.textField.status = .none
+        }
+        refreshCellsWithoutAnimation()
+    }
+
+    private func showGasFeeWarning() {
+        if let warning = viewModel.gasFeeWarning {
+            cells.totalFee.textField.status = .error(warning.description)
+        } else {
+            cells.totalFee.textField.status = .none
+        }
+        refreshCellsWithoutAnimation()
+    }
+
+    private func refreshCellsWithoutAnimation() {
+        //async needed otherwise it crashes when view controller is just created
+        DispatchQueue.main.async {
+            UIView.setAnimationsEnabled(false)
+            self.tableView.beginUpdates()
+            self.tableView.endUpdates()
+            UIView.setAnimationsEnabled(true)
         }
     }
 

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -30,6 +30,14 @@ struct ConfigureTransactionViewModel {
         configurator.gasPriceWarning(forConfiguration: configurationToEdit.configuration)
     }
 
+    var gasLimitWarning: TransactionConfigurator.GasLimitWarning? {
+        configurator.gasLimitWarning(forConfiguration: configurationToEdit.configuration)
+    }
+
+    var gasFeeWarning: TransactionConfigurator.GasFeeWarning? {
+        configurator.gasFeeWarning(forConfiguration: configurationToEdit.configuration)
+    }
+
     var gasViewModel: GasViewModel {
         return GasViewModel(fee: totalFee, symbol: server.symbol, currencyRate: currencyRate, formatter: fullFormatter)
     }


### PR DESCRIPTION
Before the PR, the red border around the textboxes and error messages only appear when the Save button is tapped.

After the PR, they (dis)appear as the user is typing.

<img width='200' src='https://user-images.githubusercontent.com/56189/101861816-f0c7bb80-3bab-11eb-8e9b-909a4d67a543.png'>
