### PR TITLE
Set `ethereum.chainId` in dapp browser. Some dapps (e.g https://omni.xdaichain.com/bridge) expect it

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ target 'AlphaWallet' do
   pod 'JavaScriptKit'
   pod 'CryptoSwift', '~> 1.0'
   pod 'Kingfisher'
-  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => '308dbd3c7f70487b90aabdeef8641b7ad959c26f'
+  pod 'AlphaWalletWeb3Provider', :git=>'https://github.com/AlphaWallet/AlphaWallet-web3-provider', :commit => '459edbeef09cbd6e2f2e7960c8e9d4c18fb94bdb'
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/alpha-wallet/trust-keystore.git', :commit => 'c0bdc4f6ffc117b103e19d17b83109d4f5a0e764'
   pod 'SwiftyJSON'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
     - secp256k1_ios (~> 0.1.3)
 
 DEPENDENCIES:
-  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `308dbd3c7f70487b90aabdeef8641b7ad959c26f`)
+  - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `459edbeef09cbd6e2f2e7960c8e9d4c18fb94bdb`)
   - APIKit
   - AssistantKit
   - AWSSNS
@@ -192,7 +192,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
-    :commit: 308dbd3c7f70487b90aabdeef8641b7ad959c26f
+    :commit: 459edbeef09cbd6e2f2e7960c8e9d4c18fb94bdb
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Eureka:
     :commit: 5c54e2607632ce586010e50e91d9adcb6bb3909e
@@ -221,7 +221,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AlphaWalletWeb3Provider:
-    :commit: 308dbd3c7f70487b90aabdeef8641b7ad959c26f
+    :commit: 459edbeef09cbd6e2f2e7960c8e9d4c18fb94bdb
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
   Eureka:
     :commit: 5c54e2607632ce586010e50e91d9adcb6bb3909e
@@ -298,6 +298,6 @@ SPEC CHECKSUMS:
   WalletConnectSwift: cd5e056cec5a2f44e92b8595199e7f2f9f0bd92d
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
 
-PODFILE CHECKSUM: 601a92df23491b387081bdbc9ea9cc30a183523d
+PODFILE CHECKSUM: 77a6bf300940257e70d2eb02161d6977670faed5
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Fixes #2758 

Involves this PR: https://github.com/AlphaWallet/AlphaWallet-web3-provider/pull/19