### PR TITLE
Show '1 <symbol>` instead of `1 Tickers` in Wallet tab for NFTs

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
@@ -71,7 +71,7 @@ struct NonFungibleTokenViewCellViewModel {
     }
 
     var tickersAmountAttributedString: NSAttributedString {
-        return .init(string: "\(amount) Tickers", attributes: [
+        return .init(string: "\(amount) \(token.symbol)", attributes: [
             .font: Screen.TokenCard.Font.subtitle,
             .foregroundColor: Screen.TokenCard.Color.subtitle
         ])


### PR DESCRIPTION
Part of #2890 

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/121860951-f30dfc80-cd2b-11eb-8208-eb03ef801053.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/121860938-eee1df00-cd2b-11eb-9431-2a217c3f2477.png'>