### PR TITLE
Fix: xDai chain access (actually all chainId >= 16) broken in dapp browser

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ target 'AlphaWallet' do
   pod 'CryptoSwift', '~> 1.0'
   pod 'SwiftyXMLParser', :git => 'https://github.com/yahoojapan/SwiftyXMLParser.git'
   pod 'Kingfisher'
-  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => '5d4368b7fe25ddc0cd01a3c5cd31ab892e55ec20'
+  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => '23322dffdce9461e5760b268ec1cf579ac841e0f'
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/alpha-wallet/trust-keystore.git', :commit => 'c0bdc4f6ffc117b103e19d17b83109d4f5a0e764'
   pod 'SwiftyJSON'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
     - secp256k1_ios (~> 0.1.3)
 
 DEPENDENCIES:
-  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `5d4368b7fe25ddc0cd01a3c5cd31ab892e55ec20`)
+  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `23322dffdce9461e5760b268ec1cf579ac841e0f`)
   - APIKit
   - AWSSNS
   - BigInt (~> 3.1)
@@ -184,7 +184,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
-    :commit: 5d4368b7fe25ddc0cd01a3c5cd31ab892e55ec20
+    :commit: 23322dffdce9461e5760b268ec1cf579ac841e0f
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Eureka:
     :commit: 5c54e2607632ce586010e50e91d9adcb6bb3909e
@@ -218,7 +218,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AlphaWalletWeb3Provider:
-    :commit: 5d4368b7fe25ddc0cd01a3c5cd31ab892e55ec20
+    :commit: 23322dffdce9461e5760b268ec1cf579ac841e0f
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Eureka:
     :commit: 5c54e2607632ce586010e50e91d9adcb6bb3909e
@@ -301,6 +301,6 @@ SPEC CHECKSUMS:
   WalletConnectSwift: cd5e056cec5a2f44e92b8595199e7f2f9f0bd92d
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
 
-PODFILE CHECKSUM: 4ec7ec9f64faf88503d4cadeb657f9b197a5e918
+PODFILE CHECKSUM: 58033461d0b2f883b8e85704188a972a51ff568f
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
Fixes #2533 