### PR TITLE
Add multi-session support to WalletConnect

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		5E7C710F30F8EAC43A706500 /* DefaultActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75B1BE3B68216AFC9C05 /* DefaultActivityViewModel.swift */; };
 		5E7C7110A4DF17DA65B912AC /* EnterSellTokensCardPriceQuantityViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7ABB1538A0E83EEAEB0C /* EnterSellTokensCardPriceQuantityViewControllerTests.swift */; };
 		5E7C71145CE952518B3EECE3 /* AccountViewTableSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E7720DE64069CCF37D5 /* AccountViewTableSectionHeader.swift */; };
+		5E7C712B11D9D9AAA02C022F /* WalletConnectSessionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7DC4B06C1A623788EEED /* WalletConnectSessionCellViewModel.swift */; };
 		5E7C7131E338A806132D989B /* DateEntryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CD1FB7D353704EF3389 /* DateEntryField.swift */; };
 		5E7C7133FCB97894647E2628 /* SeedPhraseBackupIntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78CF45AA54EF8647C44B /* SeedPhraseBackupIntroductionViewController.swift */; };
 		5E7C713ACE8C72642B1C9F93 /* SendHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B7A45EDFA8ED1E25863 /* SendHeaderViewViewModel.swift */; };
@@ -442,6 +443,8 @@
 		5E7C7896E99049F4B124FDF5 /* OpenSeaNonFungibleTokenDisplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7A9876B43B1D9D17A9A9 /* OpenSeaNonFungibleTokenDisplayHelper.swift */; };
 		5E7C78A31A16600FBA5C9956 /* ScanQRCodeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7721E0E4D4EFDD35E196 /* ScanQRCodeCoordinator.swift */; };
 		5E7C78B3FD5CA87E395E1861 /* OnboardingPageStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7AF9A592D7224ED58016 /* OnboardingPageStyle.swift */; };
+		5E7C78C511CD388E882DBD83 /* WalletConnectSessionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7FA63647CED0B0BA5A9C /* WalletConnectSessionCell.swift */; };
+		5E7C78C68AD1922796E6C88F /* WalletConnectSessionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75F0DB84DB0F5449D6C1 /* WalletConnectSessionsViewController.swift */; };
 		5E7C78F1D29280E3FF4EAF5E /* RoundedBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75918317E13AD540DCA7 /* RoundedBackground.swift */; };
 		5E7C78F7C4848D484AD4183A /* DefaultActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7AEDAAE638601C7122A5 /* DefaultActivityView.swift */; };
 		5E7C78FF73BAB3E6EBE1F682 /* SingleChainTransactionDataCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C70CA72BB443C987ECDD9 /* SingleChainTransactionDataCoordinator.swift */; };
@@ -725,7 +728,7 @@
 		87BBF9912563DD7600FF4846 /* WalletConnectActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF9772563DD7500FF4846 /* WalletConnectActionType.swift */; };
 		87BBF9922563DD7600FF4846 /* UnconfirmedTransaction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF9782563DD7500FF4846 /* UnconfirmedTransaction+Extensions.swift */; };
 		87BBF9932563DD7600FF4846 /* WalletConnectServerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF9792563DD7500FF4846 /* WalletConnectServerRequest.swift */; };
-		87BBF9942563DD7600FF4846 /* WallerConnectRawView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF97B2563DD7500FF4846 /* WallerConnectRawView.swift */; };
+		87BBF9942563DD7600FF4846 /* WalletConnectRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF97B2563DD7500FF4846 /* WalletConnectRowView.swift */; };
 		87BBF9962563DD7600FF4846 /* SignMessageCoordinatorBridgeToPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF97E2563DD7500FF4846 /* SignMessageCoordinatorBridgeToPromise.swift */; };
 		87BBF9972563DD7600FF4846 /* TransactionInProgressCoordinatorBridgeToPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF97F2563DD7500FF4846 /* TransactionInProgressCoordinatorBridgeToPromise.swift */; };
 		87BBF9982563DD7600FF4846 /* TransactionConfirmationCoordinatorBridgeToPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BBF9802563DD7500FF4846 /* TransactionConfirmationCoordinatorBridgeToPromise.swift */; };
