### PR TITLE
Fix: ERC721 token balance which has become 0 aren't zeroed-out correctly

### DIFF
--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -577,7 +577,7 @@ class TokensDataStore {
             let guarantees: [Guarantee<ContractAndJson>] = tokenIds.map { self.fetchNonFungibleJson(forTokenId: $0, address: contract, tokens: tokens) }
             return when(fulfilled: guarantees)
         }.done { listOfContractAndJsonResult in
-            var contractsAndJsons: [AlphaWallet.Address: [String]] = .init()
+            var contractsAndJsons: [AlphaWallet.Address: [String]] = [contract: .init()]
             for each in listOfContractAndJsonResult {
                 if var listOfJson = contractsAndJsons[each.contract] {
                     listOfJson.append(each.json)

--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -278,7 +278,9 @@ extension TransactionsStorage: Erc721TokenIdsFetcher {
             for each in operations {
                 let tokenId = each.tokenId
                 guard !tokenId.isEmpty else { continue }
-                if account.sameContract(as: each.from) {
+                if account.sameContract(as: each.from) && account.sameContract(as: each.to) {
+                    //no-op
+                } else if account.sameContract(as: each.from) {
                     tokenIds.remove(tokenId)
                 } else if account.sameContract(as: each.to) {
                     tokenIds.insert(tokenId)


### PR DESCRIPTION
This is for tokens source directly from blockchain explorer APIs, not from OpenSea.

Fixes: #2917 

ie. given a token with transactions in this sequence:

1. Receive tokenId 11 //balance 1, ok
2. Receive tokenId 23 //balance 2, ok
3. Sent tokenId 11 //balance 1, ok
4. Sent tokenId 23 //balance still 1, wrong, should be 0.