### PR TITLE
Fix: error message shown when user doesn't have enough funds for sending a transaction (send amount + gas) is not user friendly

### DIFF
--- a/AlphaWallet/Extensions/Session+PromiseKit.swift
+++ b/AlphaWallet/Extensions/Session+PromiseKit.swift
@@ -23,7 +23,7 @@ extension Session {
                     seal.fulfill(result)
                 case .failure(let error):
                     if case let .responseError(JSONRPCError.responseError(_, message: message, _)) = error {
-                        if message.hasPrefix("Insufficient funds") {
+                        if message.lowercased().hasPrefix("insufficient funds") {
                             seal.reject(InsufficientFundsError())
                             return
                         } else {


### PR DESCRIPTION
Users sees: "insufficient funds for gas * price + value"

Should see: "Not enough funds to send this transaction".

Introduced in #2449, but broken for some chains because of case sensitivity matching (they don't all show the exact same message, eg. xDai: "Insufficient funds. The account you tried to send transaction from does not have enough funds. Required 1000021000000000000 and got: 0.", Goerli: "insufficient funds for gas * price + value"