### PR TITLE
Remove price ticker matching completely for unsupported chains to reduce erroneous matching

### DIFF
--- a/AlphaWallet/Core/BuyToken/Ramp/Ramp.swift
+++ b/AlphaWallet/Core/BuyToken/Ramp/Ramp.swift
@@ -19,7 +19,8 @@ struct Ramp: TokenActionsProvider, BuyTokenURLProviderType {
         switch token.server {
         case .xDai:
             return URL(string: "\(Constants.buyXDaiWitRampUrl)&userAddress=\(account.address.eip55String)")
-        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        //TODO need to check if Ramp supports these? Or is it taken care of elsehwere
+        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             if let asset = asset(for: token) {
                 let base = Constants.buyWitRampUrl(asset: asset.symbol)
                 return URL(string: "\(base)&userAddress=\(account.address.eip55String)")
@@ -38,7 +39,7 @@ struct Ramp: TokenActionsProvider, BuyTokenURLProviderType {
         switch token.server {
         case .xDai:
             return true
-        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return asset(for: token) != nil
         }
     }

--- a/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
@@ -309,7 +309,7 @@ fileprivate struct Ticker: Codable {
         case .binance_smart_chain: return platform == "binance-smart-chain"
         case .avalanche: return platform == "Avalanche"
         case .polygon: return platform == "polygon-pos"
-        case .poa, .kovan, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain_testnet, .ropsten, .rinkeby, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche_testnet, .mumbai_testnet, .custom:
+        case .poa, .kovan, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain_testnet, .ropsten, .rinkeby, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche_testnet, .mumbai_testnet, .custom, .optimistic, .optimisticKovan:
             return false
         }
     }

--- a/AlphaWallet/Core/DomainResolver.swift
+++ b/AlphaWallet/Core/DomainResolver.swift
@@ -104,7 +104,7 @@ fileprivate extension RPCServer {
         case .kovan: return "kovan"
         case .ropsten: return "ropsten"
         case .rinkeby: return "rinkeby"
-        case .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .custom, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .custom, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return nil
         }
     }

--- a/AlphaWallet/Core/SwapToken/HoneySwap/HoneySwap.swift
+++ b/AlphaWallet/Core/SwapToken/HoneySwap/HoneySwap.swift
@@ -97,7 +97,7 @@ class HoneySwap: TokenActionsProvider, SwapTokenURLProviderType {
         switch token.server {
         case .xDai:
             return true
-        case .main, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .main, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return false
         }
     }

--- a/AlphaWallet/Core/SwapToken/Oneinch/Oneinch.swift
+++ b/AlphaWallet/Core/SwapToken/Oneinch/Oneinch.swift
@@ -57,7 +57,7 @@ class Oneinch: TokenActionsProvider, SwapTokenURLProviderType {
         switch token.server {
         case .main:
             return availableTokens[token.contractAddress] != nil
-        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return false
         }
     }

--- a/AlphaWallet/Core/SwapToken/Uniswap/UniswapERC20Token.swift
+++ b/AlphaWallet/Core/SwapToken/Uniswap/UniswapERC20Token.swift
@@ -19,7 +19,7 @@ extension UniswapERC20Token {
         switch token.server {
         case .main:
             return availableTokens.contains(where: { $0.contract.sameContract(as: token.contractAddress) })
-        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return false
         }
     }

--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -49,7 +49,7 @@ class OpenSea {
         switch server {
         case .main, .rinkeby:
             return true
-        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return false
         }
     }
@@ -99,7 +99,7 @@ class OpenSea {
             return Constants.openseaAPI
         case .rinkeby:
             return Constants.openseaRinkebyAPI
-        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return Constants.openseaAPI
         }
     }

