### PR TITLE
Fix: Disable error about malformed JSON if it appears to be caused by Binance testnet timing out (as there's nothing we can do about it)

### DIFF
--- a/AlphaWallet/EtherClient/ChainState.swift
+++ b/AlphaWallet/EtherClient/ChainState.swift
@@ -54,7 +54,12 @@ class ChainState {
             Session.send(request)
         }.done {
             self.latestBlock = $0
-        }.cauterize()
+        }.catch { error in
+            //We need to catch (and since we can make a good guess what it might be, capture it below) it instead of `.cauterize()` because the latter would log a scary message about malformed JSON in the console.
+            if error is PossibleBinanceTestnetTimeoutError {
+                //TODO log
+            }
+        }
     }
 
     func confirmations(fromBlock: Int) -> Int? {

--- a/AlphaWallet/Extensions/Session+PromiseKit.swift
+++ b/AlphaWallet/Extensions/Session+PromiseKit.swift
@@ -11,6 +11,9 @@ struct InsufficientFundsError: LocalizedError {
     }
 }
 
+struct PossibleBinanceTestnetTimeoutError: LocalizedError {
+}
+
 extension Session {
     class func send<Request: APIKit.Request>(_ request: Request, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
         Promise { seal in
@@ -26,6 +29,11 @@ extension Session {
                         } else {
                             //no-op
                         }
+                    }
+                    if case let SessionTaskError.responseError(e) = error, RPCServer.binance_smart_chain_testnet.rpcURL.absoluteString == request.baseURL.absoluteString, e.localizedDescription == "The data couldn’t be read because it isn’t in the correct format." {
+                        //This is potentially Binance testnet timing out
+                        seal.reject(PossibleBinanceTestnetTimeoutError())
+                        return
                     }
                     seal.reject(error)
                 }


### PR DESCRIPTION
Closes #2531 