### PR TITLE
Fix: make gas and Ether `value` in fiat appear in actionsheet for confirming transactions initiated by WalletConnect

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -752,7 +752,7 @@ class InCoordinator: NSObject, Coordinator {
     }
 
     private func createWalletConnectCoordinator() -> WalletConnectCoordinator {
-        let coordinator = WalletConnectCoordinator(keystore: keystore, sessions: walletSessions, navigationController: navigationController, analyticsCoordinator: analyticsCoordinator, config: config)
+        let coordinator = WalletConnectCoordinator(keystore: keystore, sessions: walletSessions, navigationController: navigationController, analyticsCoordinator: analyticsCoordinator, config: config, nativeCryptoCurrencyPrices: nativeCryptoCurrencyPrices)
         addCoordinator(coordinator)
         return coordinator
     }

--- a/AlphaWalletTests/Settings/ConfigTests.swift
+++ b/AlphaWalletTests/Settings/ConfigTests.swift
@@ -10,7 +10,7 @@ extension WalletConnectCoordinator {
         var sessions = ServerDictionary<WalletSession>()
         let session = WalletSession.make()
         sessions[session.server] = session
-        return .init(keystore: keystore, sessions: sessions, navigationController: .init(), analyticsCoordinator: nil, config: .make())
+        return .init(keystore: keystore, sessions: sessions, navigationController: .init(), analyticsCoordinator: nil, config: .make(), nativeCryptoCurrencyPrices: .init())
     }
 }
 


### PR DESCRIPTION
Closes #2393 

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/103330126-18b78a00-4a9b-11eb-883c-09136716233b.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/103330130-1c4b1100-4a9b-11eb-8419-4b52ae67deab.png'>