--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -52,7 +52,7 @@ extension AlphaWalletService: TargetType {
         switch self {
         case .getTransactions(_, let server, _, _, _, _):
             switch server {
-            case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+            case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
                 return ""
             }
         case .register:
@@ -98,7 +98,7 @@ extension AlphaWalletService: TargetType {
         switch self {
         case .getTransactions(_, let server, let address, let startBlock, let endBlock, let sortOrder):
             switch server {
-            case .main, .kovan, .ropsten, .rinkeby, .goerli:
+            case .main, .kovan, .ropsten, .rinkeby, .goerli, .optimistic, .optimisticKovan:
                 return .requestParameters(parameters: [
                     "module": "account",
                     "action": "txlist",
@@ -155,7 +155,7 @@ extension AlphaWalletService: TargetType {
         switch self {
         case .getTransactions(_, let server, _, _, _, _):
             switch server {
-            case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+            case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
                 return [
                     "Content-type": "application/json",
                     "client": Bundle.main.bundleIdentifier ?? "",

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -792,12 +792,12 @@ extension InCoordinator: CanOpenURL {
 
     func didPressViewContractWebPage(forContract contract: AlphaWallet.Address, server: RPCServer, in viewController: UIViewController) {
         if contract.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+            guard let url = server.etherscanContractDetailsWebPageURL(for: wallet.address) else { return }
             logExplorerUse(type: .wallet)
-            let url = server.etherscanContractDetailsWebPageURL(for: wallet.address)
             open(url: url, in: viewController)
         } else {
+            guard let url = server.etherscanTokenDetailsWebPageURL(for: contract) else { return }
             logExplorerUse(type: .token)
-            let url = server.etherscanTokenDetailsWebPageURL(for: contract)
             open(url: url, in: viewController)
         }
     }

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -433,6 +433,8 @@
 "blockchain.Avalanche.test" = "Avalanche FUJI C-Chain";
 "blockchain.Polygon" = "Polygon Mainnet";
 "blockchain.Mumbai" = "Mumbai Testnet";
+"blockchain.Optimistic" = "Optimistic Testnet";
+"blockchain.Optimistic.Kovan" = "Optimistic Kovan Testnet";
 "photos" = "Browse";
 "light" = "Light";
 "qrCode.title" = "Point your camera on QR code";

--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -69,7 +69,7 @@ class UniversalLinkCoordinator: Coordinator {
             return "xDAI"
         case .binance_smart_chain, .binance_smart_chain_testnet:
             return "BNB"
-        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom:
+        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .optimistic, .optimisticKovan:
             return "ETH"
         case .heco, .heco_testnet:
             return "HT"
@@ -449,7 +449,7 @@ class UniversalLinkCoordinator: Coordinator {
         switch server {
         case .xDai:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughXDAITitle()
-        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughEthTitle()
         }
         if ethPrice.value == nil {

--- a/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
@@ -31,7 +31,9 @@ class ServersCoordinator: Coordinator {
         .avalanche,
         .avalanche_testnet,
         .polygon,
-        .mumbai_testnet
+        .mumbai_testnet,
+        .optimistic,
+        .optimisticKovan,
     ]
 
     private let viewModel: ServersViewModel

--- a/AlphaWallet/Settings/Types/ConfigExplorer.swift
+++ b/AlphaWallet/Settings/Types/ConfigExplorer.swift
@@ -11,6 +11,7 @@ struct ConfigExplorer {
         self.server = server
     }
 
+    //TODO is this still used? Might need to check func body
     func transactionURL(for ID: String) -> (url: URL, name: String?)? {
         let result = explorer(for: server)
         guard let endpoint = result.url else { return .none }
@@ -20,7 +21,7 @@ struct ConfigExplorer {
                 return endpoint + "/txid/search/" + ID
             case .custom, .callisto:
                 return .none
-            case .main, .kovan, .ropsten, .rinkeby, .sokol, .classic, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+            case .main, .kovan, .ropsten, .rinkeby, .sokol, .classic, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
                 return endpoint + "/tx/" + ID
             }
         }()
@@ -29,6 +30,7 @@ struct ConfigExplorer {
         return (url: url, name: result.name)
     }
 
+    //TODO is this still used? Might need to check func body
     func explorerName(for server: RPCServer) -> String? {
         switch server {
         case .main, .kovan, .ropsten, .rinkeby, .goerli:
@@ -55,9 +57,14 @@ struct ConfigExplorer {
             return "Avalanche Explorer"
         case .polygon, .mumbai_testnet:
             return "Polygon Explorer"
+        case .optimistic:
+            return "Optimistic Explorer"
+        case .optimisticKovan:
+            return "Optimistic Kovan Explorer"
         }
     }
 
+    //TODO is this still used? Might need to check func body
     private func explorer(for server: RPCServer) -> (url: String?, name: String?) {
         let nameForServer = explorerName(for: server)
         switch server {
@@ -105,6 +112,10 @@ struct ConfigExplorer {
             return ("https://explorer-mainnet.maticvigil.com", nameForServer)
         case .mumbai_testnet:
             return ("https://explorer-mumbai.maticvigil.com", nameForServer)
+        case .optimistic:
+            return ("https://optimistic.etherscan.io", nameForServer)
+        case .optimisticKovan:
+            return ("https://kovan-optimistic.etherscan.io", nameForServer)
         }
     }
 }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -76,46 +76,6 @@ public struct Constants {
     //UEFA 721 balances function hash
     static let balances165Hash721Ticket = "0xc84aae17"
 
-    //etherscan-compatible erc20 transaction event APIs
-    //The fetch ERC20 transactions endpoint from Etherscan returns only ERC20 token transactions but the Blockscout version also includes ERC721 transactions too (so it's likely other types that it can detect will be returned too); thus we check the token type rather than assume that they are all ERC20
-    public static let mainnetEtherscanAPIErc20Events = "https://api-cn.etherscan.com/api?module=account&action=tokentx&address="
-    public static let ropstenEtherscanAPIErc20Events = "https://api-ropsten.etherscan.io/api?module=account&action=tokentx&address="
-    public static let kovanEtherscanAPIErc20Events = "https://api-kovan.etherscan.io/api?module=account&action=tokentx&address="
-    public static let rinkebyEtherscanAPIErc20Events = "https://api-rinkeby.etherscan.io/api?module=account&action=tokentx&address="
-    public static let classicAPIErc20Events = "https://blockscout.com/etc/mainnet/api?module=account&action=tokentx&address="
-    public static let xDaiAPIErc20Events = "https://blockscout.com/poa/dai/api?module=account&action=tokentx&address="
-    public static let poaNetworkCoreAPIErc20Events = "https://blockscout.com/poa/core/api?module=account&action=tokentx&address="
-    public static let goerliEtherscanAPIErc20Events = "https://api-goerli.etherscan.io/api?module=account&action=tokentx&address="
-    public static let artisSigma1NetworkCoreAPIErc20Events = "https://explorer.sigma1.artis.network/api?module=account&action=tokentx&address="
-    public static let artisTau1NetworkCoreAPIErc20Events = "https://explorer.tau1.artis.network/api?module=account&action=tokentx&address="
-
-    public static let mainnetEtherscanTokenDetailsWebPageURL = "https://cn.etherscan.com/token/"
-
-    //etherscan-compatible contract details web page
-    public static let mainnetEtherscanContractDetailsWebPageURL = "https://cn.etherscan.com/address/"
-    public static let kovanEtherscanContractDetailsWebPageURL = "https://kovan.etherscan.io/address/"
-    public static let rinkebyEtherscanContractDetailsWebPageURL = "https://rinkeby.etherscan.io/address/"
-    public static let ropstenEtherscanContractDetailsWebPageURL = "https://ropsten.etherscan.io/address/"
-    //Can't use https://blockscout.com/poa/dai/address/ even though it ultimately redirects there because blockscout (tested on 20190620), blockscout.com is only able to show that URL after the address has been searched (with the ?q= URL)
-    public static let xDaiContractPage = "https://blockscout.com/poa/dai/search?q="
-    public static let poaContractPage = "https://blockscout.com/poa/core/search?q="
-    public static let goerliContractPage = "https://goerli.etherscan.io/address/"
-    public static let sokolContractPage = "https://blockscout.com/poa/sokol/search?q="
-    public static let etcContractPage = "https://blockscout.com/etc/mainnet/search?q="
-    public static let callistoContractPage = "https://blockscout.com/callisto/mainnet/search?q="
-    public static let artisSigma1ContractPage = "https://explorer.sigma1.artis.network/search?q="
-    public static let artisTau1ContractPage = "https://explorer.tau1.artis.network/search?q="
-    public static let binanceContractPage = "https://bscscan.com/search?q="
-    public static let binanceTestnetContractPage = "https://testnet.bscscan.com/search?q="
-    public static let hecoContractPage = "https://scan.hecochain.com/address/"
-    public static let hecoTestnetContractPage = "https://scan-testnet.hecochain.com/address/"
-    public static let fantomContractPage = "https://ftmscan.com/address/"
-    public static let fantomTestnetContractPage = "https://ftmscan.com/address/"
-    public static let avalancheContractPage = "https://cchain.explorer.avax.network/address/"
-    public static let avalancheTestnetContractPage = "https://cchain.explorer.avax-test.network/address/"
-    public static let maticContractPage = "https://explorer-mainnet.maticvigil.com/address/"
-    public static let mumbaiContractPage = "https://explorer-mumbai.maticvigil.com/address/"
-
     //OpenSea links for erc721 assets
     public static let openseaAPI = "https://api.opensea.io/"
     public static let openseaRinkebyAPI = "https://rinkeby-api.opensea.io/"

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -34,6 +34,8 @@ public struct Constants {
     public static let avalancheTestMagicLinkHost = "test-avalanche.aw.app"
     public static let maticMagicLinkHost = "polygon.aw.app"
     public static let mumbaiTestMagicLinkHost = "test-polygon.aw.app"
+    public static let optimisticMagicLinkHost = "optimistic.aw.app"
+    public static let optimisticTestMagicLinkHost = "optimistic-kovan.aw.app"
 
     public enum Currency {
         static let usd = "USD"

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -30,6 +30,8 @@ enum RPCServer: Hashable, CaseIterable {
     case avalanche_testnet
     case polygon
     case mumbai_testnet
+    case optimistic
+    case optimisticKovan
     case custom(CustomRPC)
 
     private enum EtherscanCompatibleType {
@@ -69,6 +71,8 @@ enum RPCServer: Hashable, CaseIterable {
         case .avalanche_testnet: return 0xa869
         case .polygon: return 137
         case .mumbai_testnet: return 80001
+        case .optimistic: return 10
+        case .optimisticKovan: return 69
         }
     }
 
@@ -97,21 +101,23 @@ enum RPCServer: Hashable, CaseIterable {
         case .avalanche_testnet: return "Avalanche FUJI C-Chain"
         case .polygon: return "Polygon Mainnet"
         case .mumbai_testnet: return "Mumbai Testnet"
+        case .optimistic: return "Optimistic Ethereum"
+        case .optimisticKovan: return "Optimistic Kovan"
         }
     }
 
     var isTestnet: Bool {
         switch self {
-        case .xDai, .classic, .main, .poa, .callisto, .binance_smart_chain, .artis_sigma1, .heco, .fantom, .avalanche, .polygon:
+        case .xDai, .classic, .main, .poa, .callisto, .binance_smart_chain, .artis_sigma1, .heco, .fantom, .avalanche, .polygon, .optimistic:
             return false
-        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_tau1, .binance_smart_chain_testnet, .custom, .heco_testnet, .fantom_testnet, .avalanche_testnet, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_tau1, .binance_smart_chain_testnet, .custom, .heco_testnet, .fantom_testnet, .avalanche_testnet, .mumbai_testnet, .optimisticKovan:
             return true
         }
     }
 
     var etherscanURLForGeneralTransactionHistory: URL? {
         switch self {
-        case .main, .ropsten, .rinkeby, .kovan, .poa, .classic, .goerli, .xDai, .artis_sigma1, .artis_tau1, .polygon, .binance_smart_chain, .binance_smart_chain_testnet, .sokol, .callisto:
+        case .main, .ropsten, .rinkeby, .kovan, .poa, .classic, .goerli, .xDai, .artis_sigma1, .artis_tau1, .polygon, .binance_smart_chain, .binance_smart_chain_testnet, .sokol, .callisto, .optimistic, .optimisticKovan:
             return etherscanApiRoot.appendingQueryString("module=account&action=txlist")
         case .heco: return nil
         case .heco_testnet: return nil
@@ -157,6 +163,8 @@ enum RPCServer: Hashable, CaseIterable {
             case .binance_smart_chain_testnet: return "https://testnet.bscscan.com"
             case .polygon: return "https://explorer-mainnet.maticvigil.com"
             case .mumbai_testnet: return "https://explorer-mumbai.maticvigil.com"
+            case .optimistic: return "https://optimistic.etherscan.io"
+            case .optimisticKovan: return "https://kovan-optimistic.etherscan.io"
             case .custom: return nil
             case .fantom_testnet, .avalanche, .avalanche_testnet:
                 return nil
@@ -194,6 +202,8 @@ enum RPCServer: Hashable, CaseIterable {
             case .avalanche_testnet: return "https://cchain.explorer.avax-test.network/tx/api"
             case .polygon: return "https://explorer-mainnet.maticvigil.com/api/v2"
             case .mumbai_testnet: return "https://explorer-mumbai.maticvigil.com/api/v2"
+            case .optimistic: return "https://api-optimistic.etherscan.io/api"
+            case .optimisticKovan: return "https://api-kovan-optimistic.etherscan.io/api"
             }
         }()
         return URL(string: urlString)!
@@ -213,7 +223,7 @@ enum RPCServer: Hashable, CaseIterable {
 
     private var etherscanCompatibleType: EtherscanCompatibleType {
         switch self {
-        case .main, .ropsten, .rinkeby, .kovan, .goerli, .fantom, .heco, .heco_testnet:
+        case .main, .ropsten, .rinkeby, .kovan, .goerli, .fantom, .heco, .heco_testnet, .optimistic, .optimisticKovan:
             return .etherscan
         case .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .polygon, .mumbai_testnet, .callisto:
             return .blockscout
@@ -274,14 +284,14 @@ enum RPCServer: Hashable, CaseIterable {
         switch self {
         case .main:
             return etherscanWebpageRoot?.appendingPathComponent("token").appendingPathComponent(address.eip55String)
-        case .ropsten, .rinkeby, .kovan, .xDai, .goerli, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .ropsten, .rinkeby, .kovan, .xDai, .goerli, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return etherscanContractDetailsWebPageURL(for: address)
         }
     }
 
     var priceID: AlphaWallet.Address {
         switch self {
-        case .main, .ropsten, .rinkeby, .kovan, .sokol, .custom, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .main, .ropsten, .rinkeby, .kovan, .sokol, .custom, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return AlphaWallet.Address(string: "0x000000000000000000000000000000000000003c")!
         case .poa:
             return AlphaWallet.Address(string: "0x00000000000000000000000000000000000000AC")!
@@ -316,12 +326,14 @@ enum RPCServer: Hashable, CaseIterable {
         case .fantom, .fantom_testnet: return "FTM"
         case .avalanche, .avalanche_testnet: return "AVAX"
         case .polygon, .mumbai_testnet: return "MATIC"
+        case .optimistic: return "ETH"
+        case .optimisticKovan: return "ETH"
         }
     }
 
     var cryptoCurrencyName: String {
         switch self {
-        case .main, .classic, .callisto, .kovan, .ropsten, .rinkeby, .poa, .sokol, .goerli, .custom:
+        case .main, .classic, .callisto, .kovan, .ropsten, .rinkeby, .poa, .sokol, .goerli, .custom, .optimistic, .optimisticKovan:
             return "Ether"
         case .xDai:
             return "xDai"
@@ -348,7 +360,7 @@ enum RPCServer: Hashable, CaseIterable {
         case .kovan: return .Kovan
         case .ropsten: return .Ropsten
         case .rinkeby: return .Rinkeby
-        case .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .custom, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .custom, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return .Custom(networkID: BigUInt(chainID))
         }
     }
@@ -406,6 +418,10 @@ enum RPCServer: Hashable, CaseIterable {
             return Constants.maticMagicLinkHost
         case .mumbai_testnet:
             return Constants.mumbaiTestMagicLinkHost
+        case .optimistic:
+            return Constants.optimisticMagicLinkHost
+        case .optimisticKovan:
+            return Constants.optimisticTestMagicLinkHost
         }
     }
 
@@ -435,6 +451,8 @@ enum RPCServer: Hashable, CaseIterable {
             case .avalanche_testnet: return "https://api.avax-test.network/ext/bc/C/rpc"
             case .polygon: return "https://rpc-mainnet.maticvigil.com/"
             case .mumbai_testnet: return "https://rpc-mumbai.maticvigil.com/"
+            case .optimistic: return "https://mainnet.optimism.io"
+            case .optimisticKovan: return "https://kovan.optimism.io"
             }
         }()
         return URL(string: urlString)!
@@ -443,7 +461,7 @@ enum RPCServer: Hashable, CaseIterable {
     var transactionInfoEndpoints: URL {
         let urlString: String = {
             switch self {
-            case .main, .kovan, .ropsten, .rinkeby, .goerli, .classic, .poa, .xDai, .sokol, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .fantom, .polygon, .heco, .heco_testnet, .callisto:
+            case .main, .kovan, .ropsten, .rinkeby, .goerli, .classic, .poa, .xDai, .sokol, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .fantom, .polygon, .heco, .heco_testnet, .callisto, .optimistic, .optimisticKovan:
                 return etherscanApiRoot.absoluteString
             case .custom: return "" // Enable? make optional
             case .fantom_testnet: return "https://explorer.testnet.fantom.network/tx/"
@@ -461,7 +479,7 @@ enum RPCServer: Hashable, CaseIterable {
         case .ropsten: return Constants.ENSRegistrarRopsten
         case .rinkeby: return Constants.ENSRegistrarRinkeby
         case .goerli: return Constants.ENSRegistrarGoerli
-        case .xDai, .kovan, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .xDai, .kovan, .poa, .sokol, .classic, .callisto, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return Constants.ENSRegistrarAddress
         }
     }
@@ -470,7 +488,7 @@ enum RPCServer: Hashable, CaseIterable {
         switch self {
         case .main, .xDai:
             return .normal
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return .low
         }
     }
@@ -505,6 +523,10 @@ enum RPCServer: Hashable, CaseIterable {
             return R.string.localizable.blockchainPolygon()
         case .mumbai_testnet:
             return R.string.localizable.blockchainMumbai()
+        case .optimistic:
+            return R.string.localizable.blockchainOptimistic()
+        case .optimisticKovan:
+            return R.string.localizable.blockchainOptimisticKovan()
         }
     }
 
@@ -530,12 +552,14 @@ enum RPCServer: Hashable, CaseIterable {
         case .avalanche_testnet: return .red
         case .polygon: return .red
         case .mumbai_testnet: return .red
+        case .optimistic: return .red
+        case .optimisticKovan: return .red
         }
     }
 
     var transactionDataCoordinatorType: SingleChainTransactionDataCoordinator.Type {
         switch self {
-        case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return SingleChainTransactionEtherscanDataCoordinator.self
         }
     }
@@ -570,6 +594,10 @@ enum RPCServer: Hashable, CaseIterable {
             return R.image.iconsTokensPolygon()
         case .mumbai_testnet:
             return nil
+        case .optimistic:
+            return nil
+        case .optimisticKovan:
+            return nil
         }
     }
 
@@ -598,6 +626,8 @@ enum RPCServer: Hashable, CaseIterable {
             case RPCServer.avalanche_testnet.name: return .avalanche_testnet
             case RPCServer.polygon.name: return .polygon
             case RPCServer.mumbai_testnet.name: return .mumbai_testnet
+            case RPCServer.optimistic.name: return .optimistic
+            case RPCServer.optimisticKovan.name: return .optimisticKovan
             default: return .main
             }
         }()
@@ -628,6 +658,8 @@ enum RPCServer: Hashable, CaseIterable {
             case RPCServer.avalanche_testnet.chainID: return .avalanche_testnet
             case RPCServer.polygon.chainID: return .polygon
             case RPCServer.mumbai_testnet.chainID: return .mumbai_testnet
+            case RPCServer.optimistic.chainID: return .optimistic
+            case RPCServer.optimisticKovan.chainID: return .optimisticKovan
             default: return .main
             }
         }()
@@ -658,6 +690,8 @@ enum RPCServer: Hashable, CaseIterable {
             case RPCServer.avalanche_testnet.magicLinkHost: return .avalanche_testnet
             case RPCServer.polygon.magicLinkHost: return .polygon
             case RPCServer.mumbai_testnet.magicLinkHost: return .mumbai_testnet
+            case RPCServer.optimistic.magicLinkHost: return .optimistic
+            case RPCServer.optimisticKovan.magicLinkHost: return .optimisticKovan
             default: return nil
             }
         }()
@@ -697,7 +731,9 @@ enum RPCServer: Hashable, CaseIterable {
             .avalanche,
             .avalanche_testnet,
             .polygon,
-            .mumbai_testnet
+            .mumbai_testnet,
+            .optimistic,
+            .optimisticKovan,
         ]
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -17,7 +17,7 @@ class GetContractInteractions {
 
     //TODO rename this since it might include ERC721 (blockscout and compatible like Polygon's). Or can we make this really fetch ERC20, maybe by filtering the results?
     func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) else { return }
+        guard let etherscanURL = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) else { return }
 
         Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
             switch response.result {
@@ -89,7 +89,7 @@ class GetContractInteractions {
 
     //TODO Almost a duplicate of the the ERC20 version. De-dup maybe?
     func getErc721Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.etherscanAPIURLForERC721TxList(for: address, startBlock: startBlock) else { return }
+        guard let etherscanURL = server.getEtherscanURLForERC721TransactionHistory(for: address, startBlock: startBlock) else { return }
 
         Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
             switch response.result {
@@ -162,13 +162,13 @@ class GetContractInteractions {
     func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool, completion: @escaping ([AlphaWallet.Address], Int?) -> Void) {
         let etherscanURL: URL
         if erc20 {
-            if let url = server.etherscanAPIURLForERC20TxList(for: address, startBlock: startBlock) {
+            if let url = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return
             }
         } else {
-            if let url = server.etherscanAPIURLForTransactionList(for: address, startBlock: startBlock) {
+            if let url = server.getEtherscanURLForGeneralTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
                 return

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -177,7 +177,7 @@ class SingleChainTokenCoordinator: Coordinator {
             autoDetectXDaiPartnerTokens()
         case .rinkeby:
             autoDetectRinkebyPartnerTokens()
-        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .custom, .heco_testnet, .heco, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .custom, .heco_testnet, .heco, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             break
         }
     }

--- a/AlphaWallet/Tokens/Types/TokenCollection.swift
+++ b/AlphaWallet/Tokens/Types/TokenCollection.swift
@@ -122,6 +122,8 @@ extension RPCServer {
         case .avalanche_testnet: return 19
         case .polygon: return 20
         case .mumbai_testnet: return 21
+        case .optimistic: return 22
+        case .optimisticKovan: return 23
         }
     }
 }

--- a/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenViewControllerViewModel.swift
@@ -55,7 +55,7 @@ struct TokenViewControllerViewModel {
                 switch token.server {
                 case .xDai:
                     return [.init(type: .erc20Send), .init(type: .xDaiBridge), .init(type: .erc20Receive)] + tokenActionsProvider.actions(token: token)
-                case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+                case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
                     return actions + tokenActionsProvider.actions(token: token)
                 }
             }
@@ -70,7 +70,7 @@ struct TokenViewControllerViewModel {
                 switch token.server {
                 case .xDai:
                     xDaiBridgeActions = [.init(type: .xDaiBridge)]
-                case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+                case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
                     xDaiBridgeActions = []
                 }
 

--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -347,7 +347,7 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
             }
         case .classic, .xDai:
             break
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             break
         }
 
@@ -367,10 +367,11 @@ class SingleChainTransactionEtherscanDataCoordinator: SingleChainTransactionData
     private func notifyUserEtherReceived(for transactionId: String, amount: String) {
         let notificationCenter = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
+        //TODO support other mainnets too
         switch session.server {
         case .main, .xDai:
             content.body = R.string.localizable.transactionsReceivedEther(amount, session.server.symbol)
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             content.body = R.string.localizable.transactionsReceivedEther("\(amount) (\(session.server.name))", session.server.symbol)
         }
         content.sound = .default

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -217,7 +217,7 @@ class TransactionConfigurator {
             }
         case .xDai:
             return estimateGasPriceForXDai()
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return Promise(estimateGasPriceForUseRpcNode(server: server))
         }
     }
@@ -288,7 +288,7 @@ class TransactionConfigurator {
             if (configurations.standard.gasPrice / BigInt(EthereumUnit.gwei.rawValue)) > Constants.highStandardGasThresholdGwei {
                 return .networkCongested
             }
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .fantom, .fantom_testnet, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .fantom, .fantom_testnet, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             break
         }
         return nil
@@ -299,7 +299,7 @@ class TransactionConfigurator {
         case .xDai:
             //xdai transactions are always 1 gwei in gasPrice
             return GasPriceConfiguration.xDaiGasPrice
-        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             if let gasPrice = transaction.gasPrice, gasPrice > 0 {
                 return min(max(gasPrice, GasPriceConfiguration.minPrice), GasPriceConfiguration.maxPrice)
             } else {

--- a/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
@@ -109,7 +109,7 @@ fileprivate extension RPCServer {
             } else {
                 return rpcURL
             }
-        case .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .main, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
+        case .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .main, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan:
             return self.rpcURL
         }
     }


### PR DESCRIPTION
Only after #2841 is merged, because it includes commits from that PR.

Comments in the code which explains the rationale:

> We just filter out those that we don't think are supported by the API. One problem this helps to alleviate is in the API output, certain tickers have a non-empty platform yet the platform list might not be complete, eg. Ether on Ethereum mainnet:
> {
>    "symbol" : "eth",
>    "id" : "ethereum",
>    "name" : "Ethereum",
>    "platforms" : {
>       "huobi-token" : "0x64ff637fb478863b7468bc97d30a5bf3a428a1fd",
>       "binance-smart-chain" : "0x2170ed0880ac9a755fd29b2688956bd959f933f8"
>    }
> },
> This means we can only match solely by symbol, ignoring platform matches. But this means it's easy to match the wrong ticker (by symbol only). Hence, we at least remove those chains we don't think are supported
