### PR TITLE
Disable actionsheet's (for transaction confirmation) Confirm button briefly when the gas fee displayed changes so the user has the chance to review

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -199,12 +199,12 @@ extension TransactionConfirmationCoordinator: TransactionConfiguratorDelegate {
 
     func gasLimitEstimateUpdated(to estimate: BigInt, in configurator: TransactionConfigurator) {
         configureTransactionViewController?.configure(withEstimatedGasLimit: estimate)
-        confirmationViewController.reloadView()
+        confirmationViewController.reloadViewWithGasChanges()
     }
 
     func gasPriceEstimateUpdated(to estimate: BigInt, in configurator: TransactionConfigurator) {
         configureTransactionViewController?.configure(withEstimatedGasPrice: estimate, configurator: configurator)
-        confirmationViewController.reloadView()
+        confirmationViewController.reloadViewWithGasChanges()
     }
 
     func updateNonce(to nonce: Int, in configurator: TransactionConfigurator) {

--- a/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
@@ -21,6 +21,7 @@ class TransactionConfirmationViewController: UIViewController {
     private lazy var headerView: HeaderView = HeaderView(viewModel: .init(title: viewModel.navigationTitle))
     private let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
     private var viewModel: TransactionConfirmationViewModel
+    private var timerToReenableConfirmButton: Timer?
 
     private let stackView: UIStackView = {
         let stackView = UIStackView()
@@ -95,6 +96,7 @@ class TransactionConfirmationViewController: UIViewController {
 
     private var allowPresentationAnimation: Bool = true
     private var allowDismissialAnimation: Bool = true
+    private var canBeConfirmed = true
 
     var canBeDismissed = true
     weak var delegate: TransactionConfirmationViewControllerDelegate?
@@ -333,6 +335,20 @@ class TransactionConfirmationViewController: UIViewController {
         generateSubviews()
     }
 
+    func reloadViewWithGasChanges() {
+        canBeConfirmed = false
+        reloadView()
+        createTimerToRestoreConfirmButton()
+    }
+
+    private func createTimerToRestoreConfirmButton() {
+        timerToReenableConfirmButton?.invalidate()
+        let gap = TimeInterval(0.3)
+        timerToReenableConfirmButton = Timer.scheduledTimer(withTimeInterval: gap, repeats: false) { [weak self] _ in
+            self?.canBeConfirmed = true
+        }
+    }
+
     private func configure(for viewModel: TransactionConfirmationViewModel) {
         scrollView.backgroundColor = viewModel.backgroundColor
         view.backgroundColor = viewModel.backgroundColor
@@ -346,6 +362,7 @@ class TransactionConfirmationViewController: UIViewController {
     }
 
     @objc func confirmButtonTapped(_ sender: UIButton) {
+        guard canBeConfirmed else { return }
         delegate?.controller(self, continueButtonTapped: sender)
     }
 


### PR DESCRIPTION
Follow up to #2463