### PR TITLE
Fix: signing of EIP712 message which includes bytes

### DIFF
--- a/AlphaWallet/WalletConnect/Types/EIP712TypedData.swift
+++ b/AlphaWallet/WalletConnect/Types/EIP712TypedData.swift
@@ -133,8 +133,11 @@ extension EIP712TypedData {
 
     /// Helper func for `encodeData`
     private func makeABIValue(data: JSON?, type: String) -> ABIValue? {
-        if (type == "string" || type == "bytes"), let value = data?.stringValue, let valueData = value.data(using: .utf8) {
+        if type == "string", let value = data?.stringValue, let valueData = value.data(using: .utf8) {
             return try? ABIValue(Crypto.hash(valueData), type: .bytes(32))
+        } else if type == "bytes", let value = data?.stringValue {
+            let data = Data(hex: value.drop0x)
+            return try? ABIValue(Crypto.hash(data), type: .bytes(32))
         } else if type == "bool", let value = data?.boolValue {
             return try? ABIValue(value, type: .bool)
             //Using `AlphaWallet.Address(uncheckedAgainstNullAddress:)` instead of `AlphaWallet.Address(string:)` because EIP712v3 test pages like to use the contract 0xb...b which fails the burn address check


### PR DESCRIPTION
Fixes #2480 fixes #2462

Reproducible with https://example.walletconnect.org