### PR TITLE
Load TokenScript file even if signature verification fails (because signature verification web API isn't working properly)

### DIFF
--- a/AlphaWallet/Core/Features.swift
+++ b/AlphaWallet/Core/Features.swift
@@ -7,4 +7,5 @@ enum Features {
     static let isSendAllFundsFungibleEnabled = true
     static let isSpeedupAndCancelEnabled = true
     static let isLanguageSwitcherDisabled = true
+    static let shouldLoadTokenScriptWithFailedSignatures = true
 }

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -387,8 +387,13 @@ private class PrivateXMLHandler {
                     hasValidTokenScriptFile = false
                 }
             } else {
-                xml = PrivateXMLHandler.emptyXML
-                hasValidTokenScriptFile = false
+                if Features.shouldLoadTokenScriptWithFailedSignatures {
+                    xml = (try? Kanna.XML(xml: xmlString, encoding: .utf8)) ?? PrivateXMLHandler.emptyXML
+                    hasValidTokenScriptFile = true
+                } else {
+                    xml = PrivateXMLHandler.emptyXML
+                    hasValidTokenScriptFile = false
+                }
             }
         }
         return (xml: xml, hasValidTokenScriptFile: hasValidTokenScriptFile)


### PR DESCRIPTION
Temporarily until the web API is working again