### PR TITLE
Fix: ERC20 token transactions are sent wrong to the recipient address. Should send to contract instead

### DIFF
--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -54,7 +54,8 @@ extension DappAction {
         return UnconfirmedTransaction(
             transactionType: transactionType,
             value: value,
-            recipient: to,
+            recipient: nil,
+            contract: to,
             data: data,
             gasLimit: gasLimit,
             gasPrice: gasPrice,

--- a/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
@@ -276,7 +276,7 @@ struct FunctionOrigin {
         }
         //TODO feels ike everything can just be in `.tokenScript`. But have to check dapp, it includes other parameters like gas
         return .success((
-                UnconfirmedTransaction(transactionType: .tokenScript(tokenObject), value: BigInt(value), recipient: originContractOrRecipientAddress, data: payload),
+                UnconfirmedTransaction(transactionType: .tokenScript(tokenObject), value: BigInt(value), recipient: nil, contract: originContractOrRecipientAddress, data: payload),
                 functionCallMetaData))
     }
 

--- a/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
@@ -67,7 +67,8 @@ class ClaimPaidOrderCoordinator: Coordinator {
                 let transaction = UnconfirmedTransaction(
                         transactionType: .claimPaidErc875MagicLink(strongSelf.tokenObject),
                         value: BigInt(strongSelf.signedOrder.order.price),
-                        recipient: strongSelf.signedOrder.order.contractAddress,
+                        recipient: nil,
+                        contract: strongSelf.signedOrder.order.contractAddress,
                         data: payload,
                         gasLimit: nil,
                         gasPrice: nil,

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -91,7 +91,12 @@ class TransactionConfigurator {
     }
 
     var toAddress: AlphaWallet.Address? {
-        return transaction.recipient
+        switch transaction.transactionType {
+        case .nativeCryptocurrency:
+            return transaction.recipient
+        case .dapp, .ERC20Token, .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .tokenScript, .claimPaidErc875MagicLink:
+            return transaction.contract
+        }
     }
 
     var value: BigInt {

--- a/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
@@ -37,6 +37,7 @@ class TransferNFTCoordinator: Coordinator {
                 transactionType: transactionType,
                 value: BigInt(0),
                 recipient: recipient,
+                contract: tokenHolder.contractAddress,
                 data: nil,
                 tokenId: tokenHolder.tokens[0].id,
                 indices: tokenHolder.indices

--- a/AlphaWallet/Transfer/Types/UnconfirmedTransaction.swift
+++ b/AlphaWallet/Transfer/Types/UnconfirmedTransaction.swift
@@ -7,6 +7,7 @@ struct UnconfirmedTransaction {
     let transactionType: TransactionType
     let value: BigInt
     let recipient: AlphaWallet.Address?
+    let contract: AlphaWallet.Address?
     let data: Data?
     let gasLimit: BigInt?
     let tokenId: BigUInt?
@@ -26,6 +27,7 @@ struct UnconfirmedTransaction {
         transactionType: TransactionType,
         value: BigInt,
         recipient: AlphaWallet.Address?,
+        contract: AlphaWallet.Address?,
         data: Data?,
         tokenId: BigUInt? = nil,
         indices: [UInt16]? = nil,
@@ -35,7 +37,8 @@ struct UnconfirmedTransaction {
     ) {
         self.transactionType = transactionType
         self.value = value
-        self.recipient = recipient 
+        self.recipient = recipient
+        self.contract = contract
         self.data = data
         self.tokenId = tokenId
         self.indices = indices

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -281,7 +281,8 @@ class SendViewController: UIViewController {
         let transaction = UnconfirmedTransaction(
                 transactionType: transactionType,
                 value: value,
-                recipient: recipient, 
+                recipient: recipient,
+                contract: transactionType.contractForFungibleSend,
                 data: nil
         )
         delegate?.didPressConfirm(transaction: transaction, in: self, amount: amountTextField.ethCost)

--- a/AlphaWallet/WalletConnect/Types/UnconfirmedTransaction+Extensions.swift
+++ b/AlphaWallet/WalletConnect/Types/UnconfirmedTransaction+Extensions.swift
@@ -9,20 +9,14 @@ import Foundation
 import BigInt
 
 extension UnconfirmedTransaction {
-
     init(transactionType: TransactionType, bridge transaction: RawTransactionBridge) {
-        self.transactionType = transactionType
-        value = transaction.value ?? BigInt("0")
-        recipient = transaction.to 
-        data = transaction.data
-        gasLimit = .none
-        tokenId = .none
-        gasPrice = transaction.gasPrice
-        nonce = transaction.nonce
-        v = .none
-        r = .none
-        s = .none
-        expiry = .none
-        indices = .none
+        self = .init(
+                transactionType: transactionType,
+                value: transaction.value ?? BigInt("0"),
+                recipient: nil,
+                contract: transaction.to,
+                data: transaction.data,
+                gasPrice: transaction.gasPrice,
+                nonce: transaction.nonce)
     }
 }

--- a/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
+++ b/AlphaWalletTests/Factories/UnconfirmedTransaction.swift
@@ -17,7 +17,8 @@ extension UnconfirmedTransaction {
         return UnconfirmedTransaction(
             transactionType: transactionType,
             value: value,
-            recipient: to,
+            recipient: nil,
+            contract: to,
             data: data,
             tokenId: nil,
             gasLimit: gasLimit,


### PR DESCRIPTION
Fixes #2414 