### PR TITLE
Display the chain which each WalletConnect session is connected for

### DIFF
--- a/AlphaWallet/WalletConnect/Controllers/WalletConnectSessionsViewController.swift
+++ b/AlphaWallet/WalletConnect/Controllers/WalletConnectSessionsViewController.swift
@@ -19,11 +19,13 @@ class WalletConnectSessionsViewController: UIViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         return tableView
     }()
+    private let urlToServer: [WalletConnectURL: RPCServer]
 
     weak var delegate: WalletConnectSessionsViewControllerDelegate?
 
-    init(sessions: Subscribable<[WalletConnectSession]>) {
+    init(sessions: Subscribable<[WalletConnectSession]>, urlToServer: [WalletConnectURL: RPCServer]) {
         self.sessions = sessions
+        self.urlToServer = urlToServer
         super.init(nibName: nil, bundle: nil)
 
         view.addSubview(tableView)
@@ -60,8 +62,12 @@ extension WalletConnectSessionsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(for: indexPath) as WalletConnectSessionCell
         guard let session = sessions.value?[indexPath.row] else { return cell }
-        let viewModel = WalletConnectSessionCellViewModel(session: session)
-        cell.configure(viewModel: viewModel)
+        if let server = urlToServer[session.url] {
+            let viewModel = WalletConnectSessionCellViewModel(session: session, server: server)
+            cell.configure(viewModel: viewModel)
+        } else {
+            //Should be impossible
+        }
         return cell
     }
 

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -64,7 +64,7 @@ class WalletConnectCoordinator: NSObject, Coordinator {
             let session = sessions[0]
             display(session: session, withNavigationController: navigationController)
         } else {
-            let viewController = WalletConnectSessionsViewController(sessions: server.sessions)
+            let viewController = WalletConnectSessionsViewController(sessions: server.sessions, urlToServer: server.urlToServer)
             viewController.delegate = self
             viewController.configure()
             navigationController.pushViewController(viewController, animated: true)

--- a/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
+++ b/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionDetailsViewController.swift
@@ -25,6 +25,7 @@ class WalletConnectSessionViewController: UIViewController {
     private let statusRow = WalletConnectRowView()
     private let nameRow = WalletConnectRowView()
     private let connectedToRow = WalletConnectRowView()
+    private let chainRow = WalletConnectRowView()
     private let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
     private let roundedBackground = RoundedBackground()
     private let separatorList: UIView = {
@@ -45,6 +46,7 @@ class WalletConnectSessionViewController: UIViewController {
             statusRow,
             nameRow,
             connectedToRow,
+            chainRow,
             separatorList
         ].asStackView(axis: .vertical)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -106,6 +108,7 @@ class WalletConnectSessionViewController: UIViewController {
         statusRow.configure(viewModel: viewModel.statusRowViewModel)
         nameRow.configure(viewModel: viewModel.nameRowViewModel)
         connectedToRow.configure(viewModel: viewModel.connectedToRowViewModel)
+        chainRow.configure(viewModel: viewModel.chainRowViewModel)
         imageView.image = viewModel.walletImageIcon
 
         let button0 = buttonsBar.buttons[0]

--- a/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionCellViewModel.swift
+++ b/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionCellViewModel.swift
@@ -3,11 +3,8 @@
 import UIKit
 
 struct WalletConnectSessionCellViewModel {
-    private let session: WalletConnectSession
-
-    init(session: WalletConnectSession) {
-        self.session = session
-    }
+    let session: WalletConnectSession
+    let server: RPCServer
 
     var backgroundColor: UIColor {
         Colors.appBackground
@@ -18,6 +15,6 @@ struct WalletConnectSessionCellViewModel {
     }
 
     var name: String {
-        session.dAppInfo.peerMeta.name
+        "\(session.dAppInfo.peerMeta.name) (\(server.name))"
     }
 }

--- a/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionDetailsViewModel.swift
+++ b/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionDetailsViewModel.swift
@@ -46,6 +46,16 @@ struct WalletConnectSessionDetailsViewModel {
         )
     }
 
+    var chainRowViewModel: WallerConnectRawViewModel {
+        if let server = server.urlToServer[session.url] {
+            return .init(text: R.string.localizable.settingsNetworkButtonTitle(), details: server.name)
+        } else {
+            //Should be impossible
+            return .init(text: R.string.localizable.settingsNetworkButtonTitle(), details: "-")
+        }
+    }
+
+
     var dissconnectButtonText: String {
         return R.string.localizable.walletConnectSessionDisconnect()
     }


### PR DESCRIPTION
Closes #2397

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/104152651-22d27480-541b-11eb-8c14-997d30ae94c3.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/104152523-ca9b7280-541a-11eb-99f6-688d890c3d83.png'>
<img width='200' src='https://user-images.githubusercontent.com/56189/104152658-249c3800-541b-11eb-9ccf-a2a450a04671.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/104152527-ccfdcc80-541a-11eb-80b2-4ea790f15cb3.png'>
