### PR TITLE
Fix: dapp web3 provider needs to invoke Dapp's callbacks for `eth_call` when an error has occurred

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -163,7 +163,12 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
             let callback = DappCallback(id: callbackID, value: .ethCall(result))
             self.browserViewController.notifyFinish(callbackID: callbackID, value: .success(callback))
         }.catch { error in
-            //TODO handle error. Can we let the dapp know?
+            if case let SessionTaskError.responseError(JSONRPCError.responseError(e)) = error {
+                self.browserViewController.notifyFinish(callbackID: callbackID, value: .failure(.nodeError(e.message)))
+            } else {
+                //TODO better handle. User didn't cancel
+                self.browserViewController.notifyFinish(callbackID: callbackID, value: .failure(.cancelled))
+            }
         }
     }
 
@@ -455,7 +460,7 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
         case .unknown, .sendRawTransaction:
             break
         }
-    } 
+    }
 
     func didVisitURL(url: URL, title: String, inBrowserViewController viewController: BrowserViewController) {
         browserNavBar?.display(url: url)

--- a/AlphaWallet/Browser/Types/DAppError.swift
+++ b/AlphaWallet/Browser/Types/DAppError.swift
@@ -4,4 +4,15 @@ import Foundation
 
 enum DAppError: Error {
     case cancelled
+    case nodeError(String)
+
+    var message: String {
+        switch self {
+        case .cancelled:
+            //This is the default behavior, just keep it
+            return "\(self)"
+        case .nodeError(let message):
+            return message
+        }
+    }
 }

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -153,7 +153,7 @@ final class BrowserViewController: UIViewController {
             case .success(let result):
                 return "executeCallback(\(callbackID), null, \"\(result.value.object)\")"
             case .failure(let error):
-                return "executeCallback(\(callbackID), \"\(error)\", null)"
+                return "executeCallback(\(callbackID), \"\(error.message)\", null)"
             }
         }()
         webView.evaluateJavaScript(script, completionHandler: nil)


### PR DESCRIPTION
Closes #2516.

This fixes the problem where the dapp makes an `eth_call` which fails and blocks on it and get stuck if the `eth_call` fails.

Pseudo code for dapp:

```
let tokenName = await contract.getName() //uses eth_call underneath
//do something else. Never reach here since we don't return an error, the promise above don't reject
```