### PR TITLE
Fix: handle WalletConnect links when the mobile link is launched in dapp browser

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -329,6 +329,11 @@ extension AppCoordinator: InCoordinatorDelegate {
         guard universalLinkCoordinator == nil else { return }
         handleUniversalLink(url: url)
     }
+
+    func handleUniversalLink(_ url: URL, forCoordinator coordinator: InCoordinator) {
+        guard universalLinkCoordinator == nil else { return }
+        handleUniversalLink(url: url)
+    }
 }
 
 extension AppCoordinator: UniversalLinkCoordinatorDelegate {

--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -12,6 +12,7 @@ import Result
 protocol DappBrowserCoordinatorDelegate: class {
     func didSentTransaction(transaction: SentTransaction, inCoordinator coordinator: DappBrowserCoordinator)
     func importUniversalLink(url: URL, forCoordinator coordinator: DappBrowserCoordinator)
+    func handleUniversalLink(_ url: URL, forCoordinator coordinator: DappBrowserCoordinator)
 }
 
 final class DappBrowserCoordinator: NSObject, Coordinator {
@@ -471,6 +472,10 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
 
     func forceUpdate(url: URL, inBrowserViewController viewController: BrowserViewController) {
         browserNavBar?.display(url: url)
+    }
+
+    func handleUniversalLink(_ url: URL, inBrowserViewController viewController: BrowserViewController) {
+        delegate?.handleUniversalLink(url, forCoordinator: self)
     }
 }
 

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -11,6 +11,7 @@ protocol BrowserViewControllerDelegate: class {
     func didVisitURL(url: URL, title: String, inBrowserViewController viewController: BrowserViewController)
     func dismissKeyboard(inBrowserViewController viewController: BrowserViewController)
     func forceUpdate(url: URL, inBrowserViewController viewController: BrowserViewController)
+    func handleUniversalLink(_ url: URL, inBrowserViewController viewController: BrowserViewController)
 }
 
 final class BrowserViewController: UIViewController {
@@ -221,8 +222,12 @@ extension BrowserViewController: WKNavigationDelegate {
             app.open(url)
             return decisionHandler(.cancel)
         }
-        decisionHandler(.allow)
+        if url.host == "aw.app" && url.path == UniversalLinkCoordinator.walletConnectPath {
+            delegate?.handleUniversalLink(url, inBrowserViewController: self)
+            return decisionHandler(.cancel)
+        }
 
+        decisionHandler(.allow)
     }
 }
 

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -11,6 +11,7 @@ protocol InCoordinatorDelegate: class {
     func didShowWallet(in coordinator: InCoordinator)
     func assetDefinitionsOverrideViewController(for coordinator: InCoordinator) -> UIViewController?
     func importUniversalLink(url: URL, forCoordinator coordinator: InCoordinator)
+    func handleUniversalLink(_ url: URL, forCoordinator coordinator: InCoordinator)
 }
 
 enum Tabs {
@@ -666,7 +667,7 @@ class InCoordinator: NSObject, Coordinator {
 
     func listOfBadTokenScriptFilesChanged(fileNames: [TokenScriptFileIndices.FileName]) {
         tokensCoordinator?.listOfBadTokenScriptFilesChanged(fileNames: fileNames)
-    } 
+    }
 
     private func createWalletConnectCoordinator() -> WalletConnectCoordinator {
         let coordinator = WalletConnectCoordinator(keystore: keystore, sessions: walletSessions, navigationController: navigationController, analyticsCoordinator: analyticsCoordinator, config: config, nativeCryptoCurrencyPrices: nativeCryptoCurrencyPrices)
@@ -882,6 +883,10 @@ extension InCoordinator: DappBrowserCoordinatorDelegate {
 
     func importUniversalLink(url: URL, forCoordinator coordinator: DappBrowserCoordinator) {
         delegate?.importUniversalLink(url: url, forCoordinator: self)
+    }
+
+    func handleUniversalLink(_ url: URL, forCoordinator coordinator: DappBrowserCoordinator) {
+        delegate?.handleUniversalLink(url, forCoordinator: self)
     }
 }
 

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -22,7 +22,7 @@ class UniversalLinkCoordinator: Coordinator {
         case paid(signedOrder: SignedOrder, tokenObject: TokenObject)
     }
 
-    private static let walletConnectPath = "/wc"
+    static let walletConnectPath = "/wc"
 
     private let wallet: Wallet
     private let config: Config


### PR DESCRIPTION
Related to #2498 and #2528

Make sure that when WalletConnect and mobile link button is used in the dapp browser, we connect to WalletConnect properly instead of opening the universal link  in the dapp browser
