### PR TITLE
Refactor make clear when rpcserver main is accessed explicitly

### DIFF
--- a/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
+++ b/AlphaWallet/Accounts/Coordinators/AccountsCoordinator.swift
@@ -175,8 +175,7 @@ class AccountsCoordinator: Coordinator {
         alertController.addAction(UIAlertAction(title: R.string.localizable.cancel(), style: .cancel))
         alertController.addTextField(configurationHandler: { [weak self] (textField: UITextField!) -> Void in
             guard let strongSelf = self else { return }
-            let serverToResolveEns = RPCServer.main
-            ENSReverseLookupCoordinator(server: serverToResolveEns).getENSNameFromResolver(forAddress: account) { result in
+            ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: account) { result in
                 guard let ensName = result.value else { return }
                 textField.placeholder = ensName
             }

--- a/AlphaWallet/Accounts/ViewControllers/AccountsViewController.swift
+++ b/AlphaWallet/Accounts/ViewControllers/AccountsViewController.swift
@@ -127,7 +127,7 @@ class AccountsViewController: UIViewController {
         let addresses = (hdWallets + keystoreWallets + watchedWallets).compactMap { $0.address }
 
         let group = DispatchGroup()
-        
+
         for address in addresses {
             group.enter()
 
@@ -183,16 +183,15 @@ extension AccountsViewController: UITableViewDataSource {
         gesture.minimumPressDuration = 0.6
         cell.addGestureRecognizer(gesture)
 
-        let serverToResolveEns = RPCServer.main
         let address = cellViewModel.address
-        ENSReverseLookupCoordinator(server: serverToResolveEns).getENSNameFromResolver(forAddress: address) { result in
+        ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: address) { result in
             guard let ensName = result.value else { return }
             //Cell might have been reused. Check
             guard let cellAddress = cell.viewModel?.address, cellAddress.sameContract(as: address) else { return }
             cellViewModel.ensName = ensName
             cell.configure(viewModel: cellViewModel)
         }
-        
+
         return cell
     }
 

--- a/AlphaWallet/Core/Views/AddressOrEnsNameLabel.swift
+++ b/AlphaWallet/Core/Views/AddressOrEnsNameLabel.swift
@@ -29,7 +29,6 @@ class AddressOrEnsNameLabel: UILabel {
         }
     }
 
-    private let serverToResolveEns = RPCServer.main
     private var inResolvingState: Bool = false {
         didSet {
             if inResolvingState && shouldShowLoadingIndicator {
@@ -105,10 +104,9 @@ class AddressOrEnsNameLabel: UILabel {
     func resolve(_ value: String, completion: @escaping ((AddressOrEnsResolution) -> Void)) {
         clear()
 
-        let server = serverToResolveEns
         if let address = AlphaWallet.Address(string: value) {
             inResolvingState = true
-            ENSReverseLookupCoordinator(server: server).getENSNameFromResolver(forAddress: address) { [weak self] result in
+            ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: address) { [weak self] result in
                 guard let strongSelf = self else { return }
                 strongSelf.inResolvingState = false
 
@@ -121,8 +119,8 @@ class AddressOrEnsNameLabel: UILabel {
         } else if value.contains(".") {
             inResolvingState = true
 
-            DomainResolver(server: server).resolveAddress(value).recover { _ -> Promise<AlphaWallet.Address> in
-                return GetENSAddressCoordinator(server: server).getENSAddressFromResolverPromise(value: value)
+            DomainResolver(server: .forResolvingEns).resolveAddress(value).recover { _ -> Promise<AlphaWallet.Address> in
+                GetENSAddressCoordinator(server: .forResolvingEns).getENSAddressFromResolverPromise(value: value)
             }.done { address in
                 completion(.resolved(.address(address)))
             }.catch { _ in

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -786,7 +786,7 @@ extension InCoordinator: SettingsCoordinatorDelegate {
 
     func didPressShowWallet(in coordinator: SettingsCoordinator) {
         //We are only showing the QR code and some text for this address. Maybe have to rework graphic design so that server isn't necessary
-        showPaymentFlow(for: .request, server: .main)
+        showPaymentFlow(for: .request, server: config.anyEnabledServer())
         delegate?.didShowWallet(in: self)
     }
 

--- a/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
@@ -131,7 +131,8 @@ extension ServersCoordinatorBridgeToPromise: ServersCoordinatorDelegate {
             case .server(let value):
                 self.seal.fulfill(value)
             case .auto:
-                self.seal.fulfill(.main)
+                //TODO pass in `Config `instance instead
+                self.seal.fulfill(Config().anyEnabledServer())
             }
         }
     }

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -205,6 +205,15 @@ struct Config {
             return URL(string: "http://api.taichi.network:10000/rpc/\(key)?txroute=private")!
         }
     }
+
+    func anyEnabledServer() -> RPCServer {
+        let servers = enabledServers
+        if servers.contains(.main) {
+            return .main
+        } else {
+            return servers.first!
+        }
+    }
 }
 
 extension Config {

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -30,6 +30,11 @@ enum RPCServer: Hashable, CaseIterable {
     case mumbai_testnet
     case custom(CustomRPC)
 
+    //Using this property avoids direct reference to `.main`, which could be a sign of a possible crash — i.e. using `.main` when it is disabled by the user
+    static var forResolvingEns: RPCServer {
+        .main
+    }
+
     var chainID: Int {
         switch self {
         case .main: return 1

--- a/AlphaWallet/Tokens/Coordinators/GetWalletNameCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetWalletNameCoordinator.swift
@@ -16,8 +16,7 @@ class GetWalletNameCoordinator {
             if let walletName = config.walletNames[address] {
                 seal.fulfill(walletName)
             } else {
-                let serverToResolveEns = RPCServer.main
-                ENSReverseLookupCoordinator(server: serverToResolveEns).getENSNameFromResolver(forAddress: address) { result in
+                ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: address) { result in
                     seal.fulfill(result.value)
                 }
             }

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -284,7 +284,7 @@ extension TokensCoordinator: QRCodeResolutionCoordinatorDelegate {
         case .watchWallet:
             handleWatchWallet(address)
         case .openInEtherscan:
-            delegate?.didPressViewContractWebPage(forContract: address, server: .main, in: tokensViewController)
+            delegate?.didPressViewContractWebPage(forContract: address, server: config.anyEnabledServer(), in: tokensViewController)
         }
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
@@ -205,7 +205,7 @@ class TokenInstanceViewController: UIViewController, TokenVerifiableStatusViewCo
             }()
         case .notBackedByOpenSea:
             rowView = {
-                let view = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: .main, tokenView: .view, showCheckbox: false, assetDefinitionStore: assetDefinitionStore)
+                let view = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: server, tokenView: .view, showCheckbox: false, assetDefinitionStore: assetDefinitionStore)
                 view.isStandalone = true
                 view.tokenScriptRendererView.isWebViewInteractionEnabled = true
                 return view

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -327,7 +327,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
                     //Reuse for performance (because webviews are created)
                     return rowView
                 } else {
-                    let rowView = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: .main, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
+                    let rowView = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: server, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
                     rowView.delegate = self
                     return rowView
                 }
@@ -395,7 +395,7 @@ extension TokensCardViewController: UITableViewDelegate, UITableViewDataSource {
                     //Reuse for performance (because webviews are created)
                     return rowView
                 } else {
-                    let rowView = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: .main, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
+                    let rowView = TokenCardRowView(analyticsCoordinator: analyticsCoordinator, server: server, tokenView: .viewIconified, showCheckbox: cell.showCheckbox(), assetDefinitionStore: assetDefinitionStore)
                     //Important not to assign a delegate because we don't use actual cells to figure out the height. We use a sizing cell instead
                     return rowView
                 }

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -77,7 +77,7 @@ class TokensViewModel {
         }
         return true
     }
-    
+
     init(filterTokensCoordinator: FilterTokensCoordinator, tokens: [TokenObject], tickers: [RPCServer: [AlphaWallet.Address: CoinTicker]]) {
         self.filterTokensCoordinator = filterTokensCoordinator
         self.tokens = tokens
@@ -101,7 +101,7 @@ class TokensViewModel {
     }
 
     func nativeCryptoCurrencyToken(forServer server: RPCServer) -> TokenObject? {
-        return tokens.first(where: { $0.primaryKey == TokensDataStore.etherToken(forServer: .main).primaryKey })
+        return tokens.first(where: { $0.primaryKey == TokensDataStore.etherToken(forServer: server).primaryKey })
     }
 
     func amount(for token: TokenObject) -> Double {

--- a/AlphaWallet/Transfer/Types/RecipientResolver.swift
+++ b/AlphaWallet/Transfer/Types/RecipientResolver.swift
@@ -29,7 +29,7 @@ class RecipientResolver {
 
     func resolve(completion: @escaping () -> Void) {
         guard let address = address else { return }
-        ENSReverseLookupCoordinator(server: .main).getENSNameFromResolver(forAddress: address) { [weak self] result in
+        ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: address) { [weak self] result in
             guard let strongSelf = self else { return }
 
             strongSelf.ensName = result.value

--- a/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
@@ -172,9 +172,8 @@ class RequestViewController: UIViewController {
 	}
 
 	private func resolveEns() {
-		let serverToResolveEns = RPCServer.main
 		let address = viewModel.myAddress
-		ENSReverseLookupCoordinator(server: serverToResolveEns).getENSNameFromResolver(forAddress: address) { [weak self] result in
+		ENSReverseLookupCoordinator(server: .forResolvingEns).getENSNameFromResolver(forAddress: address) { [weak self] result in
 			guard let strongSelf = self else { return }
 			if let ensName = result.value {
                 strongSelf.ensLabel.text = ensName

--- a/AlphaWallet/UI/AddressTextField.swift
+++ b/AlphaWallet/UI/AddressTextField.swift
@@ -14,8 +14,6 @@ class AddressTextField: UIControl {
     private let notifications = NotificationCenter.default
     private var isConfigured = false
     private let textField = UITextField()
-    //Always resolve on mainnet
-    private let serverToResolveEns = RPCServer.main
     private let ensAddressLabel: AddressOrEnsNameLabel = {
         let label = AddressOrEnsNameLabel()
         label.addressFormat = .truncateMiddle


### PR DESCRIPTION
After #2689 is merged.

This PR gets rid of most cases where `.main` is referenced directly. After this PR is merged, any direct reference to `.main` that is not in `switch-case` should be watched with caution.