### PR TITLE
Fix: special search keyword in wallet 'swap' returned wrong results

### DIFF
--- a/AlphaWallet/Core/SwapToken/SwapTokenService.swift
+++ b/AlphaWallet/Core/SwapToken/SwapTokenService.swift
@@ -40,9 +40,7 @@ class TokenActionsService: TokenActionsServiceType {
     }
 
     func isSupport(token: TokenObject) -> Bool {
-        return services.compactMap {
-            $0.isSupport(token: token) ? $0 : nil
-        }.isEmpty
+        services.contains { $0.isSupport(token: token) }
     }
 }
 


### PR DESCRIPTION
The "magic" search keyword in the wallet tab "swap" was returning wrong set of results because the condition was inverted, i.e. `isEmpty` instead of `!isEmpty`.