### PR TITLE
Read token instance permalink from ERC721 token for those source directly from smart contract + JSON metadata (i.e not from OpenSea)

### DIFF
--- a/AlphaWallet/Tokens/Types/NonFungibleFromTokenUri.swift
+++ b/AlphaWallet/Tokens/Types/NonFungibleFromTokenUri.swift
@@ -16,9 +16,7 @@ struct NonFungibleFromTokenUri: Codable, NonFungibleFromJson {
     var contractImageUrl: String {
         ""
     }
-    var externalLink: String {
-        ""
-    }
+    let externalLink: String
     var backgroundColor: String? {
         ""
     }

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -601,6 +601,7 @@ class TokensDataStore {
                 jsonDictionary["name"] = ""
                 jsonDictionary["imageUrl"] = ""
                 jsonDictionary["thumbnailUrl"] = ""
+                jsonDictionary["externalLink"] = ""
             }
             return .value((contract: address, json: jsonDictionary.rawString()!))
         }
@@ -625,6 +626,8 @@ class TokensDataStore {
                         jsonDictionary["name"] = jsonDictionary["name"]
                         jsonDictionary["imageUrl"] = jsonDictionary["image"]
                         jsonDictionary["thumbnailUrl"] = jsonDictionary["image"]
+                        //We make sure the value stored is at least an empty string, never nil because we need to deserialise/decode it
+                        jsonDictionary["externalLink"] = JSON(jsonDictionary["external_url"].stringValue)
                     }
                     if let jsonString = jsonDictionary.rawString() {
                         return (contract: address, json: jsonString)


### PR DESCRIPTION
This was already read from the OpenSea API results. But if the ERC721 token isn't found in OpenSea, we would fallback to the `tokenURI` for the token metadata.

This PR makes it so that we look for the token's permalink in that metadata when we read `tokenURI`directly.