### PR TITLE
Add mobile linking support for WalletConnect

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -377,6 +377,10 @@ extension AppCoordinator: UniversalLinkCoordinatorDelegate {
     func didImported(contract: AlphaWallet.Address, in coordinator: UniversalLinkCoordinator) {
         inCoordinator?.addImported(contract: contract, forServer: coordinator.server)
     }
+
+    func handle(walletConnectUrl url: WalletConnectURL) {
+        inCoordinator?.openWalletConnectSession(url: url)
+    }
 }
 
 extension AppCoordinator: UniversalLinkInPasteboardCoordinatorDelegate {

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -756,6 +756,10 @@ class InCoordinator: NSObject, Coordinator {
         addCoordinator(coordinator)
         return coordinator
     }
+
+    func openWalletConnectSession(url: WalletConnectURL) {
+        walletConnectCoordinator.openSession(url: url)
+    }
 }
 // swiftlint:enable type_body_length
 


### PR DESCRIPTION
i.e. when user access a dapp on their iOS device, they get to see AlphaWallet in the list to use WalletConnect against in this screen:

<img width='200' src='https://user-images.githubusercontent.com/56189/103398143-52a98e80-4b76-11eb-88c9-391397df1fd8.png'>

This is described in https://docs.walletconnect.org/mobile-linking

The actual flow isn't testable directly yet, as we'll have to submit a PR to WalletConnect's repo to register our universal link. This can happen only after this PR is merged and the app is submitted + approved. It still might take a while to appear in dapps that support WalletConnect as I'm not sure whether the list of wallet apps/universal links is dynamically fetched by the WalletConnect dapp-side SDK..

One way to test now is to go to a dapp, choose WalletConnect to generate the the QR code, scan it to get the URL and form such a URL manually: `https://aw.app/wc?uri=wc:20e57b0c-357e-44cc-ba47-97e785dc0042@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=cfc1b5ab27934d59c204717b75dceb0ed94e2c75f0174d2999a55fc24eded46e` (replacing the part starting from "wc:"), paste the URL into a webpage, visit the webpage in Mobile Safari and tap on the link 😭 