### PR TITLE
Add Kyber Migration Portal  to convert legacy KNC into ERC20 KNC tokens

### DIFF
--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -48,6 +48,7 @@ enum OriginalDapps {
         Dapp(name: "0x Instant", description: "A free and flexible way to offer simple crypto purchasing", url: "http://0x-instant-staging.s3-website-us-east-1.amazonaws.com/", cat: "Exchange"),
         Dapp(name: "Bancor", description: "Built-in price discovery and a liquidity mechanism for tokens", url: "https://www.bancor.network", cat: "Exchange"),
         Dapp(name: "KyberSwap", description: "Instant and Secure Token to Token Swaps", url: "https://kyber.network/swap/eth_knc", cat: "Exchange"),
+        Dapp(name: "Kyber Migration Portal", description: "Migration portal to upgrade legacy KNC to ERC-20 KNC tokens", url: "https://kyber.org/migrate", cat: "Token Migration"),
         Dapp(name: "localethereum", description: "Peer-to-peer marketplace allowing to trade eth to fiat", url: "https://localethereum.com/", cat: "Exchange"),
         Dapp(name: "Totle", description: "Aggregating the liquidity of the top decentralized exchanges", url: "https://app.totle.com/", cat: "Exchange"),
         Dapp(name: "Uniswap", description: "Protocol for automated token exchange", url: "https://uniswap.exchange", cat: "Exchange"),


### PR DESCRIPTION
Closes #2779 

[Not a dApp] 
Kyber Migration Portal: https://kyber.org/migrate
Category: "Token Migration" 

Background: KIP6: a Kyber Token Upgrade

For KNC holders managing their own tokens on self-custodial wallets such as Alphawallet, they can connect to the Kyber Migration Portal to Alphawallet and convert to the new KNC token on their own.

Old KNC token contract: 0xdd974d5c2e2928dea5f71b9825b8b646686bd200
New KNC token contract: 0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202
Migration ratio: 1:1 (1 old KNC will be migrated to 1 new ERC-20 KNC token)

Timeline:
Migration began Tuesday 20 April 9pm SGT.
Migration process has no hard deadline and is open-ended (as of writing).
No rush to convert to the new KNC tokens.

More info:
https://blog.kyber.network/knc-token-migration-guide-fda08bfe62c2

If bug:
Fixes #

If not a bug:
Closes #

1-liner summary:

Details if any (this should probably be in the commit message too):

Screenshots of Before PR and After PR if it's applicable (sometimes this make it much faster/easier to review):

Anything particular to test:
