### PR TITLE
Use etherscan compatible endpoints to fetch transaction history for Artis mainnet and testnet

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -120,8 +120,8 @@ enum RPCServer: Hashable, CaseIterable {
         case .callisto: return nil
         case .goerli: return Constants.goerliEtherscanAPI
         case .xDai: return Constants.xDaiAPI
-        case .artis_sigma1: return nil
-        case .artis_tau1: return nil
+        case .artis_sigma1: return Constants.artisSigma1NetworkCoreAPI
+        case .artis_tau1: return Constants.artisTau1NetworkCoreAPI
         case .binance_smart_chain: return nil
         case .binance_smart_chain_testnet: return nil
         case .heco: return nil


### PR DESCRIPTION
Wasn't used previously