### PR TITLE
Fix: when a dapp asks to sign a transaction and has a bool in the payload, actionsheet doesn't appear

### DIFF
--- a/AlphaWallet/Browser/Types/DappCommand.swift
+++ b/AlphaWallet/Browser/Types/DappCommand.swift
@@ -60,6 +60,10 @@ struct DappCommandObjectValue: Decodable {
                 value = stringValue
                 eip712v3And4Data = nil
             }
+        } else if let boolValue = try? container.decode(Bool.self) {
+            //TODO not sure if we actually need the handle bools here. But just to make sure an additional Bool doesn't break the creation of `[String: DappCommandObjectValue]` and hence `DappCommand`, we convert it to a `String`
+            value = String(boolValue)
+            eip712v3And4Data = nil
         } else {
             var arrayContainer = try coder.unkeyedContainer()
             while !arrayContainer.isAtEnd {


### PR DESCRIPTION
Fixes #2839 

Example payload (note the encodeAbi = false):

```
{
   "object" : {
      "to" : "0x5d0fa08aeb173ade44b0cf7f31d506d8e04f0ac8",
      "nonce" : "0x76",
      "chainType" : "ETH",
      "gas" : "0xb51c",
      "gasPrice" : "0x2b06f0380",
      "data" : "0x095ea7b300000000000000000000000040ec5b33f54e0e8a33a975908c5ba1c14e5bbbdfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
      "encodeAbi" : false,
      "chainId" : 1,
      "from" : "0xbbce83173d5c1d122ae64856b4af0d5ae07fa362",
      "value" : "0x0"
   },
   "name" : "signTransaction",
   "id" : 8888
}
```