### PR TITLE
Fix: hang at splash screen at launch

### DIFF
--- a/AlphaWallet/Protection/Coordinators/ProtectionCoordinator.swift
+++ b/AlphaWallet/Protection/Coordinators/ProtectionCoordinator.swift
@@ -21,7 +21,7 @@ class ProtectionCoordinator: Coordinator {
 	}
 
 	func didFinishLaunchingWithOptions() {
-		splashCoordinator.start()
+		//Not calling `splashCoordinator.start()` here because it seems unnecessary, and most importantly, the implementation (changing `UIWindow.rootViewController`) seems to be (one of?) the reason why the app hangs at the splash screen at launch sometimes
 		lockEnterPasscodeCoordinator.start()
 		lockEnterPasscodeCoordinator.showAuthentication()
 	}


### PR DESCRIPTION
Fixes #2137 

Not sure if it's reproducible easily. I spotted this on my phone and debugged against it. A possible reason might be this message:

> Unbalanced calls to begin/end appearance transitions for <AlphaWallet.SplashViewController: 0x10b40b7e0>.

We might improve the way the splash screen is displayed, but in this case just not attempting to show it at launch still seems to work correctly.