### PR TITLE
Fix: Binance explorer APIs wrongly taken as Blockscout. Should be Etherscan

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -223,9 +223,9 @@ enum RPCServer: Hashable, CaseIterable {
 
     private var etherscanCompatibleType: EtherscanCompatibleType {
         switch self {
-        case .main, .ropsten, .rinkeby, .kovan, .goerli, .fantom, .heco, .heco_testnet, .optimistic, .optimisticKovan:
+        case .main, .ropsten, .rinkeby, .kovan, .goerli, .fantom, .heco, .heco_testnet, .optimistic, .optimisticKovan, .binance_smart_chain, .binance_smart_chain_testnet:
             return .etherscan
-        case .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .polygon, .mumbai_testnet, .callisto:
+        case .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .polygon, .mumbai_testnet, .callisto:
             return .blockscout
         case .custom, .fantom_testnet, .avalanche, .avalanche_testnet:
             return .unknown


### PR DESCRIPTION
Because `action=tokennfttx` is supported:

> curl 'https://api.bscscan.com/api?module=account&action=tokennfttx&address=0x007bEe82BDd9e866b2bd114780a47f2261C684E3'

> {"status":"0","message":"No transactions found","result":[]}

Doesn't say: "Unknown action"
