### PR TITLE
Fix: custom gas price appears as 1 in edit custom gas screen if we set it to >= 1000 and saved it

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/EditedTransactionConfiguration.swift
+++ b/AlphaWallet/Transfer/ViewModels/EditedTransactionConfiguration.swift
@@ -70,7 +70,7 @@ struct EditedTransactionConfiguration {
 
     init(configuration: TransactionConfiguration) {
         gasLimitRawValue = Int(configuration.gasLimit.description) ?? 21000
-        gasPriceRawValue = formatter.string(from: configuration.gasPrice, units: UnitConfiguration.gasPriceUnit).numberValue?.intValue ?? 1
+        gasPriceRawValue = Int(configuration.gasPrice / BigInt(UnitConfiguration.gasPriceUnit.rawValue))
         nonceRawValue = Int(configuration.nonce.flatMap { String($0) } ?? "")
         dataRawValue = configuration.data.hexEncoded.add0x
 


### PR DESCRIPTION
Fixes #2385 

Little chance of it happening, but still.