### PR TITLE
Fixed token autodetection for several chains + refactoring

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -792,12 +792,12 @@ extension InCoordinator: CanOpenURL {
 
     func didPressViewContractWebPage(forContract contract: AlphaWallet.Address, server: RPCServer, in viewController: UIViewController) {
         if contract.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+            guard let url = server.etherscanContractDetailsWebPageURL(for: wallet.address) else { return }
             logExplorerUse(type: .wallet)
-            let url = server.etherscanContractDetailsWebPageURL(for: wallet.address)
             open(url: url, in: viewController)
         } else {
+            guard let url = server.etherscanTokenDetailsWebPageURL(for: contract) else { return }
             logExplorerUse(type: .token)
-            let url = server.etherscanTokenDetailsWebPageURL(for: contract)
             open(url: url, in: viewController)
         }
     }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -76,46 +76,6 @@ public struct Constants {
     //UEFA 721 balances function hash
     static let balances165Hash721Ticket = "0xc84aae17"
 
-    //etherscan-compatible erc20 transaction event APIs
-    //The fetch ERC20 transactions endpoint from Etherscan returns only ERC20 token transactions but the Blockscout version also includes ERC721 transactions too (so it's likely other types that it can detect will be returned too); thus we check the token type rather than assume that they are all ERC20
-    public static let mainnetEtherscanAPIErc20Events = "https://api-cn.etherscan.com/api?module=account&action=tokentx&address="
-    public static let ropstenEtherscanAPIErc20Events = "https://api-ropsten.etherscan.io/api?module=account&action=tokentx&address="
-    public static let kovanEtherscanAPIErc20Events = "https://api-kovan.etherscan.io/api?module=account&action=tokentx&address="
-    public static let rinkebyEtherscanAPIErc20Events = "https://api-rinkeby.etherscan.io/api?module=account&action=tokentx&address="
-    public static let classicAPIErc20Events = "https://blockscout.com/etc/mainnet/api?module=account&action=tokentx&address="
-    public static let xDaiAPIErc20Events = "https://blockscout.com/poa/dai/api?module=account&action=tokentx&address="
-    public static let poaNetworkCoreAPIErc20Events = "https://blockscout.com/poa/core/api?module=account&action=tokentx&address="
-    public static let goerliEtherscanAPIErc20Events = "https://api-goerli.etherscan.io/api?module=account&action=tokentx&address="
-    public static let artisSigma1NetworkCoreAPIErc20Events = "https://explorer.sigma1.artis.network/api?module=account&action=tokentx&address="
-    public static let artisTau1NetworkCoreAPIErc20Events = "https://explorer.tau1.artis.network/api?module=account&action=tokentx&address="
-
-    public static let mainnetEtherscanTokenDetailsWebPageURL = "https://cn.etherscan.com/token/"
-
-    //etherscan-compatible contract details web page
-    public static let mainnetEtherscanContractDetailsWebPageURL = "https://cn.etherscan.com/address/"
-    public static let kovanEtherscanContractDetailsWebPageURL = "https://kovan.etherscan.io/address/"
-    public static let rinkebyEtherscanContractDetailsWebPageURL = "https://rinkeby.etherscan.io/address/"
-    public static let ropstenEtherscanContractDetailsWebPageURL = "https://ropsten.etherscan.io/address/"
-    //Can't use https://blockscout.com/poa/dai/address/ even though it ultimately redirects there because blockscout (tested on 20190620), blockscout.com is only able to show that URL after the address has been searched (with the ?q= URL)
-    public static let xDaiContractPage = "https://blockscout.com/poa/dai/search?q="
-    public static let poaContractPage = "https://blockscout.com/poa/core/search?q="
-    public static let goerliContractPage = "https://goerli.etherscan.io/address/"
-    public static let sokolContractPage = "https://blockscout.com/poa/sokol/search?q="
-    public static let etcContractPage = "https://blockscout.com/etc/mainnet/search?q="
-    public static let callistoContractPage = "https://blockscout.com/callisto/mainnet/search?q="
-    public static let artisSigma1ContractPage = "https://explorer.sigma1.artis.network/search?q="
-    public static let artisTau1ContractPage = "https://explorer.tau1.artis.network/search?q="
-    public static let binanceContractPage = "https://bscscan.com/search?q="
-    public static let binanceTestnetContractPage = "https://testnet.bscscan.com/search?q="
-    public static let hecoContractPage = "https://scan.hecochain.com/address/"
-    public static let hecoTestnetContractPage = "https://scan-testnet.hecochain.com/address/"
-    public static let fantomContractPage = "https://ftmscan.com/address/"
-    public static let fantomTestnetContractPage = "https://ftmscan.com/address/"
-    public static let avalancheContractPage = "https://cchain.explorer.avax.network/address/"
-    public static let avalancheTestnetContractPage = "https://cchain.explorer.avax-test.network/address/"
-    public static let maticContractPage = "https://explorer-mainnet.maticvigil.com/address/"
-    public static let mumbaiContractPage = "https://explorer-mumbai.maticvigil.com/address/"
-
     //OpenSea links for erc721 assets
     public static let openseaAPI = "https://api.opensea.io/"
     public static let openseaRinkebyAPI = "https://rinkeby-api.opensea.io/"

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -17,7 +17,7 @@ class GetContractInteractions {
 
     //TODO rename this since it might include ERC721 (blockscout and compatible like Polygon's). Or can we make this really fetch ERC20, maybe by filtering the results?
     func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) else { return }
+        guard let etherscanURL = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) else { return }
 
         Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
             switch response.result {
@@ -89,7 +89,7 @@ class GetContractInteractions {
 
     //TODO Almost a duplicate of the the ERC20 version. De-dup maybe?
     func getErc721Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.etherscanAPIURLForERC721TxList(for: address, startBlock: startBlock) else { return }
+        guard let etherscanURL = server.getEtherscanURLForERC721TransactionHistory(for: address, startBlock: startBlock) else { return }
 
         Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
             switch response.result {
@@ -162,13 +162,13 @@ class GetContractInteractions {
     func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool, completion: @escaping ([AlphaWallet.Address], Int?) -> Void) {
         let etherscanURL: URL
         if erc20 {
-            if let url = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) {
+            if let url = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return
             }
         } else {
-            if let url = server.etherscanAPIURLForTransactionList(for: address, startBlock: startBlock) {
+            if let url = server.getEtherscanURLForGeneralTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return


### PR DESCRIPTION
Started out as refactoring to clean up after #2819 and #2829, but found bugs related in transaction fetching and token detection for several chains.

* Fixed token autodetection for several chains
    * ARTIS sigma1
    * ARTIS tau1
    * Sokol
    * Callisto
    * Binance and testnet
    * Heco and testnet
    * Mumbai testnet
* Refactoring of how and where Etherscan API and web URLs are specified