@@ -1191,6 +1194,7 @@
 		5E7C75D9C3EA9FF978ECF8E5 /* DAI.tsml */ = {isa = PBXFileReference; lastKnownFileType = file.tsml; path = DAI.tsml; sourceTree = "<group>"; };
 		5E7C75DE215F0AAEF284948F /* HDWalletTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HDWalletTest.swift; sourceTree = "<group>"; };
 		5E7C75E7D995ABE0E6B7AD55 /* DappButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappButton.swift; sourceTree = "<group>"; };
+		5E7C75F0DB84DB0F5449D6C1 /* WalletConnectSessionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionsViewController.swift; sourceTree = "<group>"; };
 		5E7C75F65E8C1E20EBA6A5F4 /* Scrollable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scrollable.swift; sourceTree = "<group>"; };
 		5E7C76052512831B707659CA /* WhereIsWalletAddressFoundOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhereIsWalletAddressFoundOverlayView.swift; sourceTree = "<group>"; };
 		5E7C7607B0EF9B8F1BC41073 /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
@@ -1396,6 +1400,7 @@
 		5E7C7D913DAA3322F1C7DD46 /* OpenSeaNonFungibleTokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSeaNonFungibleTokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7D931F68BFB5E1DCE001 /* TokenCardRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenCardRowView.swift; path = Views/TokenCardRowView.swift; sourceTree = "<group>"; };
 		5E7C7DAFCCF74F40D144CB0E /* GetNextNonce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetNextNonce.swift; sourceTree = "<group>"; };
+		5E7C7DC4B06C1A623788EEED /* WalletConnectSessionCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7DCB0BDDD30D10130AE7 /* GetIsERC875Encode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetIsERC875Encode.swift; sourceTree = "<group>"; };
 		5E7C7DD409C330DA4033F504 /* Keystore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keystore.swift; sourceTree = "<group>"; };
 		5E7C7DD9C564F2C7DE435894 /* ConfirmSignMessageTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1436,6 +1441,7 @@
 		5E7C7F89E3480D3680750EA9 /* TokenRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenRowView.swift; sourceTree = "<group>"; };
 		5E7C7F8F3CB3847D0E4E977B /* AlphaWalletAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlphaWalletAddress.swift; sourceTree = "<group>"; };
 		5E7C7F932B48011A24C26733 /* TokensCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensCoordinator.swift; sourceTree = "<group>"; };
+		5E7C7FA63647CED0B0BA5A9C /* WalletConnectSessionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectSessionCell.swift; sourceTree = "<group>"; };
 		5E7C7FB7C3FB2A9CC0CC51D7 /* TokensViewControllerTableViewSectionHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensViewControllerTableViewSectionHeader.swift; sourceTree = "<group>"; };
 		5E7C7FB99843529061368DA1 /* LocalesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalesViewModel.swift; sourceTree = "<group>"; };
 		5E7C7FBADEDE47DC37B9197A /* XmlContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XmlContext.swift; sourceTree = "<group>"; };
@@ -1568,7 +1574,7 @@
 		87BBF9772563DD7500FF4846 /* WalletConnectActionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectActionType.swift; sourceTree = "<group>"; };
 		87BBF9782563DD7500FF4846 /* UnconfirmedTransaction+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnconfirmedTransaction+Extensions.swift"; sourceTree = "<group>"; };
 		87BBF9792563DD7500FF4846 /* WalletConnectServerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectServerRequest.swift; sourceTree = "<group>"; };
-		87BBF97B2563DD7500FF4846 /* WallerConnectRawView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallerConnectRawView.swift; sourceTree = "<group>"; };
+		87BBF97B2563DD7500FF4846 /* WalletConnectRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConnectRowView.swift; sourceTree = "<group>"; };
 		87BBF97E2563DD7500FF4846 /* SignMessageCoordinatorBridgeToPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignMessageCoordinatorBridgeToPromise.swift; sourceTree = "<group>"; };
 		87BBF97F2563DD7500FF4846 /* TransactionInProgressCoordinatorBridgeToPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionInProgressCoordinatorBridgeToPromise.swift; sourceTree = "<group>"; };
 		87BBF9802563DD7500FF4846 /* TransactionConfirmationCoordinatorBridgeToPromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionConfirmationCoordinatorBridgeToPromise.swift; sourceTree = "<group>"; };
@@ -3853,6 +3859,7 @@
 			children = (
 				87BBF96B2563DD7500FF4846 /* WalletConnectSessionDetailsViewModel.swift */,
 				87BBF96C2563DD7500FF4846 /* WallerConnectRawViewModel.swift */,
