### PR TITLE
Use the chainId in the WalletConnect connection request, if provided and don't ask the user to choose chain

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -525,6 +525,7 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.status.online" = "Online";
 "walletConnect.status.offline" = "Offline";
 "walletConnect.session.name" = "Name";
+"walletConnect.session.connect" = "Connect on %@";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -525,6 +525,7 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.status.online" = "Online";
 "walletConnect.status.offline" = "Offline";
 "walletConnect.session.name" = "Name";
+"walletConnect.session.connect" = "Connect on %@";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -525,6 +525,7 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.status.online" = "Online";
 "walletConnect.status.offline" = "Offline";
 "walletConnect.session.name" = "Name";
+"walletConnect.session.connect" = "Connect on %@";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -525,6 +525,7 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.status.online" = "Online";
 "walletConnect.status.offline" = "Offline";
 "walletConnect.session.name" = "Name";
+"walletConnect.session.connect" = "Connect on %@";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -525,6 +525,7 @@ You can check the latest gas price on gasnow.org";
 "walletConnect.status.online" = "Online";
 "walletConnect.status.offline" = "Offline";
 "walletConnect.session.name" = "Name";
+"walletConnect.session.connect" = "Connect on %@";
 "walletConnect.session.connectedURL" = "Connected to";
 "walletConnect.session.disconnect" = "Disconnect";
 "walletConnect.session.signedTransactions" = "Signed Transactions"; 

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -179,7 +179,7 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
     }
 
     func server(_ server: WalletConnectServer, shouldConnectFor connection: WalletConnectConnection, completion: @escaping (WalletConnectServer.ConnectionChoice) -> Void) {
-        showConnectToSession(title: connection.name, url: connection.url, completion: completion)
+        showConnectToSession(connection: connection, completion: completion)
     }
 
     //TODO after we support sendRawTransaction in dapps (and hence a proper UI, be it the actionsheet for transaction confirmation or a simple prompt), let's modify this to use the same flow
@@ -244,23 +244,38 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
         }
     }
 
