### PR TITLE
Remove the Signed Transactions cell from the WalletConnect session screen, which does nothing when tapped anyway

### DIFF
--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectSessionCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectSessionCoordinator.swift
@@ -58,8 +58,4 @@ extension WalletConnectSessionCoordinator: WalletConnectSessionViewControllerDel
         navigationController.popViewController(animated: true)
         delegate.didDismiss(in: self)
     }
-
-    func signedTransactionSelected(in controller: WalletConnectSessionViewController) {
-        //no op
-    }
 }

--- a/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
+++ b/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
@@ -10,7 +10,6 @@ import WalletConnectSwift
 
 protocol WalletConnectSessionViewControllerDelegate: class {
     func controller(_ controller: WalletConnectSessionViewController, disconnectSelected sender: UIButton)
-    func signedTransactionSelected(in controller: WalletConnectSessionViewController)
     func didDismiss(in controller: WalletConnectSessionViewController)
 }
 
@@ -35,49 +34,17 @@ class WalletConnectSessionViewController: UIViewController {
         return view
     }()
 
-    private let transactionsLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .left
-        label.text = R.string.localizable.walletConnectSessionSignedTransactions()
-        label.font = Fonts.regular(size: 17)
-        label.textColor = Colors.black
-        label.isUserInteractionEnabled = true
-
-        return label
-    }()
-
-    private let transactionsDisclosureImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFit
-        imageView.image = R.image.chevronRight()?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = R.color.mercury()
-        return imageView
-    }()
-
     weak var delegate: WalletConnectSessionViewControllerDelegate?
 
     init(viewModel: WalletConnectSessionDetailsViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
 
-        let tap = UIGestureRecognizer(target: self, action: #selector(signedTransactionSelected))
-        transactionsLabel.addGestureRecognizer(tap)
-
-        let transactionsLabelStackView = [
-            .spacerWidth(16),
-            transactionsLabel,
-            transactionsDisclosureImageView,
-            .spacerWidth(16)
-        ].asStackView()
-
         let stackView = [
             [.spacerWidth(50), imageView, .spacerWidth(50)].asStackView(),
             statusRow,
             nameRow,
             connectedToRow,
-            transactionsLabelStackView,
             separatorList
         ].asStackView(axis: .vertical)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -93,11 +60,7 @@ class WalletConnectSessionViewController: UIViewController {
         roundedBackground.addSubview(footerBar)
 
         NSLayoutConstraint.activate([
-            transactionsDisclosureImageView.heightAnchor.constraint(equalToConstant: 20),
-            transactionsDisclosureImageView.widthAnchor.constraint(equalToConstant: 20),
-
             separatorList.heightAnchor.constraint(equalToConstant: 1),
-            transactionsLabelStackView.heightAnchor.constraint(equalToConstant: 60),
             imageView.heightAnchor.constraint(equalToConstant: 250),
             stackView.leadingAnchor.constraint(equalTo: roundedBackground.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: roundedBackground.trailingAnchor),
@@ -149,10 +112,6 @@ class WalletConnectSessionViewController: UIViewController {
         button0.setTitle(viewModel.dissconnectButtonText, for: .normal)
         button0.addTarget(self, action: #selector(disconnectButtonSelected), for: .touchUpInside)
         button0.isEnabled = viewModel.isDisconnectAvailable
-    }
-
-    @objc private func signedTransactionSelected(_ sender: UITapGestureRecognizer) {
-        delegate?.signedTransactionSelected(in: self)
     }
 
     @objc private func disconnectButtonSelected(_ sender: UIButton) {


### PR DESCRIPTION
Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/103331241-e9574c00-4a9f-11eb-8df7-2d1f9e1b4098.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/103331243-ec523c80-4a9f-11eb-9b21-563b42b44317.png'>