+				5E7C7DC4B06C1A623788EEED /* WalletConnectSessionCellViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -3881,7 +3888,8 @@
 		87BBF97A2563DD7500FF4846 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				87BBF97B2563DD7500FF4846 /* WallerConnectRawView.swift */,
+				87BBF97B2563DD7500FF4846 /* WalletConnectRowView.swift */,
+				5E7C7FA63647CED0B0BA5A9C /* WalletConnectSessionCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3892,6 +3900,7 @@
 				87BBF97E2563DD7500FF4846 /* SignMessageCoordinatorBridgeToPromise.swift */,
 				87BBF97F2563DD7500FF4846 /* TransactionInProgressCoordinatorBridgeToPromise.swift */,
 				87BBF9802563DD7500FF4846 /* TransactionConfirmationCoordinatorBridgeToPromise.swift */,
+				5E7C75F0DB84DB0F5449D6C1 /* WalletConnectSessionsViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -4729,7 +4738,7 @@
 				442FC258BAEFDE2D64E48D0D /* TokensCardCoordinator.swift in Sources */,
 				87BBF9912563DD7600FF4846 /* WalletConnectActionType.swift in Sources */,
 				76F1D91659771C9EEA7B48DC /* CreateRedeem.swift in Sources */,
-				87BBF9942563DD7600FF4846 /* WallerConnectRawView.swift in Sources */,
+				87BBF9942563DD7600FF4846 /* WalletConnectRowView.swift in Sources */,
 				442FCE0DAE5527A93F54022C /* RedeemTokenCardQuantitySelectionViewController.swift in Sources */,
 				442FC0B59B23C0F3068621C0 /* NumberStepper.swift in Sources */,
 				442FCE2BEE8D475C7DEB39C1 /* RedeemTokenCardQuantitySelectionViewModel.swift in Sources */,
@@ -5177,6 +5186,9 @@
 				5E7C7DFC309C7CC499202375 /* DecodedFunctionCall.swift in Sources */,
 				5E7C7CD5C69451722BAB63E4 /* GetNextNonce.swift in Sources */,
 				5E7C7B1689D3E1D51788FE26 /* Session+PromiseKit.swift in Sources */,
