### PR TITLE
Fix: Oneinch (swap) service broken because web API is no longer valid

### DIFF
--- a/AlphaWallet/Core/SwapToken/Oneinch/ERC20Token.swift
+++ b/AlphaWallet/Core/SwapToken/Oneinch/ERC20Token.swift
@@ -9,6 +9,10 @@ import Foundation
 import TrustKeystore
 
 extension Oneinch {
+    struct ApiResponsePayload: Decodable {
+        let tokens: [String: ERC20Token]
+    }
+
     struct ERC20Token: Decodable {
         private enum AnyError: Error {
             case invalidAddress

--- a/AlphaWallet/Core/SwapToken/Oneinch/Oneinch.swift
+++ b/AlphaWallet/Core/SwapToken/Oneinch/Oneinch.swift
@@ -70,9 +70,9 @@ class Oneinch: TokenActionsProvider, SwapTokenURLProviderType {
         let provider = AlphaWalletProviderFactory.makeProvider()
 
         provider.request(.oneInchTokens(config: config)).map { response -> [String: Oneinch.ERC20Token] in
-            try JSONDecoder().decode([String: Oneinch.ERC20Token].self, from: response.data)
+            try JSONDecoder().decode(ApiResponsePayload.self, from: response.data).tokens
         }.map { data -> [Oneinch.ERC20Token] in
-            return data.map { $0.value }
+            data.map { $0.value }
         }.done { response in
             for token in self.predefinedTokens + response {
                 self.availableTokens[token.address] = token

--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -63,7 +63,7 @@ extension AlphaWalletService: TargetType {
         case .gasPriceEstimate:
             return "/api/v3/gas/price"
         case .oneInchTokens:
-            return "/v1.1/tokens"
+            return "/v3.0/1/tokens"
         case .honeySwapTokens:
             return ""
         case .rampAssets:


### PR DESCRIPTION
Fixes: #2711 

The version 1.1 of the web API we were using seems no longer work and the latest is v3.0. The response has changed from

```
{
  "0x2688213fedd489762a281a67ae4f2295d8e17ecc" : {
     "logoURI" : "https://tokens.1inch.exchange/0x2688213fedd489762a281a67ae4f2295d8e17ecc.png",
     "address" : "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
     "name" : "FUD.finance",
     "decimals" : 18,
     "symbol" : "FUD"
  },
```

to:

```
{
   "tokens" : {
      "0x2688213fedd489762a281a67ae4f2295d8e17ecc" : {
         "logoURI" : "https://tokens.1inch.exchange/0x2688213fedd489762a281a67ae4f2295d8e17ecc.png",
         "address" : "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
         "name" : "FUD.finance",
         "decimals" : 18,
         "symbol" : "FUD"
      },
```