### PR TITLE
Fix: detecting of transactions for ERC20 approvals broken when downloading transaction history

### DIFF
--- a/AlphaWallet/Core/DecodedFunctionCall.swift
+++ b/AlphaWallet/Core/DecodedFunctionCall.swift
@@ -3,7 +3,7 @@
 import Foundation
 import BigInt
 import TrustKeystore
-import web3swift 
+import web3swift
 
 struct DecodedFunctionCall {
     enum FunctionType {
@@ -13,14 +13,14 @@ struct DecodedFunctionCall {
 //        case erc20Allowance(address: AlphaWallet.Address, address: AlphaWallet.Address)
 //        case erc20TransferFrom(address: AlphaWallet.Address, address: AlphaWallet.Address, value: BigUInt)
         case erc20Transfer(recipient: AlphaWallet.Address, value: BigUInt)
-        case erc20Approve(sender: AlphaWallet.Address, value: BigUInt)
+        case erc20Approve(spender: AlphaWallet.Address, value: BigUInt)
         case nativeCryptoTransfer(value: BigUInt)
         case others
     }
 
     static let erc20Transfer = (name: "transfer", interfaceHash: "a9059cbb", byteCount: 68)
-    static let erc20Approve = (name: "approve", interfaceHash: "095ea7b3", byteCount: 68) 
-    
+    static let erc20Approve = (name: "approve", interfaceHash: "095ea7b3", byteCount: 68)
+
     let name: String
     let arguments: [(type: ABIType, value: AnyObject)]
     let type: FunctionType

--- a/AlphaWallet/Core/Ethereum/ABI/DecodedFunctionCall+Decode.swift
+++ b/AlphaWallet/Core/Ethereum/ABI/DecodedFunctionCall+Decode.swift
@@ -88,7 +88,7 @@ extension DecodedFunctionCall.FunctionType {
         if name == DecodedFunctionCall.erc20Transfer.name, let address: EthereumAddress = arguments.get(type: .address), let value: BigUInt = arguments.get(type: .uint(bits: 256)) {
             self = .erc20Transfer(recipient: AlphaWallet.Address.ethereumAddress(eip55String: address.address), value: value)
         } else if name == DecodedFunctionCall.erc20Approve.name, let address: EthereumAddress = arguments.get(type: .address), let value: BigUInt = arguments.get(type: .uint(bits: 256)) {
-            self = .erc20Approve(sender: AlphaWallet.Address.ethereumAddress(eip55String: address.address), value: value)
+            self = .erc20Approve(spender: AlphaWallet.Address.ethereumAddress(eip55String: address.address), value: value)
         } else {
             self = .others
         }

--- a/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/AlphaWallet/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -66,7 +66,7 @@ extension TransactionInstance {
         }()
 
         let to = AlphaWallet.Address(string: transaction.to)?.eip55String ?? transaction.to
-        
+
         return firstly {
             createOperationForTokenTransfer(forTransaction: transaction, tokensStorage: tokensStorage)
         }.then { operations -> Promise<TransactionInstance?> in
@@ -87,7 +87,7 @@ extension TransactionInstance {
                     state: state,
                     isErc20Interaction: false
             )
-            
+
             return .value(result)
         }
     }
@@ -121,13 +121,13 @@ extension TransactionInstance {
             }
         }
 
-        if let data = transaction.input.data(using: .ascii), let functionCall = DecodedFunctionCall(data: data) {
+        let data = Data(hex: transaction.input)
+        if let functionCall = DecodedFunctionCall(data: data) {
             switch functionCall.type {
             case .erc20Transfer(let recipient, let value):
                 return generateLocalizedOperation(value: value, contract: contract, to: recipient, functionCall: functionCall)
-            case .erc20Approve(let sender, let value):
-                //NOTE: not sure if from and to values a right, maybe we need to change their positions
-                return generateLocalizedOperation(value: value, contract: contract, to: sender, functionCall: functionCall)
+            case .erc20Approve(let spender, let value):
+                return generateLocalizedOperation(value: value, contract: contract, to: spender, functionCall: functionCall)
             case .nativeCryptoTransfer, .others:
                 break
             }

--- a/AlphaWallet/Transactions/Storage/Transaction.swift
+++ b/AlphaWallet/Transactions/Storage/Transaction.swift
@@ -114,7 +114,7 @@ extension Transaction {
 extension Transaction {
     static func from(from: AlphaWallet.Address, transaction: SentTransaction, tokensDataStore: TokensDataStore) -> Transaction {
         let (operations: operations, isErc20Interaction: isErc20Interaction) = decodeOperations(fromData: transaction.original.data, from: transaction.original.account, contractOrRecipient: transaction.original.to, tokensDataStore: tokensDataStore)
-        
+
         return Transaction(
                 id: transaction.id,
                 server: transaction.original.server,
@@ -138,8 +138,8 @@ extension Transaction {
     fileprivate static func decodeOperations(fromData data: Data, from: AlphaWallet.Address, contractOrRecipient: AlphaWallet.Address?, tokensDataStore: TokensDataStore) -> (operations: [LocalizedOperationObject], isErc20Interaction: Bool) {
         if let functionCallMetaData = DecodedFunctionCall(data: data), let contract = contractOrRecipient, let token = tokensDataStore.tokenThreadSafe(forContract: contract) {
             switch functionCallMetaData.type {
-            case .erc20Approve(let sender, let value):
-                return (operations: [LocalizedOperationObject(from: from.eip55String, to: sender.eip55String, contract: contract, type: OperationType.erc20TokenApprove.rawValue, value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
+            case .erc20Approve(let spender, let value):
+                return (operations: [LocalizedOperationObject(from: from.eip55String, to: spender.eip55String, contract: contract, type: OperationType.erc20TokenApprove.rawValue, value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
             case .erc20Transfer(let recipient, let value):
                 return (operations: [LocalizedOperationObject(from: from.eip55String, to: recipient.eip55String, contract: contract, type: OperationType.erc20TokenTransfer.rawValue, value: String(value), symbol: token.symbol, name: token.name, decimals: token.decimals)], isErc20Interaction: true)
             case .nativeCryptoTransfer, .others:


### PR DESCRIPTION
* Also fix naming "sender" -> "spender" for ERC20 approvals