+				5E7C78C68AD1922796E6C88F /* WalletConnectSessionsViewController.swift in Sources */,
+				5E7C78C511CD388E882DBD83 /* WalletConnectSessionCell.swift in Sources */,
+				5E7C712B11D9D9AAA02C022F /* WalletConnectSessionCellViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -120,11 +120,7 @@ class InCoordinator: NSObject, Coordinator {
         return service
     }()
 
-    lazy var walletConnectCoordinator: WalletConnectCoordinator = {
-        let coordinator = WalletConnectCoordinator(keystore: keystore, sessions: walletSessions, navigationController: navigationController, analyticsCoordinator: analyticsCoordinator, config: config)
-        addCoordinator(coordinator)
-        return coordinator
-    }()
+    private lazy var walletConnectCoordinator: WalletConnectCoordinator = createWalletConnectCoordinator()
 
     init(
             navigationController: UINavigationController = UINavigationController(),
@@ -389,8 +385,8 @@ class InCoordinator: NSObject, Coordinator {
         keystore.recentlyUsedWallet = account
         wallet = account
         setupResourcesOnMultiChain()
+        walletConnectCoordinator = createWalletConnectCoordinator()
         fetchEthereumEvents()
-        walletConnectCoordinator.disconnect()
 
         //TODO creating many objects here. Messy. Improve?
         let realm = self.realm(forAccount: wallet)
@@ -753,6 +749,12 @@ class InCoordinator: NSObject, Coordinator {
     private func createConsoleViewController() -> ConsoleViewController {
         let coordinator = ConsoleCoordinator(assetDefinitionStore: assetDefinitionStore)
         return coordinator.createConsoleViewController()
+    }
+
+    private func createWalletConnectCoordinator() -> WalletConnectCoordinator {
+        let coordinator = WalletConnectCoordinator(keystore: keystore, sessions: walletSessions, navigationController: navigationController, analyticsCoordinator: analyticsCoordinator, config: config)
+        addCoordinator(coordinator)
+        return coordinator
     }
 }
 // swiftlint:enable type_body_length

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -526,6 +526,6 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";
-"start" = "Start";
+"walletConnect.start" = "%@\n\nStart WalletConnect session on:";
 "walletConnect.failure.title" = "Wallet connect failure";
 "walletConnect.sendRawTransaction.title" = "Send raw transaction"; 

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -526,6 +526,6 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";
-"start" = "Start";
+"walletConnect.start" = "%@\n\nStart WalletConnect session on:";
 "walletConnect.failure.title" = "Wallet connect failure";
 "walletConnect.sendRawTransaction.title" = "Send raw transaction";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -526,6 +526,6 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";
-"start" = "Start";
+"walletConnect.start" = "%@\n\nStart WalletConnect session on:";
 "walletConnect.failure.title" = "Wallet connect failure";
 "walletConnect.sendRawTransaction.title" = "Send raw transaction";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -526,6 +526,6 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";
-"start" = "Start";
+"walletConnect.start" = "%@\n\nStart WalletConnect session on:";
 "walletConnect.failure.title" = "Wallet connect failure";
 "walletConnect.sendRawTransaction.title" = "Send raw transaction";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -526,6 +526,6 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions"; 
-"start" = "Start"; 
+"walletConnect.start" = "%@\n\nStart WalletConnect session on:";
 "walletConnect.failure.title" = "Wallet connect failure";
 "walletConnect.sendRawTransaction.title" = "Send raw transaction";

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -512,3 +512,20 @@ enum RPCServer: Hashable, CaseIterable {
     }
 }
 // swiftlint:enable type_body_length
+
+extension RPCServer: Codable {
+    private enum Keys: String, CodingKey {
+        case chainId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Keys.self)
+        let chainId = try container.decode(Int.self, forKey: .chainId)
+        self = .init(chainID: chainId)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Keys.self)
+        try container.encode(chainID, forKey: .chainId)
+    }
+}

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -169,9 +169,8 @@ class TokensCoordinator: Coordinator {
 }
 
 extension TokensCoordinator: TokensViewControllerDelegate {
-
     func walletConnectSelected(in viewController: UIViewController) {
-        walletConnectCoordinator.perform(.openSessionDetails(navigationController: navigationController))
+        walletConnectCoordinator.showSessionDetails(inNavigationController: navigationController)
     }
 
     func didPressAddHideTokens(viewModel: TokensViewModel) {
@@ -347,8 +346,7 @@ extension TokensCoordinator: QRCodeResolutionCoordinatorDelegate {
 
     func coordinator(_ coordinator: QRCodeResolutionCoordinator, didResolveWalletConnectURL url: WalletConnectURL) {
         removeCoordinator(coordinator)
-
-        walletConnectCoordinator.perform(.startWalletConnectSession(url))
+        walletConnectCoordinator.openSession(url: url)
     }
 
     func coordinator(_ coordinator: QRCodeResolutionCoordinator, didResolveString value: String) {

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -175,7 +175,6 @@ class TokensViewController: UIViewController {
             }
         }
     }
-    private var subscription: Subscribable<WalletConnectServerConnection>.SubscribableKey?
 
     init(sessions: ServerDictionary<WalletSession>,
          account: Wallet,
@@ -241,16 +240,13 @@ class TokensViewController: UIViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem.qrCodeBarButton(self, selector: #selector(scanQRCodeButtonSelected))
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: blockieImageView)
 
-        subscription = walletConnectCoordinator.connection.subscribe { [weak self] connection in
-            guard let strongSelf = self, let connection = connection else { return }
-
-            switch connection {
-            case .connected:
-                strongSelf.sections = [.filters, .addHideToken, .activeWalletSession, .tokens]
-            case .disconnected:
+        walletConnectCoordinator.walletConnectSessions.subscribe { [weak self] sessions in
+            guard let strongSelf = self, let sessions = sessions else { return }
+            if sessions.isEmpty {
                 strongSelf.sections = [.filters, .addHideToken, .tokens]
+            } else {
+                strongSelf.sections = [.filters, .addHideToken, .activeWalletSession, .tokens]
             }
-
             strongSelf.tableView.reloadData()
         }
     }

--- a/AlphaWallet/WalletConnect/Controllers/SignMessageCoordinatorBridgeToPromise.swift
+++ b/AlphaWallet/WalletConnect/Controllers/SignMessageCoordinatorBridgeToPromise.swift
@@ -51,7 +51,7 @@ private class SignMessageCoordinatorBridgeToPromise {
         coordinator.start(with: signType)
 
         return promise
-    } 
+    }
 }
 
 extension SignMessageCoordinator {

--- a/AlphaWallet/WalletConnect/Controllers/TransactionConfirmationCoordinatorBridgeToPromise.swift
+++ b/AlphaWallet/WalletConnect/Controllers/TransactionConfirmationCoordinatorBridgeToPromise.swift
@@ -92,6 +92,7 @@ extension UIViewController {
 
 extension TransactionConfirmationCoordinator {
 
+    //session contains account already
     static func promise(_ navigationController: UINavigationController, session: WalletSession, coordinator: Coordinator, account: AlphaWallet.Address, transaction: UnconfirmedTransaction, configuration: TransactionConfirmationConfiguration, analyticsCoordinator: AnalyticsCoordinator?) -> Promise<ConfirmResult> {
         let bridge = TransactionConfirmationCoordinatorBridgeToPromise(navigationController, session: session, coordinator: coordinator, analyticsCoordinator: analyticsCoordinator)
         return bridge.promise(account: account, transaction: transaction, configuration: configuration)

--- a/AlphaWallet/WalletConnect/Controllers/WalletConnectSessionsViewController.swift
+++ b/AlphaWallet/WalletConnect/Controllers/WalletConnectSessionsViewController.swift
@@ -1,0 +1,71 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import UIKit
+
+protocol WalletConnectSessionsViewControllerDelegate: class {
+    func didSelect(session: WalletConnectSession, in viewController: WalletConnectSessionsViewController)
+}
+
+class WalletConnectSessionsViewController: UIViewController {
+    private let sessions: Subscribable<[WalletConnectSession]>
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        tableView.register(WalletConnectSessionCell.self)
+        tableView.estimatedRowHeight = DataEntry.Metric.TableView.estimatedRowHeight
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.tableFooterView = UIView.tableFooterToRemoveEmptyCellSeparators()
+        tableView.separatorInset = .zero
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+
+    weak var delegate: WalletConnectSessionsViewControllerDelegate?
+
+    init(sessions: Subscribable<[WalletConnectSession]>) {
+        self.sessions = sessions
+        super.init(nibName: nil, bundle: nil)
+
+        view.addSubview(tableView)
+
+        sessions.subscribe { _ in
+            self.tableView.reloadData()
+        }
+
+        NSLayoutConstraint.activate([
+            tableView.anchorsConstraint(to: view),
+        ])
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        nil
+    }
+
+    func configure() {
+        navigationItem.largeTitleDisplayMode = .never
+        hidesBottomBarWhenPushed = true
+        title = R.string.localizable.walletConnectTitle()
+    }
+}
+
+extension WalletConnectSessionsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let session = sessions.value?[indexPath.row] else { return }
+        delegate?.didSelect(session: session, in: self)
+    }
+}
+
+extension WalletConnectSessionsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(for: indexPath) as WalletConnectSessionCell
+        guard let session = sessions.value?[indexPath.row] else { return cell }
+        let viewModel = WalletConnectSessionCellViewModel(session: session)
+        cell.configure(viewModel: viewModel)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sessions.value?.count ?? 0
+    }
+}

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectSessionCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectSessionCoordinator.swift
@@ -18,7 +18,6 @@ class WalletConnectSessionCoordinator: Coordinator {
     private let server: WalletConnectServer
     private var viewController: WalletConnectSessionViewController
     private let session: WalletConnectSession
-    private var sessionsSubscribableKey: Subscribable<[WalletConnectSession]>.SubscribableKey?
 
     var coordinators: [Coordinator] = []
     weak var delegate: WalletConnectSessionCoordinatorDelegate?
@@ -31,9 +30,8 @@ class WalletConnectSessionCoordinator: Coordinator {
         viewController = WalletConnectSessionViewController(viewModel: .init(server: server, session: session))
         viewController.delegate = self
 
-        sessionsSubscribableKey = server.sessions.subscribe { [weak self] sessions in
+        server.sessions.subscribe { [weak self] sessions in
             guard let strongSelf = self else { return }
-
             strongSelf.viewController.reload()
         }
     }
@@ -44,23 +42,19 @@ class WalletConnectSessionCoordinator: Coordinator {
 }
 
 extension WalletConnectSessionCoordinator: WalletConnectSessionViewControllerDelegate {
-
-    func didDissmiss(in controller: WalletConnectSessionViewController) {
+    func didDismiss(in controller: WalletConnectSessionViewController) {
         guard let delegate = delegate else { return }
-
         navigationController.popViewController(animated: true)
         delegate.didDismiss(in: self)
     }
 
-    func controller(_ controller: WalletConnectSessionViewController, dissconnectSelected sender: UIButton) {
+    func controller(_ controller: WalletConnectSessionViewController, disconnectSelected sender: UIButton) {
         guard let delegate = delegate else { return }
-
         do {
             try server.disconnect(session: session)
         } catch {
-            print(error)
+            //no-op
         }
-
         navigationController.popViewController(animated: true)
         delegate.didDismiss(in: self)
     }

--- a/AlphaWallet/WalletConnect/View/WalletConnectRowView.swift
+++ b/AlphaWallet/WalletConnect/View/WalletConnectRowView.swift
@@ -7,8 +7,7 @@
 
 import UIKit
 
-class WallerConnectRawView: UIView {
-
+class WalletConnectRowView: UIView {
     private let textLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/AlphaWallet/WalletConnect/View/WalletConnectSessionCell.swift
+++ b/AlphaWallet/WalletConnect/View/WalletConnectSessionCell.swift
@@ -1,0 +1,31 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import UIKit
+
+class WalletConnectSessionCell: UITableViewCell {
+    private let nameLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        let stackView = [.spacerWidth(Table.Metric.plainLeftMargin), nameLabel].asStackView(axis: .horizontal)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.anchorsConstraint(to: contentView, edgeInsets: .init(top: 7, left: StyleLayout.sideMargin, bottom: 7, right: StyleLayout.sideMargin)),
+            stackView.heightAnchor.constraint(equalToConstant: 44),
+        ])
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(viewModel: WalletConnectSessionCellViewModel) {
+        selectionStyle = .default
+        backgroundColor = viewModel.backgroundColor
+        nameLabel.font = viewModel.nameFont
+        nameLabel.text = viewModel.name
+    }
+}

--- a/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
+++ b/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
@@ -9,9 +9,9 @@ import UIKit
 import WalletConnectSwift
 
 protocol WalletConnectSessionViewControllerDelegate: class {
-    func controller(_ controller: WalletConnectSessionViewController, dissconnectSelected sender: UIButton)
+    func controller(_ controller: WalletConnectSessionViewController, disconnectSelected sender: UIButton)
     func signedTransactionSelected(in controller: WalletConnectSessionViewController)
-    func didDissmiss(in controller: WalletConnectSessionViewController)
+    func didDismiss(in controller: WalletConnectSessionViewController)
 }
 
 class WalletConnectSessionViewController: UIViewController {
@@ -23,9 +23,9 @@ class WalletConnectSessionViewController: UIViewController {
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
-    private let statusRow = WallerConnectRawView()
-    private let nameRow = WallerConnectRawView()
-    private let connectedToRow = WallerConnectRawView()
+    private let statusRow = WalletConnectRowView()
+    private let nameRow = WalletConnectRowView()
+    private let connectedToRow = WalletConnectRowView()
     private let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
     private let roundedBackground = RoundedBackground()
     private let separatorList: UIView = {
@@ -57,11 +57,11 @@ class WalletConnectSessionViewController: UIViewController {
     }()
 
     weak var delegate: WalletConnectSessionViewControllerDelegate?
-    
+
     init(viewModel: WalletConnectSessionDetailsViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        
+
         let tap = UIGestureRecognizer(target: self, action: #selector(signedTransactionSelected))
         transactionsLabel.addGestureRecognizer(tap)
 
@@ -105,7 +105,7 @@ class WalletConnectSessionViewController: UIViewController {
 
             footerBar.anchorsConstraint(to: view),
         ] + roundedBackground.createConstraintsWithContainer(view: view))
-        
+
     }
 
     required init?(coder: NSCoder) {
@@ -117,7 +117,7 @@ class WalletConnectSessionViewController: UIViewController {
 
         buttonsBar.configure()
         reload()
-        
+
         hidesBottomBarWhenPushed = true
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem.backBarButton(self, selector: #selector(backButtonSelected))
@@ -134,7 +134,7 @@ class WalletConnectSessionViewController: UIViewController {
     }
 
     @objc private func backButtonSelected(_ sender: UIBarButtonItem) {
-        delegate?.didDissmiss(in: self)
+        delegate?.didDismiss(in: self)
     }
 
     private func configure(viewModel: WalletConnectSessionDetailsViewModel) {
@@ -147,7 +147,7 @@ class WalletConnectSessionViewController: UIViewController {
 
         let button0 = buttonsBar.buttons[0]
         button0.setTitle(viewModel.dissconnectButtonText, for: .normal)
-        button0.addTarget(self, action: #selector(dissconnectButtonSelected), for: .touchUpInside)
+        button0.addTarget(self, action: #selector(disconnectButtonSelected), for: .touchUpInside)
         button0.isEnabled = viewModel.isDisconnectAvailable
     }
 
@@ -155,7 +155,7 @@ class WalletConnectSessionViewController: UIViewController {
         delegate?.signedTransactionSelected(in: self)
     }
 
-    @objc private func dissconnectButtonSelected(_ sender: UIButton) {
-        delegate?.controller(self, dissconnectSelected: sender)
+    @objc private func disconnectButtonSelected(_ sender: UIButton) {
+        delegate?.controller(self, disconnectSelected: sender)
     }
 }

--- a/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionCellViewModel.swift
+++ b/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionCellViewModel.swift
@@ -1,0 +1,23 @@
+// Copyright © 2020 Stormbird PTE. LTD.
+
+import UIKit
+
+struct WalletConnectSessionCellViewModel {
+    private let session: WalletConnectSession
+
+    init(session: WalletConnectSession) {
+        self.session = session
+    }
+
+    var backgroundColor: UIColor {
+        Colors.appBackground
+    }
+
+    var nameFont: UIFont {
+        Fonts.regular(size: 17)
+    }
+
+    var name: String {
+        session.dAppInfo.peerMeta.name
+    }
+}

--- a/AlphaWallet/WalletConnect/WalletConnect+UserDefaults.swift
+++ b/AlphaWallet/WalletConnect/WalletConnect+UserDefaults.swift
@@ -8,25 +8,24 @@
 import Foundation
 
 extension UserDefaults {
-    private static let lastSessionKey = "LastSessionKey"
+    private static let walletConnectSessionsKey = "WalletConnectSessionsKey"
 
-    var lastSession: WalletConnectSession? {
+    var walletConnectSessions: [WalletConnectSession] {
         get {
-            guard let data = object(forKey: UserDefaults.lastSessionKey) as? Data, let session = try? JSONDecoder().decode(WalletConnectSession.self, from: data) else {
-                return nil
+            guard let data = object(forKey: UserDefaults.walletConnectSessionsKey) as? Data, let sessions = try? JSONDecoder().decode([WalletConnectSession].self, from: data) else { return [] }
+            if let session = sessions.first, let walletAddress = session.walletInfo?.accounts[0] {
+                //Make sure to clear WalletConnect sessions if we change wallet
+                if EtherKeystore.currentWallet.address.sameContract(as: walletAddress) {
+                    //no-op
+                } else {
+                    self.walletConnectSessions = []
+                }
             }
-
-            return session
+            return sessions
         }
         set {
-            if let value = newValue {
-                if let data = try? JSONEncoder().encode(value) {
-                    set(data, forKey: UserDefaults.lastSessionKey)
-                }
-
-            } else {
-                removeObject(forKey: UserDefaults.lastSessionKey)
-            }
+            guard let data = try? JSONEncoder().encode(newValue) else { return }
+            set(data, forKey: UserDefaults.walletConnectSessionsKey)
         }
     }
 }

--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -7,7 +7,10 @@ extension WalletConnectCoordinator {
 
     static func fake() -> WalletConnectCoordinator {
         let keystore = FakeEtherKeystore()
-        return .init(keystore: keystore, configuration: .init(wallet: .make(), rpcServer: .main), navigationController: .init(), analyticsCoordinator: nil, config: .make())
+        var sessions = ServerDictionary<WalletSession>()
+        let session = WalletSession.make()
+        sessions[session.server] = session
+        return .init(keystore: keystore, sessions: sessions, navigationController: .init(), analyticsCoordinator: nil, config: .make())
     }
 }
 
@@ -42,7 +45,7 @@ class ConfigTests: XCTestCase {
         XCTAssertEqual(vc1.title, "Wallet")
 
         Config.setLocale(AppLocale.simplifiedChinese)
-        
+
         let vc2 = TokensViewController(
                 sessions: sessions,
                 account: .make(),


### PR DESCRIPTION
Closes #2398, closes #2396

Before this PR, WalletConnect sessions connect to the chain selected in the browser tab.

After this PR is applied, the user will be asked to choose the (enabled) chain to connect to when opening a WalletConnect session:

<img width='200' src='https://user-images.githubusercontent.com/56189/103264868-fc5a1580-49e6-11eb-929b-f89e80ce9d37.png'>

and when there are more than 1 active session, a list of sessions is shown:

<img width='200' src='https://user-images.githubusercontent.com/56189/103264919-20b5f200-49e7-11eb-8338-015245048753.png'>