### PR TITLE
Hide in-app language setting

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -55,6 +55,10 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     func start() {
+        if Features.isLanguageSwitcherDisabled {
+            Config.setLocale(.system)
+        }
+
         if isRunningTests() {
             startImpl()
         } else {

--- a/AlphaWallet/Core/Features.swift
+++ b/AlphaWallet/Core/Features.swift
@@ -6,4 +6,5 @@ enum Features {
     static let isActivityEnabled = true
     static let isSendAllFundsFungibleEnabled = true
     static let isSpeedupAndCancelEnabled = true
+    static let isLanguageSwitcherDisabled = true
 }

--- a/AlphaWallet/Settings/ViewControllers/AdvancedSettingsViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/AdvancedSettingsViewController.swift
@@ -59,11 +59,6 @@ class AdvancedSettingsViewController: UIViewController {
 }
 
 extension AdvancedSettingsViewController: UITableViewDataSource {
-
-    public func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfRows()
     }
@@ -82,12 +77,12 @@ extension AdvancedSettingsViewController: UITableViewDataSource {
             cell.delegate = self
 
             return cell
-        } 
+        }
     }
 }
 
 extension AdvancedSettingsViewController: SwitchTableViewCellDelegate {
-    
+
     func cell(_ cell: SwitchTableViewCell, switchStateChanged isOn: Bool) {
         guard let indexPath = cell.indexPath else { return }
 

--- a/AlphaWallet/Settings/ViewControllers/SupportViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SupportViewController.swift
@@ -52,11 +52,6 @@ class SupportViewController: UIViewController {
 }
 
 extension SupportViewController: UITableViewDataSource {
-
-    public func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.rows.count
     }

--- a/AlphaWallet/Settings/ViewModels/AdvancedSettingsViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/AdvancedSettingsViewModel.swift
@@ -9,12 +9,17 @@ import Foundation
 import UIKit
 
 struct AdvancedSettingsViewModel {
-    
-    var rows: [AdvancedSettingsRow] = [.console, .clearBrowserCache, .tokenScript, .changeLanguage, .useTaiChiNetwork]
-    
+    var rows: [AdvancedSettingsRow] = {
+        if Features.isLanguageSwitcherDisabled {
+            return [.console, .clearBrowserCache, .tokenScript, .useTaiChiNetwork]
+        } else {
+            return [.console, .clearBrowserCache, .tokenScript, .changeLanguage, .useTaiChiNetwork]
+        }
+    }()
+
     func numberOfRows() -> Int {
         return rows.count
-    } 
+    }
 }
 
 enum AdvancedSettingsRow: CaseIterable {
@@ -63,4 +68,4 @@ enum AdvancedSettingsRow: CaseIterable {
             return R.image.iconsSettingsTaiChi()!
         }
     }
-} 
+}

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -569,11 +569,6 @@ extension TokensViewController: SegmentedControlDelegate {
 }
 
 extension TokensViewController: UICollectionViewDataSource {
-
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
-    }
-
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         //Defensive check to make sure we don't return the wrong count. iOS might decide to load (the first time especially) the collection view at some point even if we don't switch to it, thus getting the wrong count and then at some point asking for a cell for those non-existent rows/items. E.g 10 tokens total, only 3 are collectibles and asked for the 6th cell
         switch viewModel.filter {


### PR DESCRIPTION
Followup #2666

Closes #2655, fixes #2596

Decimal separators doesn't seem to get overridden as expected in newer iOS versions.