### PR TITLE
Remove unnecessary call to name and symbol for ENS token

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/AlphaWallet/TokenScriptClient/Models/FunctionOrigin.swift
@@ -340,6 +340,12 @@ struct FunctionOrigin {
         guard let arguments = formArguments(withTokenId: tokenId, attributeAndValues: attributeAndValues, localRefs: localRefs, account: account) else { return nil }
         guard let functionName = functionType.functionName else { return nil }
         let functionCall = AssetFunctionCall(server: server, contract: originContract, functionName: functionName, inputs: functionType.inputs, output: output, arguments: arguments)
+
+        //ENS token is treated as ERC721 because it is picked up from OpenSea. But it doesn't respond to `name` and `symbol`. Calling them is harmless but causes node errors that can be confusing "execution reverted" when looking at logs
+        if ["name", "symbol"].contains(functionCall.functionName) && functionCall.contract.sameContract(as: Constants.ensContractOnMainnet) {
+            return Subscribable<AssetInternalValue>(nil)
+        }
+
         return callForAssetAttributeCoordinator.getValue(forAttributeId: attributeId, tokenId: tokenId, functionCall: functionCall)
     }
 }


### PR DESCRIPTION
They aren't implemented. While harmless to call, they introduce error messages to our logs which could be puzzling

> PromiseKit:cauterized-error: execution reverted