### PR TITLE
Add comment for clarify about frequent "execution reverted" RPC node errors

### DIFF
--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -394,6 +394,8 @@ class TokensDataStore {
         var knownToBeNotERC875 = false
         withRetry(times: numberOfTimesToRetryFetchContractData) { [weak self] triggerRetry in
             guard let strongSelf = self else { return }
+            //Function hash is "0x4f452b9a". This might cause many "execution reverted" RPC errors
+            //TODO rewrite flow so we reduce checks for this as it causes too many "execution reverted" RPC errors and looks scary when we look in Charles proxy. Maybe check for ERC20 (via EIP165) as well as ERC721 in parallel first, then fallback to this ERC875 check
             strongSelf.getIsERC875ContractCoordinator.getIsERC875Contract(for: address) { [weak self] result in
                 guard self != nil else { return }
                 switch result {


### PR DESCRIPTION
There can be many "execution reverted" errors (especially obvious if looking with Charles proxy). Many of these are caused by checking the token type for ERC875, with the function hash `0x4f452b9a`.

This PR adds a comment, including the hash so this can be more easily discovered as well as a TODO to how to improve it.