-    private func showConnectToSession(title: String, url: WCURL, completion: @escaping (WalletConnectServer.ConnectionChoice) -> Void) {
+    private func showConnectToSession(connection: WalletConnectConnection, completion: @escaping (WalletConnectServer.ConnectionChoice) -> Void) {
         let style: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
-        let alertViewController = UIAlertController(title: title, message: R.string.localizable.walletConnectStart(url.absoluteString), preferredStyle: style)
-
-        for each in serverChoices {
-            let action = UIAlertAction(title: each.name, style: .default) { _ in
-                completion(.connect(each))
+        if let server = connection.server {
+            let alertViewController = UIAlertController(title: connection.name, message: connection.url.absoluteString, preferredStyle: style)
+            let startAction = UIAlertAction(title: R.string.localizable.walletConnectSessionConnect(server.name), style: .default) { _ in
+                completion(.connect(server))
             }
-            alertViewController.addAction(action)
-        }
 
-        let cancelAction = UIAlertAction(title: R.string.localizable.cancel(), style: .cancel) { _ in
-            completion(.cancel)
-        }
-        alertViewController.addAction(cancelAction)
+            let cancelAction = UIAlertAction(title: R.string.localizable.cancel(), style: .cancel) { _ in
+                completion(.cancel)
+            }
 
-        navigationController.present(alertViewController, animated: true)
+            alertViewController.addAction(startAction)
+            alertViewController.addAction(cancelAction)
+
+            navigationController.present(alertViewController, animated: true)
+        } else {
+            let alertViewController = UIAlertController(title: connection.name, message: R.string.localizable.walletConnectStart(connection.url.absoluteString), preferredStyle: style)
+            for each in serverChoices {
+                let action = UIAlertAction(title: each.name, style: .default) { _ in
+                    completion(.connect(each))
+                }
+                alertViewController.addAction(action)
+            }
+
+            let cancelAction = UIAlertAction(title: R.string.localizable.cancel(), style: .cancel) { _ in
+                completion(.cancel)
+            }
+            alertViewController.addAction(cancelAction)
+
+            navigationController.present(alertViewController, animated: true)
+        }
     }
 }
 

--- a/AlphaWallet/WalletConnect/WalletConnectServer.swift
+++ b/AlphaWallet/WalletConnect/WalletConnectServer.swift
@@ -245,10 +245,12 @@ struct WalletConnectConnection {
     let url: WCURL
     let name: String
     let icon: URL?
+    let server: RPCServer?
 
     init(dAppInfo info: Session.DAppInfo, url: WCURL) {
         self.url = url
         name = info.peerMeta.name
         icon = info.peerMeta.icons.first
+        server = info.chainId.flatMap { .init(chainID: $0) }
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -39,7 +39,7 @@ target 'AlphaWallet' do
   pod 'Mixpanel-swift'
   pod 'UnstoppableDomainsResolution', '0.1.6'
   pod 'BlockiesSwift'
-  pod 'WalletConnectSwift' 
+  pod 'WalletConnectSwift', :git => 'https://github.com/WalletConnect/WalletConnectSwift.git', :commit => 'c86938785303b99ff09d90e32e553ce38eee0aa6'
 
   # pod 'AWSCognito'
   target 'AlphaWalletTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -92,7 +92,7 @@ PODS:
   - UnstoppableDomainsResolution (0.1.6):
     - Base58Swift (~> 2.1)
     - EthereumABI (~> 1.3)
-  - WalletConnectSwift (1.3.0):
+  - WalletConnectSwift (1.3.1):
     - CryptoSwift (~> 1.2)
     - Starscream (~> 3.1)
   - web3swift (0.9.0):
@@ -139,7 +139,7 @@ DEPENDENCIES:
   - TrustKeystore (from `https://github.com/alpha-wallet/trust-keystore.git`, commit `c0bdc4f6ffc117b103e19d17b83109d4f5a0e764`)
   - TrustWalletCore
   - UnstoppableDomainsResolution (= 0.1.6)
-  - WalletConnectSwift
+  - WalletConnectSwift (from `https://github.com/WalletConnect/WalletConnectSwift.git`, commit `c86938785303b99ff09d90e32e553ce38eee0aa6`)
   - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `169e50e29b60df72351c689a002005d2e2bc7559`)
 
 SPEC REPOS:
@@ -181,7 +181,6 @@ SPEC REPOS:
     - SWXMLHash
     - TrustWalletCore
     - UnstoppableDomainsResolution
-    - WalletConnectSwift
 
 EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
@@ -210,6 +209,9 @@ EXTERNAL SOURCES:
   TrustKeystore:
     :commit: c0bdc4f6ffc117b103e19d17b83109d4f5a0e764
     :git: https://github.com/alpha-wallet/trust-keystore.git
+  WalletConnectSwift:
+    :commit: c86938785303b99ff09d90e32e553ce38eee0aa6
+    :git: https://github.com/WalletConnect/WalletConnectSwift.git
   web3swift:
     :commit: 169e50e29b60df72351c689a002005d2e2bc7559
     :git: https://github.com/AlphaWallet/web3swift.git
@@ -242,6 +244,9 @@ CHECKOUT OPTIONS:
   TrustKeystore:
     :commit: c0bdc4f6ffc117b103e19d17b83109d4f5a0e764
     :git: https://github.com/alpha-wallet/trust-keystore.git
+  WalletConnectSwift:
+    :commit: c86938785303b99ff09d90e32e553ce38eee0aa6
+    :git: https://github.com/WalletConnect/WalletConnectSwift.git
   web3swift:
     :commit: 169e50e29b60df72351c689a002005d2e2bc7559
     :git: https://github.com/AlphaWallet/web3swift.git
@@ -293,9 +298,9 @@ SPEC CHECKSUMS:
   TrustKeystore: 3d8b4571c66648fb985015c96b3185440bb837fe
   TrustWalletCore: 84a87886e55b4efa875b452926d3ba58a32359c8
   UnstoppableDomainsResolution: dc89a8d9e51f3786b46274b457875a231d5bdbb8
-  WalletConnectSwift: e7854a4b333046977934d2835374f1bf411b571d
+  WalletConnectSwift: cd5e056cec5a2f44e92b8595199e7f2f9f0bd92d
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
 
-PODFILE CHECKSUM: f54afae84b68bb9cdb486b73c483d29600787d5e
+PODFILE CHECKSUM: e82a0f8696385f905e177a0121b5ecdbb4ef0eca
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
If `chainId` is provided in the incoming request:

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/103859943-e5f23f00-50f5-11eb-9270-f0d6b67e29b2.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/103859958-e985c600-50f5-11eb-8da3-205f1dea93bd.png'>
