### PR TITLE
Refactor: make distinction between WalletConnect and Dapp-browser initiated transactions

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -13,6 +13,7 @@ import Result
 enum TransactionConfirmationConfiguration {
     case tokenScriptTransaction(confirmType: ConfirmType, contract: AlphaWallet.Address, keystore: Keystore, functionCallMetaData: DecodedFunctionCall, ethPrice: Subscribable<Double>)
     case dappTransaction(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>)
+    case walletConnect(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>)
     case sendFungiblesTransaction(confirmType: ConfirmType, keystore: Keystore, assetDefinitionStore: AssetDefinitionStore, amount: FungiblesTransactionAmount, ethPrice: Subscribable<Double>)
     case sendNftTransaction(confirmType: ConfirmType, keystore: Keystore, ethPrice: Subscribable<Double>, tokenInstanceName: String?)
     case claimPaidErc875MagicLink(confirmType: ConfirmType, keystore: Keystore, price: BigUInt, ethPrice: Subscribable<Double>, numberOfTokens: UInt)
@@ -20,7 +21,7 @@ enum TransactionConfirmationConfiguration {
     case cancelTransaction(keystore: Keystore, ethPrice: Subscribable<Double>)
     var confirmType: ConfirmType {
         switch self {
-        case .dappTransaction(let confirmType, _, _), .sendFungiblesTransaction(let confirmType, _, _, _, _), .sendNftTransaction(let confirmType, _, _, _), .tokenScriptTransaction(let confirmType, _, _, _, _), .claimPaidErc875MagicLink(let confirmType, _, _, _, _):
+        case .dappTransaction(let confirmType, _, _), .walletConnect(let confirmType, _, _), .sendFungiblesTransaction(let confirmType, _, _, _, _), .sendNftTransaction(let confirmType, _, _, _), .tokenScriptTransaction(let confirmType, _, _, _, _), .claimPaidErc875MagicLink(let confirmType, _, _, _, _):
             return confirmType
         case .speedupTransaction, .cancelTransaction:
             return .signThenSend
@@ -29,14 +30,14 @@ enum TransactionConfirmationConfiguration {
 
     var keystore: Keystore {
         switch self {
-        case .dappTransaction(_, let keystore, _), .sendFungiblesTransaction(_, let keystore, _, _, _), .sendNftTransaction(_, let keystore, _, _), .tokenScriptTransaction(_, _, let keystore, _, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _), .speedupTransaction(let keystore, _), .cancelTransaction(let keystore, _):
+        case .dappTransaction(_, let keystore, _), .walletConnect(_, let keystore, _), .sendFungiblesTransaction(_, let keystore, _, _, _), .sendNftTransaction(_, let keystore, _, _), .tokenScriptTransaction(_, _, let keystore, _, _), .claimPaidErc875MagicLink(_, let keystore, _, _, _), .speedupTransaction(let keystore, _), .cancelTransaction(let keystore, _):
             return keystore
         }
     }
 
     var ethPrice: Subscribable<Double> {
         switch self {
-        case .dappTransaction(_, _, let ethPrice), .sendFungiblesTransaction(_, _, _, _, let ethPrice), .sendNftTransaction(_, _, let ethPrice, _), .tokenScriptTransaction(_, _, _, _, let ethPrice), .claimPaidErc875MagicLink(_, _, _, let ethPrice, _), .speedupTransaction(_, let ethPrice), .cancelTransaction(_, let ethPrice):
+        case .dappTransaction(_, _, let ethPrice), .walletConnect(_, _, let ethPrice), .sendFungiblesTransaction(_, _, _, _, let ethPrice), .sendNftTransaction(_, _, let ethPrice, _), .tokenScriptTransaction(_, _, _, _, let ethPrice), .claimPaidErc875MagicLink(_, _, _, let ethPrice, _), .speedupTransaction(_, let ethPrice), .cancelTransaction(_, let ethPrice):
             return ethPrice
         }
     }

--- a/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
@@ -169,7 +169,7 @@ class TransactionConfirmationViewController: UIViewController {
         }
 
         switch viewModel {
-        case .dappTransaction(let dappTransactionViewModel):
+        case .dappOrWalletConnectTransaction(let dappTransactionViewModel):
             dappTransactionViewModel.ethPrice.subscribe { [weak self] cryptoToDollarRate in
                 guard let strongSelf = self else { return }
                 dappTransactionViewModel.cryptoToDollarRate = cryptoToDollarRate
@@ -357,7 +357,7 @@ class TransactionConfirmationViewController: UIViewController {
     //NOTE: we need to recalculate all funds value to send according to updated gas estimates, nativecrypto only
     func reloadViewWithCurrentBalanceValue() {
         switch viewModel {
-        case .dappTransaction, .tokenScriptTransaction, .speedupTransaction, .cancelTransaction:
+        case .dappOrWalletConnectTransaction, .tokenScriptTransaction, .speedupTransaction, .cancelTransaction:
             break
         case .sendFungiblesTransaction(let sendFungiblesViewModel):
             switch sendFungiblesViewModel.transactionType {
@@ -411,7 +411,7 @@ extension TransactionConfirmationViewController {
         stackView.removeAllArrangedSubviews()
         var views: [UIView] = []
         switch viewModel {
-        case .dappTransaction(let viewModel):
+        case .dappOrWalletConnectTransaction(let viewModel):
             for (sectionIndex, section) in viewModel.sections.enumerated() {
                 var children: [UIView] = []
 
@@ -575,7 +575,7 @@ extension TransactionConfirmationViewController: TransactionConfirmationHeaderVi
 
     func headerView(_ header: TransactionConfirmationHeaderView, shouldShowChildren section: Int, index: Int) -> Bool {
         switch viewModel {
-        case .dappTransaction, .claimPaidErc875MagicLink, .tokenScriptTransaction, .speedupTransaction, .cancelTransaction:
+        case .dappOrWalletConnectTransaction, .claimPaidErc875MagicLink, .tokenScriptTransaction, .speedupTransaction, .cancelTransaction:
             return true
         case .sendFungiblesTransaction(let viewModel):
             switch viewModel.sections[section] {

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -4,7 +4,7 @@ import Foundation
 import BigInt
 
 enum TransactionConfirmationViewModel {
-    case dappTransaction(DappTransactionViewModel)
+    case dappOrWalletConnectTransaction(DappOrWalletConnectTransactionViewModel)
     case tokenScriptTransaction(TokenScriptTransactionViewModel)
     case sendFungiblesTransaction(SendFungiblesTransactionViewModel)
     case sendNftTransaction(SendNftTransactionViewModel)
@@ -16,8 +16,8 @@ enum TransactionConfirmationViewModel {
         switch configuration {
         case .tokenScriptTransaction(_, let contract, _, let functionCallMetaData, let ethPrice):
             self = .tokenScriptTransaction(.init(address: contract, configurator: configurator, functionCallMetaData: functionCallMetaData, ethPrice: ethPrice))
-        case .dappTransaction(_, _, let ethPrice):
-            self = .dappTransaction(.init(configurator: configurator, ethPrice: ethPrice))
+        case .dappTransaction(_, _, let ethPrice), .walletConnect(_, _, let ethPrice):
+            self = .dappOrWalletConnectTransaction(.init(configurator: configurator, ethPrice: ethPrice))
         case .sendFungiblesTransaction(_, _, let assetDefinitionStore, let amount, let ethPrice):
             let resolver = RecipientResolver(address: configurator.transaction.recipient)
             self = .sendFungiblesTransaction(.init(configurator: configurator, assetDefinitionStore: assetDefinitionStore, recipientResolver: resolver, amount: amount, ethPrice: ethPrice))
@@ -40,7 +40,7 @@ enum TransactionConfirmationViewModel {
 
     mutating func showHideSection(_ section: Int) -> Action {
         switch self {
-        case .dappTransaction(var viewModel):
+        case .dappOrWalletConnectTransaction(var viewModel):
             return viewModel.showHideSection(section)
         case .tokenScriptTransaction(var viewModel):
             return viewModel.showHideSection(section)
@@ -203,7 +203,7 @@ extension TransactionConfirmationViewModel {
                     let double = amount.value.optionalDecimalValue ?? 0
                     let value = double.multiplying(by: NSDecimalNumber(value: cryptoToDollarRate))
                     let cryptoToDollarValue = StringFormatter().currency(with: value, and: cryptoToDollarSymbol)
-                    
+
                     return "\(amount.value) \(token.symbol) ≈ \(cryptoToDollarValue) \(cryptoToDollarSymbol)"
                 } else {
                     return "\(amount.value) \(token.symbol)"
@@ -279,7 +279,7 @@ extension TransactionConfirmationViewModel {
         }
     }
 
-    class DappTransactionViewModel: SectionProtocol {
+    class DappOrWalletConnectTransactionViewModel: SectionProtocol {
         enum Section {
             case gas
             case network
@@ -764,7 +764,7 @@ extension TransactionConfirmationViewModel {
         switch self {
         case .sendFungiblesTransaction, .sendNftTransaction:
             return R.string.localizable.tokenTransactionTransferConfirmationTitle()
-        case .dappTransaction, .tokenScriptTransaction:
+        case .dappOrWalletConnectTransaction, .tokenScriptTransaction:
             return R.string.localizable.tokenTransactionConfirmationTitle()
         case .claimPaidErc875MagicLink:
             return R.string.localizable.tokenTransactionPurchaseConfirmationTitle()
@@ -780,7 +780,7 @@ extension TransactionConfirmationViewModel {
     }
     var confirmationButtonTitle: String {
         switch self {
-        case .dappTransaction, .tokenScriptTransaction, .sendFungiblesTransaction, .sendNftTransaction, .claimPaidErc875MagicLink:
+        case .dappOrWalletConnectTransaction, .tokenScriptTransaction, .sendFungiblesTransaction, .sendNftTransaction, .claimPaidErc875MagicLink:
             return R.string.localizable.confirmPaymentConfirmButtonTitle()
         case .speedupTransaction:
             return R.string.localizable.activitySpeedup()
@@ -799,7 +799,7 @@ extension TransactionConfirmationViewModel {
 
     var hasSeparatorAboveConfirmButton: Bool {
         switch self {
-        case .sendFungiblesTransaction, .sendNftTransaction, .dappTransaction, .tokenScriptTransaction, .claimPaidErc875MagicLink:
+        case .sendFungiblesTransaction, .sendNftTransaction, .dappOrWalletConnectTransaction, .tokenScriptTransaction, .claimPaidErc875MagicLink:
             return true
         case .speedupTransaction, .cancelTransaction:
             return false

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -219,7 +219,7 @@ extension WalletConnectCoordinator: WalletConnectServerDelegate {
     private func executeTransaction(session: WalletSession, callbackID id: WalletConnectRequestID, url: WalletConnectURL, transaction: UnconfirmedTransaction, type: ConfirmType) -> Promise<WalletConnectServer.Callback> {
         guard let rpcServer = server.urlToServer[url] else { return Promise(error: WalletConnectError.connectionInvalid) }
         let ethPrice = nativeCryptoCurrencyPrices[rpcServer]
-        let configuration: TransactionConfirmationConfiguration = .dappTransaction(confirmType: type, keystore: keystore, ethPrice: ethPrice)
+        let configuration: TransactionConfirmationConfiguration = .walletConnect(confirmType: type, keystore: keystore, ethPrice: ethPrice)
         return firstly {
             TransactionConfirmationCoordinator.promise(navigationController, session: session, coordinator: self, account: session.account.address, transaction: transaction, configuration: configuration, analyticsCoordinator: analyticsCoordinator, source: .walletConnect)
         }.map { data -> WalletConnectServer.Callback in


### PR DESCRIPTION
Didn't go all the way and duplicate `TransactionConfirmationViewModel.dappTransaction`, instead just renamed it to `TransactionConfirmationViewModel.dappOrWalletConnectTransaction`.
