### PR TITLE
Display more user-friendly message when there's not enough funds for sending a transaction instead of: "APIKit.Session-TaskError error 2"

### DIFF
--- a/AlphaWallet/Extensions/Session+PromiseKit.swift
+++ b/AlphaWallet/Extensions/Session+PromiseKit.swift
@@ -2,7 +2,14 @@
 
 import Foundation
 import APIKit
+import JSONRPCKit
 import PromiseKit
+
+struct InsufficientFundsError: LocalizedError {
+    var errorDescription: String? {
+        R.string.localizable.configureTransactionNotEnoughFunds()
+    }
+}
 
 extension Session {
     class func send<Request: APIKit.Request>(_ request: Request, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
@@ -12,6 +19,14 @@ extension Session {
                 case .success(let result):
                     seal.fulfill(result)
                 case .failure(let error):
+                    if case let .responseError(JSONRPCError.responseError(e)) = error {
+                        if e.message.hasPrefix("Insufficient funds") {
+                            seal.reject(InsufficientFundsError())
+                            return
+                        } else {
+                            //no-op
+                        }
+                    }
                     seal.reject(error)
                 }
             }

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -491,6 +491,7 @@
 "configureTransaction.barButton.useDefault" = "Use Default";
 "configureTransaction.header.gasPrice" = "Gas Price";
 "configureTransaction.header.gasLimit" = "Gas Limit";
+"configureTransaction.notEnoughFunds" = "Not enough funds to send this transaction";
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -491,6 +491,7 @@
 "configureTransaction.barButton.useDefault" = "Use Default";
 "configureTransaction.header.gasPrice" = "Gas Price";
 "configureTransaction.header.gasLimit" = "Gas Limit";
+"configureTransaction.notEnoughFunds" = "Not enough funds to send this transaction";
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -491,6 +491,7 @@
 "configureTransaction.barButton.useDefault" = "Use Default";
 "configureTransaction.header.gasPrice" = "Gas Price";
 "configureTransaction.header.gasLimit" = "Gas Limit";
+"configureTransaction.notEnoughFunds" = "Not enough funds to send this transaction";
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -491,6 +491,7 @@
 "configureTransaction.barButton.useDefault" = "Use Default";
 "configureTransaction.header.gasPrice" = "Gas Price";
 "configureTransaction.header.gasLimit" = "Gas Limit";
+"configureTransaction.notEnoughFunds" = "Not enough funds to send this transaction";
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -491,6 +491,7 @@
 "configureTransaction.barButton.useDefault" = "Use Default";
 "configureTransaction.header.gasPrice" = "Gas Price";
 "configureTransaction.header.gasLimit" = "Gas Limit";
+"configureTransaction.notEnoughFunds" = "Not enough funds to send this transaction";
 "transactionConfiguration.Type.slow" = "Slow";
 "transactionConfiguration.Type.average" = "Average";
 "transactionConfiguration.Type.fast" = "Fast";


### PR DESCRIPTION
Closes #2441.

Easiest way to reproduce is to send 0 eth on a testnet without funds.