### PR TITLE
Add Gas Fee Estimator utility to dApps list

### DIFF
--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -75,6 +75,9 @@ enum OriginalDapps {
         Dapp(name: "Mushrooms Finance", description: "Sustainable crypto earning in DeFi", url: "https://mushrooms.finance/", cat: "Finance"),
         Dapp(name: "Levinswap", description: "Decentralized exchange for trading crypto and serurities tokens", url: "https://app.levinswap.org/", cat: "Exchange")
         Dapp(name: "Matic Faucet", description: "Matic Faucet to access Mumbai and Goerli testnet tokens", url: "https://faucet.matic.network/", cat: "Tool")
+        Dapp(name: "Eth Gas Station", description: "Consumer oriented metrics for Eth Gas Market", url: "https://ethgasstation.info", cat: "Tool")
+        Dapp(name: "Gas Now", description: "Eth Gas Price forecast system", url: "https://www.gasnow.org/", cat: "Tool")
+
     ]
 
     struct Category {


### PR DESCRIPTION
Add Utility dApps to list: 

https://ethgasstation.info - Consumer oriented metrics for Eth Gas Market
https://www.gasnow.org/ - Eth Gas Price forecast system

Submitting in iOS to keep track of dapp list. Also in Android: https://github.com/AlphaWallet/alpha-wallet-android/pull/1876