### PR TITLE
Make sure to prefix raw transactions sending initiated by WalletConnect with 0x

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
@@ -43,7 +43,7 @@ class SendTransactionCoordinator {
 
     func send(rawTransaction: String) -> Promise<ConfirmResult> {
         return Promise { seal in
-            let request = EtherServiceRequest(server: session.server, batch: BatchFactory().create(SendRawTransactionRequest(signedTransaction: rawTransaction)))
+            let request = EtherServiceRequest(server: session.server, batch: BatchFactory().create(SendRawTransactionRequest(signedTransaction: rawTransaction.add0x)))
             Session.send(request) { result in
                 switch result {
                 case .success(let transactionID):


### PR DESCRIPTION
Not sure if it's needed, but existing code (for sending transactions) does it, so better to be safe.