### PR TITLE
Refactor to fix unnecessary/wrong access to "current chain id"

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -326,7 +326,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     private func scanQrCode() {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
 
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
         coordinator.delegate = self
         addCoordinator(coordinator)
         coordinator.start()

--- a/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
@@ -85,24 +85,25 @@ private enum CheckEIP681Error: Error {
 }
 
 final class QRCodeResolutionCoordinator: Coordinator {
+    enum Usage {
+        case all(tokensDatastores: [TokensDataStore], assetDefinitionStore: AssetDefinitionStore)
+        case importWalletOnly
+    }
 
-    private let tokensDatastores: [TokensDataStore]?
-    private let assetDefinitionStore: AssetDefinitionStore?
+    private let config: Config
+    private let usage: Usage
     private var skipResolvedCodes: Bool = false
     private var navigationController: UINavigationController {
         scanQRCodeCoordinator.parentNavigationController
     }
     private let scanQRCodeCoordinator: ScanQRCodeCoordinator
-    private var rpcServer: RPCServer {
-        return Config().server
-    }
     var coordinators: [Coordinator] = []
     weak var delegate: QRCodeResolutionCoordinatorDelegate?
 
-    init(coordinator: ScanQRCodeCoordinator, tokensDatastores: [TokensDataStore]?, assetDefinitionStore: AssetDefinitionStore?) {
-        self.tokensDatastores = tokensDatastores
+    init(config: Config, coordinator: ScanQRCodeCoordinator, usage: Usage) {
+        self.config = config
+        self.usage = usage
         self.scanQRCodeCoordinator = coordinator
-        self.assetDefinitionStore = assetDefinitionStore
     }
 
     func start() {
@@ -127,16 +128,16 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
     }
 
     private func availableActions(forContract contract: AlphaWallet.Address) -> [ScanQRCodeAction] {
-        //NOTE: or maybe we need pass though all servers?
-        guard let tokensDatastore = tokensDatastores?.first(where: { $0.server == rpcServer }) else {
-            return []
-        }
-
-        //I guess if we have token, we shouldn't be able to send to it, or we should?
-        if tokensDatastore.token(forContract: contract) != nil {
-            return [.sendToAddress, .watchWallet, .openInEtherscan]
-        } else {
-            return [.sendToAddress, .addCustomToken, .watchWallet, .openInEtherscan]
+        switch usage {
+        case .all(let tokensDataStores, _):
+            let isTokenFound = tokensDataStores.contains { $0.token(forContract: contract) != nil } ?? false
+            if isTokenFound {
+                return [.sendToAddress, .watchWallet, .openInEtherscan]
+            } else {
+                return [.sendToAddress, .addCustomToken, .watchWallet, .openInEtherscan]
+            }
+        case .importWalletOnly:
+            return [.watchWallet]
         }
     }
 
@@ -148,8 +149,8 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
             switch value {
             case .address(let contract):
                 let actions = availableActions(forContract: contract)
-                if actions.isEmpty {
-                    delegate.coordinator(self, didResolveAddress: contract, action: .watchWallet)
+                if actions.count == 1 {
+                    delegate.coordinator(self, didResolveAddress: contract, action: actions[0])
                 } else {
                     showDidScanWalletAddress(for: actions, completion: { action in
                         delegate.coordinator(self, didResolveAddress: contract, action: action)
@@ -158,12 +159,17 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
                     })
                 }
             case .eip681(let protocolName, let address, let function, let params):
-                guard let tokensDatastores = tokensDatastores, let assetDefinitionStore = assetDefinitionStore else { return }
-                let data = CheckEIP681Params(protocolName: protocolName, address: address, functionName: function, params: params, rpcServer: rpcServer)
-
-                self.checkEIP681(data, tokensDatastores: tokensDatastores, assetDefinitionStore: assetDefinitionStore).done { result in
-                    delegate.coordinator(self, didResolveTransactionType: result.transactionType, token: result.token)
-                }.cauterize()
+                let data = CheckEIP681Params(protocolName: protocolName, address: address, functionName: function, params: params)
+                switch usage {
+                case .all(let tokensDataStores, let assetDefinitionStore):
+                    firstly {
+                        checkEIP681(data, tokensDatastores: tokensDataStores, assetDefinitionStore: assetDefinitionStore)
+                    }.done { result in
+                        delegate.coordinator(self, didResolveTransactionType: result.transactionType, token: result.token)
+                    }.cauterize()
+                case .importWalletOnly:
+                    break
+                }
             }
         case .other(let value):
             delegate.coordinator(self, didResolveString: value)
@@ -233,26 +239,19 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
         let address: AddressOrEnsName
         let functionName: String?
         let params: [String: String]
-        let rpcServer: RPCServer
     }
 
     private func checkEIP681(_ params: CheckEIP681Params, tokensDatastores: [TokensDataStore], assetDefinitionStore: AssetDefinitionStore) -> Promise<(transactionType: TransactionType, token: TokenObject)> {
-        return Eip681Parser(protocolName: params.protocolName, address: params.address, functionName: params.functionName, params: params.params).parse().then { result -> Promise<(transactionType: TransactionType, token: TokenObject)> in
-            guard let (contract: contract, customServer, recipient, maybeScientificAmountString) = result.parameters else {
-                return .init(error: CheckEIP681Error.parameterInvalid)
-            }
-
-            guard let storage = tokensDatastores.first(where: { $0.server == customServer ?? params.rpcServer }) else {
-                return .init(error: CheckEIP681Error.missingRpcServer)
-            }
+        Eip681Parser(protocolName: params.protocolName, address: params.address, functionName: params.functionName, params: params.params).parse().then { result -> Promise<(transactionType: TransactionType, token: TokenObject)> in
+            guard let (contract: contract, customServer, recipient, maybeScientificAmountString) = result.parameters else { return .init(error: CheckEIP681Error.parameterInvalid) }
+            guard let server = self.serverFromEip681LinkOrDefault(customServer) else { return .init(error: CheckEIP681Error.missingRpcServer) }
+            guard let storage = tokensDatastores.first(where: { $0.server == server }) else { return .init(error: CheckEIP681Error.missingRpcServer) }
 
             if let token = storage.token(forContract: contract) {
                 let amount = maybeScientificAmountString.scientificAmountToBigInt.flatMap {
                     EtherNumberFormatter.full.string(from: $0, decimals: token.decimals)
                 }
-
                 let transactionType = TransactionType(token: token, recipient: recipient, amount: amount)
-
                 return .value((transactionType, token))
             } else {
                 return Promise { resolver in
@@ -281,6 +280,18 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
                 }
             }
         }
+    }
+
+    private func serverFromEip681LinkOrDefault(_ serverInLink: RPCServer?) -> RPCServer? {
+        let server: RPCServer
+        if let serverInLink = serverInLink {
+            return serverInLink
+        }
+        if config.enabledServers.count == 1 {
+            //Specs https://eips.ethereum.org/EIPS/eip-681 says we should fallback to the current chainId, but since we support multiple chains at the same time, we only fallback if there is exactly 1 enabled network
+            return config.enabledServers.first!
+        }
+        return nil
     }
 }
 

--- a/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
@@ -173,7 +173,7 @@ extension QRCodeResolutionCoordinator: ScanQRCodeCoordinatorDelegate {
             showOpenURL(completion: {
                 delegate.coordinator(self, didResolveURL: url)
             }, cancelCompletion: {
-                //NOTE: we need to reset flat to false to make sure that next detected QR code will be handled
+                //NOTE: we need to reset flag to false to make sure that next detected QR code will be handled
                 self.skipResolvedCodes = false
             })
         case .json(let value):

--- a/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
@@ -39,15 +39,13 @@ final class ScanQRCodeCoordinator: NSObject, Coordinator {
         return controller
     }()
     private let account: Wallet?
-    private let server: RPCServer
 
     let parentNavigationController: UINavigationController
     var coordinators: [Coordinator] = []
     weak var delegate: ScanQRCodeCoordinatorDelegate?
 
-    init(navigationController: UINavigationController, account: Wallet?, server: RPCServer) {
+    init(navigationController: UINavigationController, account: Wallet?) {
         self.account = account
-        self.server = server
         self.parentNavigationController = navigationController
     }
 
@@ -85,7 +83,7 @@ extension ScanQRCodeCoordinator: QRCodeReaderDelegate {
     func reader(_ reader: QRCodeReaderViewController!, myQRCodeSelected sender: UIButton!) {
         //Showing QR code functionality is not available if there's no account, specifically when importing wallet during onboarding
         guard let account = account else { return }
-        let coordinator = RequestCoordinator(account: account, server: server)
+        let coordinator = RequestCoordinator(account: account)
         coordinator.delegate = self
         coordinator.start()
         addCoordinator(coordinator)

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "Refresh" = "Refresh";
 "request.addressCopied.title" = "Address copied";
 "request.copyWallet.button.title" = "Copy wallet address";
-"request.myAddressIs.label.title" = "My %1$@ address is: %2$@";
 "Retry" = "Retry";
 "Send" = "Send";
 "Receive" = "Receive";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "Refresh" = "Actualizar";
 "request.addressCopied.title" = "Dirección copiada";
 "request.copyWallet.button.title" = "Copiar la dirección del monedero";
-"request.myAddressIs.label.title" = "Mi dirección de %1$@ es: %2$@";
 "Retry" = "Reintentar";
 "Send" = "Enviar";
 "Receive" = "Recibir";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "Refresh" = "リフレッシュ";
 "request.addressCopied.title" = "アドレスがコピーされました";
 "request.copyWallet.button.title" = "ウォレットのアドレスをコピー";
-"request.myAddressIs.label.title" = "私の %1$@ のアドレス: %2$@";
 "Retry" = "再試行";
 "Send" = "送信";
 "Receive" = "Receive";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "Refresh" = "새로 고침";
 "request.addressCopied.title" = "주소가 복사되었습니다";
 "request.copyWallet.button.title" = "지갑 주소 복사";
-"request.myAddressIs.label.title" = "내 %1$@ 주소: %2$@";
 "Retry" = "다시 시도";
 "Send" = "보내기";
 "Receive" = "Receive";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "Refresh" = "刷新";
 "request.addressCopied.title" = "地址已复制";
 "request.copyWallet.button.title" = "复制钱包地址";
-"request.myAddressIs.label.title" = "我的%1$@地址是： %2$@";
 "Retry" = "重试";
 "Send" = "发送";
 "Receive" = "接收";

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -58,6 +58,7 @@ struct Config {
         defaults.set(chainId, forKey: Keys.chainID)
     }
 
+    //TODO Only Dapp browser uses this
     static func getChainId(defaults: UserDefaults = UserDefaults.standard) -> Int {
         let id = defaults.integer(forKey: Keys.chainID)
         guard id > 0 else { return RPCServer.main.chainID }
@@ -140,6 +141,7 @@ struct Config {
         }
     }
 
+    //TODO Only Dapp browser uses this. Shall we move it?
     var server: RPCServer {
         let chainId = Config.getChainId()
         if let server = enabledServers.first(where: { $0.chainID == chainId }) {

--- a/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
@@ -196,7 +196,7 @@ extension NewTokenCoordinator: NewTokenViewControllerDelegate {
         guard let nc = controller.navigationController, nc.ensureHasDeviceAuthorization() else { return }
 
         let session = sessions[config.server]
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
         coordinator.delegate = self
         addCoordinator(coordinator)
 

--- a/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
@@ -195,8 +195,8 @@ extension NewTokenCoordinator: NewTokenViewControllerDelegate {
     func openQRCode(in controller: NewTokenViewController) {
         guard let nc = controller.navigationController, nc.ensureHasDeviceAuthorization() else { return }
 
-        let session = sessions[config.server]
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
+        let account = sessions.anyValue.account
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: account)
         coordinator.delegate = self
         addCoordinator(coordinator)
 

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import UIKit
-import PromiseKit 
+import PromiseKit
 
 protocol TokensCoordinatorDelegate: class, CanOpenURL {
     func didTapSwap(forTransactionType transactionType: TransactionType, service: SwapTokenURLProviderType, in coordinator: TokensCoordinator)
@@ -160,7 +160,7 @@ class TokensCoordinator: Coordinator {
         let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
         let tokensDatastores = tokenCollection.tokenDataStores
 
-        let coordinator = QRCodeResolutionCoordinator(coordinator: scanQRCodeCoordinator, tokensDatastores: tokensDatastores, assetDefinitionStore: assetDefinitionStore)
+        let coordinator = QRCodeResolutionCoordinator(config: config, coordinator: scanQRCodeCoordinator, usage: .all(tokensDatastores: tokensDatastores, assetDefinitionStore: assetDefinitionStore))
         coordinator.delegate = self
 
         addCoordinator(coordinator)

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -156,8 +156,8 @@ class TokensCoordinator: Coordinator {
     }
 
     func launchUniversalScanner() {
-        let session = sessions[config.server]
-        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
+        let account = sessions.anyValue.account
+        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: account)
         let tokensDatastores = tokenCollection.tokenDataStores
 
         let coordinator = QRCodeResolutionCoordinator(config: config, coordinator: scanQRCodeCoordinator, usage: .all(tokensDatastores: tokensDatastores, assetDefinitionStore: assetDefinitionStore))

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -157,7 +157,7 @@ class TokensCoordinator: Coordinator {
 
     func launchUniversalScanner() {
         let session = sessions[config.server]
-        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
+        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
         let tokensDatastores = tokenCollection.tokenDataStores
 
         let coordinator = QRCodeResolutionCoordinator(config: config, coordinator: scanQRCodeCoordinator, usage: .all(tokensDatastores: tokensDatastores, assetDefinitionStore: assetDefinitionStore))

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -644,7 +644,7 @@ extension TokensCardCoordinator: TransferTokensCardViaWalletAddressViewControlle
     func openQRCode(in controller: TransferTokensCardViaWalletAddressViewController) {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
 
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
         coordinator.delegate = self
         addCoordinator(coordinator)
         coordinator.start()

--- a/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
@@ -66,8 +66,7 @@ class PaymentCoordinator: Coordinator {
         case (.request, _):
             let coordinator = RequestCoordinator(
                 navigationController: navigationController,
-                account: session.account,
-                server: session.server
+                account: session.account
             )
             coordinator.delegate = self
             coordinator.start()

--- a/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/RequestCoordinator.swift
@@ -9,13 +9,12 @@ protocol RequestCoordinatorDelegate: class {
 
 class RequestCoordinator: Coordinator {
     private let account: Wallet
-    private let server: RPCServer
 
     private lazy var requestViewController: RequestViewController = {
-        let viewModel: RequestViewModel = .init(account: account, server: server)
+        let viewModel: RequestViewModel = .init(account: account)
         let controller = RequestViewController(viewModel: viewModel)
         controller.navigationItem.leftBarButtonItem = UIBarButtonItem.backBarButton(self, selector: #selector(dismiss))
-        
+
         return controller
     }()
 
@@ -23,22 +22,17 @@ class RequestCoordinator: Coordinator {
     var coordinators: [Coordinator] = []
     weak var delegate: RequestCoordinatorDelegate?
 
-    init(
-        navigationController: UINavigationController = UINavigationController(),
-        account: Wallet,
-        server: RPCServer
-    ) {
+    init(navigationController: UINavigationController = UINavigationController(), account: Wallet) {
         self.navigationController = navigationController
         self.navigationController.modalPresentationStyle = .formSheet
         self.navigationController.setNavigationBarHidden(false, animated: true)
 
         self.account = account
-        self.server = server
     }
 
     func start() {
         navigationController.pushViewController(requestViewController, animated: true)
-    } 
+    }
 
     @objc func dismiss() {
         delegate?.didCancel(in: self)

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -131,7 +131,7 @@ extension SendCoordinator: SendViewControllerDelegate {
     func openQRCode(in controller: SendViewController) {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
 
-        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account, server: session.server)
+        let coordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: session.account)
         coordinator.delegate = self
         addCoordinator(coordinator)
         coordinator.start()

--- a/AlphaWallet/Transfer/ViewModels/RequestViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/RequestViewModel.swift
@@ -5,11 +5,9 @@ import UIKit
 
 struct RequestViewModel {
 	private let account: Wallet
-    private let server: RPCServer
 
-	init(account: Wallet, server: RPCServer) {
+	init(account: Wallet) {
 		self.account = account
-		self.server = server
 	}
 
 	var myAddressText: String {
@@ -18,10 +16,6 @@ struct RequestViewModel {
 
 	var myAddress: AlphaWallet.Address {
 		return account.address
-	}
-
-	var shareMyAddressText: String {
-		return R.string.localizable.requestMyAddressIsLabelTitle(server.name, myAddressText)
 	}
 
 	var copyWalletText: String {

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -154,11 +154,9 @@ extension WalletCoordinator: ImportWalletViewControllerDelegate {
 
     func openQRCode(in controller: ImportWalletViewController) {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
-
         let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.recentlyUsedWallet, server: config.server)
-        let coordinator = QRCodeResolutionCoordinator(coordinator: scanQRCodeCoordinator, tokensDatastores: nil, assetDefinitionStore: nil)
+        let coordinator = QRCodeResolutionCoordinator(config: config, coordinator: scanQRCodeCoordinator, usage: .importWalletOnly)
         coordinator.delegate = self
-
         addCoordinator(coordinator)
         coordinator.start()
     }
@@ -214,7 +212,7 @@ extension WalletCoordinator: QRCodeResolutionCoordinatorDelegate {
 
     func coordinator(_ coordinator: QRCodeResolutionCoordinator, didResolvePrivateKey privateKey: String) {
         removeCoordinator(coordinator)
-        
+
         importWalletViewController?.set(tabSelection: .privateKey)
         importWalletViewController?.setValueForCurrentField(string: privateKey)
     }

--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -154,7 +154,7 @@ extension WalletCoordinator: ImportWalletViewControllerDelegate {
 
     func openQRCode(in controller: ImportWalletViewController) {
         guard navigationController.ensureHasDeviceAuthorization() else { return }
-        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.recentlyUsedWallet, server: config.server)
+        let scanQRCodeCoordinator = ScanQRCodeCoordinator(navigationController: navigationController, account: keystore.recentlyUsedWallet)
         let coordinator = QRCodeResolutionCoordinator(config: config, coordinator: scanQRCodeCoordinator, usage: .importWalletOnly)
         coordinator.delegate = self
         addCoordinator(coordinator)

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 import WalletConnectSwift
-import PromiseKit  
+import PromiseKit
 import Result
 
 protocol WalletConnectCoordinatorDelegate: class {
@@ -30,7 +30,7 @@ class WalletConnectCoordinator: NSObject, Coordinator {
     }()
 
     private let navigationController: UINavigationController
-    
+
     var coordinators: [Coordinator] = []
     weak var delegate: WalletConnectCoordinatorDelegate?
     var connection: Subscribable<WalletConnectServerConnection> {
@@ -101,7 +101,7 @@ extension WalletConnectCoordinator: WalletConnectSessionCoordinatorDelegate {
     func didDismiss(in coordinator: WalletConnectSessionCoordinator) {
         removeCoordinator(coordinator)
     }
-} 
+}
 
 extension WalletConnectCoordinator: WalletConnectServerDelegate {
 
@@ -157,7 +157,7 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
     }
 
     private func executeTransaction(account: AlphaWallet.Address, callbackID id: WalletConnectRequestID, url: WalletConnectURL, transaction: UnconfirmedTransaction, type: ConfirmType) -> Promise<WalletConnectServer.Callback> {
-        
+
         return Promise { seal in
             let dummyPrice: Subscribable<Double> = Subscribable<Double>(nil)
             let configuration: TransactionConfirmationConfiguration = .dappTransaction(confirmType: type, keystore: keystore, ethPrice: dummyPrice)
@@ -270,7 +270,7 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
         alertViewController.addAction(cancelAction)
 
         navigationController.present(alertViewController, animated: true)
-    } 
+    }
 }
 
 extension String {

--- a/AlphaWallet/WalletConnect/WalletConnectServer.swift
+++ b/AlphaWallet/WalletConnect/WalletConnectServer.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 import WalletConnectSwift
-import PromiseKit 
+import PromiseKit
 
 enum WalletConnectError: Error {
     case connectionInvalid
@@ -198,11 +198,11 @@ extension WalletConnectServer: ServerDelegate {
         DispatchQueue.main.async {
             if let delegate = self.delegate {
                 let connection = WalletConnectConnection(dAppInfo: session.dAppInfo, url: session.url.absoluteString)
-                
+
                 delegate.server(self, shouldConnectFor: connection) { [weak self] isApproved in
                     guard let strongSelf = self else { return }
                     print(session)
-                    
+
                     if let chainIdToConnect = session.walletInfo?.chainId {
                         let rpcServer = RPCServer(chainID: chainIdToConnect)
 

--- a/AlphaWalletTests/Coordinators/RequestCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/RequestCoordinatorTests.swift
@@ -4,16 +4,9 @@ import XCTest
 @testable import AlphaWallet
 
 class RequestCoordinatorTests: XCTestCase {
-
     func testRootViewController() {
-        let coordinator = RequestCoordinator(
-            navigationController: FakeNavigationController(),
-            account: .make(),
-            server: .main
-        )
-
+        let coordinator = RequestCoordinator(navigationController: FakeNavigationController(), account: .make())
         coordinator.start()
-
         XCTAssertTrue(coordinator.navigationController.viewControllers.first is RequestViewController)
     }
 }

--- a/AlphaWalletTests/Transfer/ViewModels/RequestViewModelTests.swift
+++ b/AlphaWalletTests/Transfer/ViewModels/RequestViewModelTests.swift
@@ -4,21 +4,12 @@ import XCTest
 @testable import AlphaWallet
 
 class RequestViewModelTests: XCTestCase {
-    
+
     func testMyAddressText() {
         let account: Wallet = .make()
         let server: RPCServer = .main
-        let viewModel = RequestViewModel(account: account, server: server)
+        let viewModel = RequestViewModel(account: account)
 
         XCTAssertEqual(account.address.eip55String, viewModel.myAddressText)
-    }
-
-    func testShareMyAddressText() {
-        let account: Wallet = .make()
-        let server: RPCServer = .main
-        let viewModel = RequestViewModel(account: account, server: server)
-
-        LiveLocaleSwitcherBundle.switchLocale(to: "en")
-        XCTAssertEqual("My \(server.name) address is: \(account.address.eip55String)", viewModel.shareMyAddressText)
     }
 }


### PR DESCRIPTION
Current chain (ID) should only be used by dapp and WalletConnect as the other parts of the app support multichain.