### PR TITLE
Fix EIP712 v3 support for WalletConnect

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -197,8 +197,8 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
                     callback = DappCallback(id: callbackID, value: .signPersonalMessage(data))
                 case .typedMessage:
                     callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
-                case .eip712:
-                    callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
+                case .eip712v3:
+                    callback = DappCallback(id: callbackID, value: .signTypedMessageV3(data))
                 }
                 strongSelf.browserViewController.notifyFinish(callbackID: callbackID, value: .success(callback))
             case .failure:
@@ -419,6 +419,8 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
             signMessage(with: .personalMessage(Data(hex: msg)), account: account, callbackID: callbackID)
         case .signTypedMessage(let typedData):
             signMessage(with: .typedMessage(typedData), account: account, callbackID: callbackID)
+        case .signTypedMessageV3(let typedData):
+            signMessage(with: .eip712v3(typedData), account: account, callbackID: callbackID)
         case .unknown, .sendRawTransaction:
             break
         }

--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -8,6 +8,7 @@ enum DappAction {
     case signMessage(String)
     case signPersonalMessage(String)
     case signTypedMessage([EthTypedData])
+    case signTypedMessageV3(EIP712TypedData)
     case signTransaction(UnconfirmedTransaction)
     case sendTransaction(UnconfirmedTransaction)
     case sendRawTransaction(String)
@@ -28,8 +29,15 @@ extension DappAction {
             let data = command.object["data"]?.value ?? ""
             return .signPersonalMessage(data)
         case .signTypedMessage:
-            let array = command.object["data"]?.array ?? []
-            return .signTypedMessage(array)
+            if let data = command.object["data"] {
+                if let eip712Data = data.eip712v3Data {
+                    return .signTypedMessageV3(eip712Data)
+                } else {
+                    return .signTypedMessage(data.eip712PreV3Array)
+                }
+            } else {
+                return .signTypedMessage([])
+            }
         case .unknown:
             return .unknown
         }

--- a/AlphaWallet/Core/Types/AlphaWalletAddress.swift
+++ b/AlphaWallet/Core/Types/AlphaWalletAddress.swift
@@ -6,11 +6,11 @@ import TrustKeystore
 import WalletCore
 
 ///Use an enum as a namespace until Swift has proper namespaces
-enum AlphaWallet {}
+public enum AlphaWallet {}
 
 //TODO move this to a standard alone internal Pod with 0 external dependencies so main app and TokenScript can use it?
 extension AlphaWallet {
-    enum Address: Hashable, Codable {
+    public enum Address: Hashable, Codable {
         //Computing EIP55 is really slow. Cache needed when we need to create many addresses, like parsing a whole lot of Ethereum event logs
         private static var cache: [String: Address] = .init()
 
@@ -47,7 +47,7 @@ extension AlphaWallet {
             self = Address.deriveEthereumAddress(fromPublicKey: publicKey)
         }
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: Key.self)
             let address = try container.decode(String.self, forKey: .ethereumAddress)
             self = .ethereumAddress(eip55String: address)
@@ -66,7 +66,7 @@ extension AlphaWallet {
             return Data(hexString: eip55String)!
         }
 
-        func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: Key.self)
             try container.encode(eip55String, forKey: .ethereumAddress)
         }
@@ -83,7 +83,7 @@ extension AlphaWallet {
 }
 
 extension AlphaWallet.Address {
-    static func == (lsh: AlphaWallet.Address, rhs: AlphaWallet.Address) -> Bool {
+    public static func == (lsh: AlphaWallet.Address, rhs: AlphaWallet.Address) -> Bool {
         return lsh.sameContract(as: rhs)
     }
 }

--- a/AlphaWallet/KeyManagement/EtherKeystore.swift
+++ b/AlphaWallet/KeyManagement/EtherKeystore.swift
@@ -480,7 +480,7 @@ open class EtherKeystore: Keystore {
     }
 
     func signEip712TypedData(_ data: EIP712TypedData, for account: AlphaWallet.Address) -> Result<Data, KeystoreError> {
-        return signHash(data.signHash, for: account)
+        signHash(data.digest, for: account)
     }
 
     func signTypedMessage(_ datas: [EthTypedData], for account: AlphaWallet.Address) -> Result<Data, KeystoreError> {

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -442,7 +442,7 @@ extension TokenInstanceWebView: WKScriptMessageHandler {
                 let msg = convertMessageToHex(msg: hexMessage)
                 let callbackID = command.id
                 signMessage(with: .personalMessage(Data(hex: msg)), account: account, callbackID: callbackID)
-            case .signTransaction, .sendTransaction, .signMessage, .signTypedMessage, .unknown, .sendRawTransaction:
+            case .signTransaction, .sendTransaction, .signMessage, .signTypedMessage, .unknown, .sendRawTransaction, .signTypedMessageV3:
                 return
             }
         case .watch:
@@ -500,8 +500,8 @@ extension TokenInstanceWebView {
                     callback = DappCallback(id: callbackID, value: .signPersonalMessage(data))
                 case .typedMessage:
                     callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
-                case .eip712:
-                    callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
+                case .eip712v3:
+                    callback = DappCallback(id: callbackID, value: .signTypedMessageV3(data))
                 }
                 strongSelf.notifyFinish(callbackID: callbackID, value: .success(callback))
             case .failure:

--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -9,7 +9,7 @@ enum SignMessageType {
     case message(Data)
     case personalMessage(Data)
     case typedMessage([EthTypedData])
-    case eip712(EIP712TypedData)
+    case eip712v3(EIP712TypedData)
 }
 
 protocol SignMessageCoordinatorDelegate: class {
@@ -64,7 +64,7 @@ class SignMessageCoordinator: Coordinator {
             } else {
                 result = keystore.signTypedMessage(typedData, for: account)
             }
-        case .eip712(let data):
+        case .eip712v3(let data):
             result = keystore.signEip712TypedData(data, for: account)
         }
         switch result {

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
@@ -80,14 +80,14 @@ struct ConfirmSignMessageViewControllerViewModel {
             return message
         case .typedMessage:
             return nil
-        case .eip712(let data):
+        case .eip712v3(let data):
             return data.rawStringValue
         }
     }
 
     var typedMessagesCount: Int {
         switch message {
-        case .message, .eip712, .personalMessage:
+        case .message, .eip712v3, .personalMessage:
             return 0
         case .typedMessage(let typedMessage):
             return typedMessage.count
@@ -96,7 +96,7 @@ struct ConfirmSignMessageViewControllerViewModel {
 
     private func typedMessage(at index: Int) -> EthTypedData? {
         switch message {
-        case .message, .eip712, .personalMessage:
+        case .message, .eip712v3, .personalMessage:
             return nil
         case .typedMessage(let typedMessage):
             if index < typedMessage.count {

--- a/AlphaWallet/Vendors/TrustCore/ABIEncoder.swift
+++ b/AlphaWallet/Vendors/TrustCore/ABIEncoder.swift
@@ -29,6 +29,8 @@ public final class ABIEncoder {
             try encode(value)
         case .address(let address):
             try encode(address)
+        case .address2(let address):
+            try encode(address)
         case .bool(let value):
             try encode(value)
         case .fixed(_, _, let value):
@@ -159,6 +161,12 @@ public final class ABIEncoder {
     //TODO change this to use AlphaWallet.Address?
     /// Encodes an address
     public func encode(_ address: Address) throws {
+        let padding = ((address.data.count + 31) / 32) * 32 - address.data.count
+        data.append(Data(repeating: 0, count: padding))
+        data.append(address.data)
+    }
+
+    public func encode(_ address: AlphaWallet.Address) throws {
         let padding = ((address.data.count + 31) / 32) * 32 - address.data.count
         data.append(Data(repeating: 0, count: padding))
         data.append(address.data)

--- a/AlphaWallet/Vendors/TrustCore/ABIValue.swift
+++ b/AlphaWallet/Vendors/TrustCore/ABIValue.swift
@@ -16,7 +16,6 @@ public indirect enum ABIValue: Equatable {
     case int(bits: Int, BigInt)
 
     /// Address, similar to `uint(bits: 160)`
-    //TODO change this to use AlphaWallet.Address?
     case address(Address)
 
     //TODO eventually replace `address` with this

--- a/AlphaWallet/Vendors/TrustCore/ABIValue.swift
+++ b/AlphaWallet/Vendors/TrustCore/ABIValue.swift
@@ -19,6 +19,9 @@ public indirect enum ABIValue: Equatable {
     //TODO change this to use AlphaWallet.Address?
     case address(Address)
 
+    //TODO eventually replace `address` with this
+    case address2(AlphaWallet.Address)
+
     /// Boolean
     case bool(Bool)
 
@@ -58,6 +61,8 @@ public indirect enum ABIValue: Equatable {
             return .int(bits: bits)
         case .address:
             return .address
+        case .address2:
+            return .address
         case .bool:
             return .bool
         case .fixed(let bits, let scale, _):
@@ -84,7 +89,7 @@ public indirect enum ABIValue: Equatable {
     /// Encoded length in bytes
     public var length: Int {
         switch self {
-        case .uint, .int, .address, .bool, .fixed, .ufixed:
+        case .uint, .int, .address, .address2, .bool, .fixed, .ufixed:
             return 32
         case .bytes(let data):
             return ((data.count + 31) / 32) * 32
@@ -107,7 +112,7 @@ public indirect enum ABIValue: Equatable {
     /// Whether the value is dynamic
     public var isDynamic: Bool {
         switch self {
-        case .uint, .int, .address, .bool, .fixed, .ufixed, .bytes, .array:
+        case .uint, .int, .address, .address2, .bool, .fixed, .ufixed, .bytes, .array:
             return false
         case .dynamicBytes, .string, .dynamicArray:
             return true
@@ -135,6 +140,8 @@ public indirect enum ABIValue: Equatable {
             self = .int(bits: bits, value)
         case (.address, let address as Address):
             self = .address(address)
+        case (.address, let address as AlphaWallet.Address):
+            self = .address2(address)
         case (.bool, let value as Bool):
             self = .bool(value)
         case (.fixed(let bits, let scale), let value as BigInt):
@@ -171,6 +178,8 @@ public indirect enum ABIValue: Equatable {
             return value
         case .address(let value):
             return value
+        case .address2(let value):
+            return Address(address: value)
         case .bool(let value):
             return value
         case .fixed(_, _, let value):

--- a/AlphaWallet/WalletConnect/Types/WalletConnectActionType.swift
+++ b/AlphaWallet/WalletConnect/Types/WalletConnectActionType.swift
@@ -10,11 +10,11 @@ import Foundation
 extension WalletConnectServer {
 
     struct Action {
-        
+
         enum ActionType {
             case signMessage(String)
             case signPersonalMessage(String)
-            case signTypedMessage(EIP712TypedData)
+            case signTypedMessageV3(EIP712TypedData)
             case signTransaction(UnconfirmedTransaction)
             case sendTransaction(UnconfirmedTransaction)
             case sendRawTransaction(String)
@@ -28,35 +28,8 @@ extension WalletConnectServer {
     }
 
     struct Callback {
-
-        enum Value {
-            case signTransaction(Data)
-            case sentTransaction(Data)
-            case signMessage(Data)
-            case signPersonalMessage(Data)
-            case signTypedMessage(Data)
-            case getTransactionCount(Data)
-
-            var object: String {
-                switch self {
-                case .signTransaction(let data):
-                    return data.hexEncoded
-                case .sentTransaction(let data):
-                    return data.hexEncoded
-                case .signMessage(let data):
-                    return data.hexEncoded
-                case .signPersonalMessage(let data):
-                    return data.hexEncoded
-                case .signTypedMessage(let data):
-                    return data.hexEncoded
-                case .getTransactionCount(let data):
-                    return data.hexEncoded
-                }
-            }
-        }
-
         let id: WalletConnectRequestID
         let url: WalletConnectURL
-        let value: Value
+        let value: Data
     }
 }

--- a/AlphaWallet/WalletConnect/Types/WalletConnectServerRequest.swift
+++ b/AlphaWallet/WalletConnect/Types/WalletConnectServerRequest.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import WalletConnectSwift 
+import WalletConnectSwift
 
 extension WalletConnectServer {
 
@@ -76,7 +76,7 @@ extension WalletConnectServer {
                 self = .sendRawTransaction(data)
             case .getTransactionCount:
                 let data = try request.parameter(of: String.self, at: 0)
-                
+
                 self = .getTransactionCount(data)
             case .none:
                 self = .unknown
@@ -95,7 +95,7 @@ private enum EIP712TypedDataPair: Decodable {
             case invalid
         }
         let container = try decoder.singleValueContainer()
-        
+
         if let value = try? container.decode(String.self) {
             self = .id(value)
         } else if let value = try? container.decode(EIP712TypedData.self) {

--- a/AlphaWallet/WalletConnect/WalletConnectServer.swift
+++ b/AlphaWallet/WalletConnect/WalletConnectServer.swift
@@ -88,7 +88,7 @@ class WalletConnectServer {
     }
 
     func fulfill(_ callback: Callback, request: WalletConnectSwift.Request) throws {
-        let response = try Response(url: callback.url, value: callback.value.object, id: callback.id)
+        let response = try Response(url: callback.url, value: callback.value.hexEncoded, id: callback.id)
         server.send(response)
     }
 
@@ -158,7 +158,7 @@ extension WalletConnectServer: RequestHandler {
                 return .value(.signTransaction(data))
             case .signTypedData(_, let data):
 
-                return .value(.signTypedMessage(data))
+                return .value(.signTypedMessageV3(data))
             case .sendTransaction(let data):
                 let data = UnconfirmedTransaction(transactionType: transactionType, bridge: data)
 


### PR DESCRIPTION
Note that this was tested against https://danfinlay.github.io/js-eth-personal-sign-examples/ in the dapp browser rather than with WalletConnect.

The bulk of the change is in `EIP712TypedData.swift`.

This PR doesn't work in the dapp browser though because there are a few missing things:

* The version of `HookedWalletSubprovider` included and used by the web3 provider doesn't support EIP712v3
* `web3.currentProvider.sendAsync({ method: 'net_version', ... })` doesn't work in our dapp browser

The above were temporarily fixed during development for testing. Will follow up with separate PR(s) if we can fix them properly and enable EIP712v3 for the dapp browser.