### PR TITLE
Refactor to make sending Etherscan API key clearer

### DIFF
--- a/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
+++ b/AlphaWallet/EtherClient/TrustClient/AlphaWalletService.swift
@@ -97,27 +97,20 @@ extension AlphaWalletService: TargetType {
     var task: Task {
         switch self {
         case .getTransactions(_, let server, let address, let startBlock, let endBlock, let sortOrder):
-            switch server {
-            case .main, .kovan, .ropsten, .rinkeby, .goerli, .optimistic, .optimisticKovan:
-                return .requestParameters(parameters: [
-                    "module": "account",
-                    "action": "txlist",
-                    "address": address,
-                    "startblock": startBlock,
-                    "endblock": endBlock,
-                    "sort": sortOrder.rawValue,
-                    "apikey": Constants.Credentials.etherscanKey,
-                ], encoding: URLEncoding())
-            case .classic, .callisto, .custom, .poa, .sokol, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet:
-                return .requestParameters(parameters: [
-                    "module": "account",
-                    "action": "txlist",
-                    "address": address,
-                    "startblock": startBlock,
-                    "endblock": endBlock,
-                    "sort": sortOrder.rawValue,
-                ], encoding: URLEncoding())
+            var parameters: [String: Any] = [
+                "module": "account",
+                "action": "txlist",
+                "address": address,
+                "startblock": startBlock,
+                "endblock": endBlock,
+                "sort": sortOrder.rawValue,
+            ]
+            if let apiKey = server.etherscanApiKey {
+                parameters["apikey"] = apiKey
+            } else {
+                //no-op
             }
+            return .requestParameters(parameters: parameters, encoding: URLEncoding())
         case .register(_, let device):
             return .requestJSONEncodable(device)
         case .unregister(_, let device):

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -232,9 +232,21 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    var etherscanApiKey: String? {
+        switch etherscanCompatibleType {
+        case .etherscan:
+            //TODO this is quite correct too. Sometimes the etherscan-compatible site is based on Etherscan, but the API keys wouldn't work. But it's harmless to send them, for now
+            return Constants.Credentials.etherscanKey
+        case .blockscout:
+            return nil
+        case .unknown:
+            return nil
+        }
+    }
+
     func getEtherscanURLForGeneralTransactionHistory(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
          etherscanURLForGeneralTransactionHistory.flatMap {
-             let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)")
+             let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(etherscanApiKey ?? "")")
              if let startBlock = startBlock {
                  return url?.appendingQueryString("startBlock=\(startBlock)")
              } else {
@@ -245,7 +257,7 @@ enum RPCServer: Hashable, CaseIterable {
 
     func getEtherscanURLForTokenTransactionHistory(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
         etherscanURLForTokenTransactionHistory.flatMap {
-            let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)")
+            let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(etherscanApiKey ?? "")")
             if let startBlock = startBlock {
                 return url?.appendingQueryString("startBlock=\(startBlock)")
             } else {
@@ -256,7 +268,7 @@ enum RPCServer: Hashable, CaseIterable {
 
     func getEtherscanURLForERC721TransactionHistory(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
         etherscanURLForERC721TransactionHistory.flatMap {
-            let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(Constants.Credentials.etherscanKey)")
+            let url = $0.appendingQueryString("address=\(address.eip55String)&apikey=\(etherscanApiKey ?? "")")
             if let startBlock = startBlock {
                 return url?.appendingQueryString("startBlock=\(startBlock)")
             } else {


### PR DESCRIPTION
Make it clearer where the API key is used.

This still has the limitation that we are sometimes sending the Etherscan API key to sites that are based on Etherscan (not Blockscout), but is actually not Etherscan, eg. https://ftmscan.com for `.fantom`. This should be harmless, so leave it for now.