### PR TITLE
Fix: In the switch server screen, de-selecting every testnets should not bounce the user back to mainnet (testnet can't be enabled again, if that happens)

### DIFF
--- a/AlphaWallet/Settings/Coordinators/EnabledServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/EnabledServersCoordinator.swift
@@ -22,7 +22,7 @@ class EnabledServersCoordinator: Coordinator {
     private let analyticsCoordinator: AnalyticsCoordinator
 
     private lazy var enabledServersViewController: EnabledServersViewController = {
-        let viewModel = EnabledServersViewModel(servers: serverChoices, selectedServers: selectedServers)
+        let viewModel = EnabledServersViewModel(servers: serverChoices, selectedServers: selectedServers, mode: selectedServers.contains(where: { $0.isTestnet }) ? .testnet : .mainnet )
         let controller = EnabledServersViewController(viewModel: viewModel, restartQueue: restartQueue)
         controller.delegate = self
         controller.hidesBottomBarWhenPushed = true

--- a/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
@@ -156,7 +156,7 @@ extension EnabledServersViewController: UITableViewDelegate, UITableViewDataSour
         } else {
             servers = viewModel.selectedServers + [server]
         }
-        configure(viewModel: .init(servers: viewModel.servers, selectedServers: servers))
+        configure(viewModel: .init(servers: viewModel.servers, selectedServers: servers, mode: viewModel.mode))
         tableView.reloadData()
         //Even if no servers is selected, we don't attempt to disable the back button here since calling code will take care of ignore the change server "request" when there are no servers selected. We don't want to disable the back button because users can't cancel the operation
     }
@@ -186,10 +186,10 @@ extension EnabledServersViewController: EnableServersHeaderViewDelegate {
         case (.mainnet, true), (.testnet, false):
             if let serversSelectedInPreviousMode = serversSelectedInPreviousMode {
                 self.serversSelectedInPreviousMode = viewModel.selectedServers
-                configure(viewModel: .init(servers: viewModel.servers, selectedServers: serversSelectedInPreviousMode))
+                configure(viewModel: .init(servers: viewModel.servers, selectedServers: serversSelectedInPreviousMode, mode: .mainnet))
             } else {
                 serversSelectedInPreviousMode = viewModel.selectedServers
-                configure(viewModel: .init(servers: viewModel.servers, selectedServers: Constants.defaultEnabledServers))
+                configure(viewModel: .init(servers: viewModel.servers, selectedServers: Constants.defaultEnabledServers, mode: .mainnet))
             }
             tableView.reloadData()
             tableView.reloadSections(sectionIndices, with: .automatic)
@@ -210,10 +210,10 @@ extension EnabledServersViewController: PromptViewControllerDelegate {
         controller.dismiss(animated: true) {
             if let serversSelectedInPreviousMode = self.serversSelectedInPreviousMode {
                 self.serversSelectedInPreviousMode = self.viewModel.selectedServers
-                self.configure(viewModel: .init(servers: self.viewModel.servers, selectedServers: serversSelectedInPreviousMode))
+                self.configure(viewModel: .init(servers: self.viewModel.servers, selectedServers: serversSelectedInPreviousMode, mode: .testnet))
             } else {
                 self.serversSelectedInPreviousMode = self.viewModel.selectedServers
-                self.configure(viewModel: .init(servers: self.viewModel.servers, selectedServers: Constants.defaultEnabledTestnetServers))
+                self.configure(viewModel: .init(servers: self.viewModel.servers, selectedServers: Constants.defaultEnabledTestnetServers, mode: .testnet))
             }
             //Animation breaks section headers. No idea why. So don't animate
             self.tableView.reloadData()

--- a/AlphaWallet/Settings/ViewModels/EnabledServersViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/EnabledServersViewModel.swift
@@ -24,16 +24,13 @@ struct EnabledServersViewModel {
     let selectedServers: [RPCServer]
     let mode: Mode
 
-    init(servers: [RPCServer], selectedServers: [RPCServer]) {
+    //Cannot infer `mode` from `selectedServers` because of this case: we are in testnet and tap to deselect all of them. Can't know to stay in testnet
+    init(servers: [RPCServer], selectedServers: [RPCServer], mode: Mode) {
         self.servers = servers
         self.selectedServers = selectedServers
         self.mainnets = servers.filter { !$0.isTestnet }
         self.testnets = servers.filter { $0.isTestnet }
-        if selectedServers.contains(where: { $0.isTestnet }) {
-            self.mode = .testnet
-        } else {
-            self.mode = .mainnet
-        }
+        self.mode = mode
     }
 
     var title: String {


### PR DESCRIPTION
Fixes #2898 