### PR TITLE
Tweak height of 'Contract Execution' cell in Activity tab

### DIFF
--- a/AlphaWallet/Activities/Views/GroupActivityViewCell.swift
+++ b/AlphaWallet/Activities/Views/GroupActivityViewCell.swift
@@ -27,7 +27,7 @@ class GroupActivityViewCell: UITableViewCell {
 
             background.anchorsConstraint(to: contentView),
 
-            contentView.heightAnchor.constraint(equalToConstant: 40)
+            contentView.heightAnchor.constraint(equalToConstant: 80)
         ])
     }
 


### PR DESCRIPTION
Closes #2850 

Temporarily solution until we implement the real thing (want to have a build we can ship first).

Before PR|After PR
-|-
<img width="200" alt="Screenshot 2021-06-07 at 7 34 59 PM" src="https://user-images.githubusercontent.com/56189/121010028-74630d80-c7c7-11eb-907c-ee3e2bd6d4d9.png">|<img width="200" alt="Screenshot 2021-06-07 at 7 31 41 PM" src="https://user-images.githubusercontent.com/56189/121009933-53022180-c7c7-11eb-8425-2a7630971228.png">

Final form (not in this PR):

<img width="200" alt="Screenshot 2021-06-07 at 7 33 40 PM" src="https://user-images.githubusercontent.com/56189/121009951-57c6d580-c7c7-11eb-923d-3f962a791089.png">
