### PR TITLE
Improve price matching false positives

### DIFF
--- a/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
@@ -11,11 +11,13 @@ import SwiftyJSON
 
 struct TokenMappedToTicker: Hashable {
     let symbol: String
+    let name: String
     let contractAddress: AlphaWallet.Address
     let server: RPCServer
 
     init(tokenObject: TokenObject) {
         symbol = tokenObject.symbol
+        name = tokenObject.name
         contractAddress = tokenObject.contractAddress
         server = tokenObject.server
     }
@@ -282,7 +284,7 @@ fileprivate struct Ticker: Codable {
                 return false
             }
         } else {
-            return symbol.localizedLowercase == tokenObject.symbol.localizedLowercase
+            return symbol.localizedLowercase == tokenObject.symbol.localizedLowercase && name.localizedLowercase == tokenObject.name.localizedLowercase
         }
     }
 

--- a/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
@@ -19,12 +19,6 @@ struct TokenMappedToTicker: Hashable {
         contractAddress = tokenObject.contractAddress
         server = tokenObject.server
     }
-
-    init(symbol: String, contractAddress: AlphaWallet.Address, server: RPCServer) {
-        self.symbol = symbol
-        self.contractAddress = contractAddress
-        self.server = server
-    }
 }
 
 protocol CoinTickersFetcherType {


### PR DESCRIPTION
Specifically:

This "360APP" token (symbol=DAPP) [1] has at least 2 false positives when they are different tokens. They no longer match if we check the names too.

[1] https://etherscan.io/token/0x5D0fa08AEb173AdE44B0Cf7F31d506D8E04f0ac8