### PR TITLE
Make chain ID returned by `web3.version.getNetwork()` be hex encoded

### DIFF
--- a/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
+++ b/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
@@ -130,7 +130,7 @@ extension WKWebViewConfiguration {
                    }
                }, {
                    address: addressHex,
-                   networkVersion: chainID
+                   networkVersion: "0x" + parseInt(chainID).toString(16) || null
                })
 
                web3.setProvider = function () {


### PR DESCRIPTION
Before PR:

```
(new Web3(window.web3.currentProvider)).version.getNetwork(function(e, chainId) { console.log(chainId) })
```
> 128

After PR:

```
(new Web3(window.web3.currentProvider)).version.getNetwork(function(e, chainId) { console.log(chainId) })
```
> 0x80

After the PR, it will be consistent with this:

```
await ethereum.request({method: 'eth_chainId'})
```
> "0x80"

and adhere to how JSON RPC hex value is encoded according to https://eth.wiki/json-rpc/API
