### PR TITLE
Fix: display of "to" address for ERC20 and other token transfers are wrong for pending transactions in the transaction view — shows the contract rather than the recipient

### DIFF
--- a/AlphaWallet/Transactions/ViewModels/TransactionDetailsViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionDetailsViewModel.swift
@@ -82,7 +82,11 @@ struct TransactionDetailsViewModel {
     var to: String {
         switch transactionRow {
         case .standalone(let transaction):
-            return transaction.to
+            if let to = transaction.operation?.to {
+                return to
+            } else {
+                return transaction.to
+            }
         case .group(let transaction):
             return transaction.to
         case .item(_, operation: let operation):


### PR DESCRIPTION
Before the PR, when the transaction for an ERC20 transfer is pending, we (wrongly) display the contract as the "to" value when we should display the recipient's wallet address.