### PR TITLE
Fix: amount of ERC20 to send in actionsheet for transaction confirmation is displayed incorrectly

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -197,7 +197,7 @@ extension TransactionConfirmationViewModel {
                     return "\(double) \(token.symbol)"
                 }
             case .ERC20Token(let token, _, _):
-                return "\(amount) \(token.symbol)"
+                return "\(amount.value) \(token.symbol)"
             case .ERC875Token, .ERC875TokenOrder, .ERC721Token, .ERC721ForTicketToken, .dapp, .tokenScript, .claimPaidErc875MagicLink:
                 return String()
             }


### PR DESCRIPTION
Before PR|After PR
-|-
<img width="463" alt="Screenshot 2021-03-12 at 12 45 47 PM" src="https://user-images.githubusercontent.com/56189/110893540-29a13900-8331-11eb-9d6a-0012db623f5e.png">|<img width="407" alt="Screenshot 2021-03-12 at 12 44 58 PM" src="https://user-images.githubusercontent.com/56189/110893533-24dc8500-8331-11eb-8372-ba54b15fd7fb.png">
