### PR TITLE
Pretty print the Eip712v3 or v4 message to be signed

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -197,7 +197,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
                     callback = DappCallback(id: callbackID, value: .signPersonalMessage(data))
                 case .typedMessage:
                     callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
-                case .eip712v3:
+                case .eip712v3And4:
                     callback = DappCallback(id: callbackID, value: .signTypedMessageV3(data))
                 }
                 strongSelf.browserViewController.notifyFinish(callbackID: callbackID, value: .success(callback))
@@ -420,7 +420,7 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
         case .signTypedMessage(let typedData):
             signMessage(with: .typedMessage(typedData), account: account, callbackID: callbackID)
         case .signTypedMessageV3(let typedData):
-            signMessage(with: .eip712v3(typedData), account: account, callbackID: callbackID)
+            signMessage(with: .eip712v3And4(typedData), account: account, callbackID: callbackID)
         case .unknown, .sendRawTransaction:
             break
         }

--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -30,7 +30,7 @@ extension DappAction {
             return .signPersonalMessage(data)
         case .signTypedMessage:
             if let data = command.object["data"] {
-                if let eip712Data = data.eip712v3Data {
+                if let eip712Data = data.eip712v3And4Data {
                     return .signTypedMessageV3(eip712Data)
                 } else {
                     return .signTypedMessage(data.eip712PreV3Array)

--- a/AlphaWallet/Browser/Types/DappCommand.swift
+++ b/AlphaWallet/Browser/Types/DappCommand.swift
@@ -42,27 +42,27 @@ enum DappCallbackValue {
 struct DappCommandObjectValue: Decodable {
     var value: String = ""
     var eip712PreV3Array: [EthTypedData] = []
-    let eip712v3Data: EIP712TypedData?
+    let eip712v3And4Data: EIP712TypedData?
 
     init(from coder: Decoder) throws {
         let container = try coder.singleValueContainer()
         if let intValue = try? container.decode(Int.self) {
             value = String(intValue)
-            eip712v3Data = nil
+            eip712v3And4Data = nil
         } else if let stringValue = try? container.decode(String.self) {
             if let data = stringValue.data(using: .utf8), let object = try? JSONDecoder().decode(EIP712TypedData.self, from: data) {
                 value = ""
-                eip712v3Data = object
+                eip712v3And4Data = object
             } else {
                 value = stringValue
-                eip712v3Data = nil
+                eip712v3And4Data = nil
             }
         } else {
             var arrayContainer = try coder.unkeyedContainer()
             while !arrayContainer.isAtEnd {
                 eip712PreV3Array.append(try arrayContainer.decode(EthTypedData.self))
             }
-            eip712v3Data = nil
+            eip712v3And4Data = nil
         }
     }
 }

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -500,7 +500,7 @@ extension TokenInstanceWebView {
                     callback = DappCallback(id: callbackID, value: .signPersonalMessage(data))
                 case .typedMessage:
                     callback = DappCallback(id: callbackID, value: .signTypedMessage(data))
-                case .eip712v3:
+                case .eip712v3And4:
                     callback = DappCallback(id: callbackID, value: .signTypedMessageV3(data))
                 }
                 strongSelf.notifyFinish(callbackID: callbackID, value: .success(callback))

--- a/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SignMessageCoordinator.swift
@@ -9,7 +9,7 @@ enum SignMessageType {
     case message(Data)
     case personalMessage(Data)
     case typedMessage([EthTypedData])
-    case eip712v3(EIP712TypedData)
+    case eip712v3And4(EIP712TypedData)
 }
 
 protocol SignMessageCoordinatorDelegate: class {
@@ -64,7 +64,7 @@ class SignMessageCoordinator: Coordinator {
             } else {
                 result = keystore.signTypedMessage(typedData, for: account)
             }
-        case .eip712v3(let data):
+        case .eip712v3And4(let data):
             result = keystore.signEip712TypedData(data, for: account)
         }
         switch result {

--- a/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfirmSignMessageViewController.swift
@@ -12,6 +12,7 @@ protocol ConfirmSignMessageViewControllerDelegate: class {
 class ConfirmSignMessageViewController: UIViewController {
     private let background = UIView()
 	private let header = TokensCardViewControllerTitleHeader()
+    private let subtitleLabel = UILabel()
     private let detailsBackground = UIView()
     private let singleMessageLabel = UILabel()
     private let singleMessageScrollView = UIScrollView()
@@ -60,6 +61,7 @@ class ConfirmSignMessageViewController: UIViewController {
 
         let stackView = [
 			header,
+            subtitleLabel,
             .spacer(height: 20),
             tableView,
             singleMessageScrollView,
@@ -121,13 +123,20 @@ class ConfirmSignMessageViewController: UIViewController {
 
             header.configure(title: viewModel.headerTitle)
 
-            singleMessageLabel.textAlignment = .center
+            subtitleLabel.textAlignment = .center
+            subtitleLabel.numberOfLines = 0
+            subtitleLabel.textColor = viewModel.subtitleColor
+            subtitleLabel.font = viewModel.subtitleFont
+            subtitleLabel.text = viewModel.subtitle
+
+            singleMessageLabel.textAlignment = viewModel.singleMessageLabelTextAlignment
             singleMessageLabel.numberOfLines = 0
             singleMessageLabel.textColor = viewModel.singleMessageLabelTextColor
             singleMessageLabel.font = viewModel.singleMessageLabelFont
-            singleMessageLabel.text = viewModel.singleMessageLabelText
+            singleMessageLabel.attributedText = viewModel.singleMessageLabelText
             //We don't need to check if it's more than 1 line, the scroll indicator wouldn't flash if there's too little content
-            if !viewModel.singleMessageLabelText.isEmpty {
+            let str = viewModel.singleMessageLabelText?.string
+            if !str.isEmpty {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                     self.singleMessageScrollView.flashScrollIndicators()
                 }

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
@@ -18,6 +18,28 @@ struct ConfirmSignMessageViewControllerViewModel {
         return R.string.localizable.confirmSignMessage()
 	}
 
+    var subtitle: String {
+        switch message {
+        case .message, .personalMessage, .typedMessage:
+            return ""
+        case .eip712v3(let message):
+            let name = message.domainName
+            if let verifyingContract = message.domainVerifyingContract {
+                return "\(name)\n\(verifyingContract.truncateMiddle)"
+            } else {
+                return name
+            }
+        }
+    }
+
+    var subtitleFont: UIFont {
+        Fonts.regular(size: 13)
+    }
+
+    var subtitleColor: UIColor {
+        Colors.appText
+    }
+
     var actionButtonTitleColor: UIColor {
         return Colors.appWhite
     }
@@ -59,6 +81,15 @@ struct ConfirmSignMessageViewControllerViewModel {
         return Colors.darkGray
     }
 
+    var singleMessageLabelTextAlignment: NSTextAlignment {
+        switch message {
+        case .message, .personalMessage, .typedMessage:
+            return .center
+        case .eip712v3:
+            return .left
+        }
+    }
+
     var nameTextFont: UIFont {
         return Fonts.semibold(size: 16)
     }
@@ -71,13 +102,13 @@ struct ConfirmSignMessageViewControllerViewModel {
         return UIColor(red: 236, green: 236, blue: 236)
     }
 
-    var singleMessageLabelText: String? {
+    var singleMessageLabelText: NSAttributedString? {
         switch message {
         case .message(let data), .personalMessage(let data):
             guard let message = String(data: data, encoding: .utf8) else {
-                return data.hexEncoded
+                return NSAttributedString(string: data.hexEncoded, attributes: [ .font: singleMessageLabelFont, .foregroundColor: singleMessageLabelTextColor ])
             }
-            return message
+            return NSAttributedString(string: message)
         case .typedMessage:
             return nil
         case .eip712v3(let data):
@@ -124,5 +155,93 @@ struct ConfirmSignMessageViewControllerViewModel {
                 name: typedMessageName(at: index) ?? "",
                 value: typedMessageValue(at: index) ?? ""
         )
+    }
+}
+
+extension EIP712TypedData {
+    var rawStringValue: NSAttributedString {
+        let str = message.formattedString()
+        return str
+    }
+}
+
+extension EIP712TypedData.JSON {
+    //TODO Better to follow the order define in the type
+    func formattedString(indentationLevel: Int = 0) -> NSAttributedString {
+        let nameAttributes: [NSAttributedString.Key : Any] = [.foregroundColor: Colors.gray, .font: Fonts.light(size: 15)]
+        let valueAttributes: [NSAttributedString.Key : Any] = [.foregroundColor: R.color.dove(), .font: Fonts.regular(size: 15)]
+
+        switch self {
+        case .object(let dictionary):
+            let nextLevelIndentationString = "".indented(indentationLevel + 2)
+            let indentation = NSAttributedString(string: "".indented(indentationLevel + 1))
+            let str = NSMutableAttributedString(string: "{\n".indented(indentationLevel), attributes: nameAttributes)
+            str.append(indentation)
+            str.append(dictionary.map { key, value in
+                switch value {
+                case .object, .array:
+                    let s = NSMutableAttributedString(string: "\(key):\n", attributes: nameAttributes)
+                    s.append(value.formattedString(indentationLevel: indentationLevel + 2))
+                    return s
+                case .string, .number, .bool, .null:
+                    let s = NSMutableAttributedString(string: "\(key): ", attributes: nameAttributes)
+                    s.append(value.formattedString())
+                    return s
+                }
+            }.joined(separator: NSAttributedString(string: ",\n\(nextLevelIndentationString)", attributes: nameAttributes)))
+            str.append(NSAttributedString(string: "\n"))
+            str.append(NSAttributedString(string: "}".indented(indentationLevel), attributes: nameAttributes))
+            return str
+        case .string(let value):
+            let fittedString: String
+            //Arbitrary limit to fit (some) addresses
+            //TODO improve truncation. Support different device width, also depending on shape of data
+            let limit = 18
+            if value.count > limit {
+                fittedString = "\(value.substring(to: [limit, value.count].min()!))…"
+            } else {
+                fittedString = value
+            }
+            return NSAttributedString(string: fittedString.indented(indentationLevel), attributes: valueAttributes)
+
+        case .number(let value):
+            return NSAttributedString(string: String(value).indented(indentationLevel), attributes: valueAttributes)
+        case .array(let array):
+            let str = NSMutableAttributedString(string: "[\n".indented(indentationLevel), attributes: nameAttributes)
+            str.append(array.map { $0.formattedString(indentationLevel: indentationLevel + 1) }.joined(separator: NSAttributedString(string: ",\n", attributes: nameAttributes)))
+            str.append(NSAttributedString(string: "\n"))
+            str.append(NSAttributedString(string: "]".indented(indentationLevel), attributes: nameAttributes))
+            return str
+        case .bool(let value):
+            return NSAttributedString(string: String(value).indented(indentationLevel), attributes: valueAttributes)
+        case .number(let value):
+            return NSAttributedString(string: String(value).indented(indentationLevel), attributes: valueAttributes)
+        case .null:
+            return NSAttributedString(string: "")
+        }
+    }
+}
+
+private extension String {
+    func indented(_ indentationLevel: Int) -> String {
+        let spacesPerIndentation = 1
+        let indentationPerLevel = " "
+        let indentation = String(repeating: indentationPerLevel, count: spacesPerIndentation * indentationLevel)
+        return "\(indentation)\(self)"
+    }
+}
+
+private extension Array where Element: NSAttributedString {
+    func joined(separator: NSAttributedString) -> NSAttributedString {
+        var isFirst = true
+        return self.reduce(NSMutableAttributedString()) { (sum, each) in
+            if isFirst {
+                isFirst = false
+            } else {
+                sum.append(separator)
+            }
+            sum.append(each)
+            return sum
+        }
     }
 }

--- a/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmSignMessageViewControllerViewModel.swift
@@ -22,7 +22,7 @@ struct ConfirmSignMessageViewControllerViewModel {
         switch message {
         case .message, .personalMessage, .typedMessage:
             return ""
-        case .eip712v3(let message):
+        case .eip712v3And4(let message):
             let name = message.domainName
             if let verifyingContract = message.domainVerifyingContract {
                 return "\(name)\n\(verifyingContract.truncateMiddle)"
@@ -85,7 +85,7 @@ struct ConfirmSignMessageViewControllerViewModel {
         switch message {
         case .message, .personalMessage, .typedMessage:
             return .center
-        case .eip712v3:
+        case .eip712v3And4:
             return .left
         }
     }
@@ -111,14 +111,14 @@ struct ConfirmSignMessageViewControllerViewModel {
             return NSAttributedString(string: message)
         case .typedMessage:
             return nil
-        case .eip712v3(let data):
+        case .eip712v3And4(let data):
             return data.rawStringValue
         }
     }
 
     var typedMessagesCount: Int {
         switch message {
-        case .message, .eip712v3, .personalMessage:
+        case .message, .eip712v3And4, .personalMessage:
             return 0
         case .typedMessage(let typedMessage):
             return typedMessage.count
@@ -127,7 +127,7 @@ struct ConfirmSignMessageViewControllerViewModel {
 
     private func typedMessage(at index: Int) -> EthTypedData? {
         switch message {
-        case .message, .eip712v3, .personalMessage:
+        case .message, .eip712v3And4, .personalMessage:
             return nil
         case .typedMessage(let typedMessage):
             if index < typedMessage.count {

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -113,7 +113,7 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
             case .signPersonalMessage(let hexMessage):
                 return self.signMessage(with: .personalMessage(hexMessage.toHexData), account: account, callbackID: action.id, url: action.url)
             case .signTypedMessageV3(let typedData):
-                return self.signMessage(with: .eip712v3(typedData), account: account, callbackID: action.id, url: action.url)
+                return self.signMessage(with: .eip712v3And4(typedData), account: account, callbackID: action.id, url: action.url)
             case .sendRawTransaction(let raw):
                 return self.sendRawTransaction(session: session, rawTransaction: raw, callbackID: action.id, url: action.url)
             case .getTransactionCount:


### PR DESCRIPTION
* Pretty print the EIP712v3 or v4 message to be signed
* Also display the `domain` information

The second commit is just a rename for the enum-case and var name.

Barring bugs or tweaks to the UI, this should close everything EIP712 for a while.

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/104892766-888ba700-59ad-11eb-9cfb-da93e6c058e4.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/104892621-5f6b1680-59ad-11eb-95ac-29f76f1bbd47.png'>
