### PR TITLE
Refactor, move remaining API keys in `Constants.swift` to `Constants+Credentials.swift`

### DIFF
--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -113,7 +113,7 @@ class OpenSea {
         Alamofire.request(
                 url,
                 method: .get,
-                headers: ["X-API-KEY": Constants.openseaAPIKEY]
+                headers: ["X-API-KEY": Constants.Credentials.openseaKey]
         ).responseJSON { response in
             guard let data = response.data, let json = try? JSON(data: data) else {
                 completion(.failure(AnyError(OpenSeaError(localizedDescription: "Error calling \(baseURL) API: \(String(describing: response.error))"))))

--- a/AlphaWallet/Settings/Types/Constants+Credentials.swift
+++ b/AlphaWallet/Settings/Types/Constants+Credentials.swift
@@ -10,5 +10,7 @@ extension Constants {
         static let paperTrail = (host: "", port: UInt(0))
         static let taiChiRPCKey = ""
         static let mailChimpListSpecificKey = ""
+        static let openseaKey = "11ba1b4f0c4246aeb07b1f8e5a20525f"
+        static let rampApiKey = "j5wr7oqktym7z69yyf84bb8a6cqb7qfu5ynmeyvn"
     }
 }

--- a/AlphaWallet/Settings/Types/Constants.swift
+++ b/AlphaWallet/Settings/Types/Constants.swift
@@ -81,17 +81,15 @@ public struct Constants {
     //OpenSea links for erc721 assets
     public static let openseaAPI = "https://api.opensea.io/"
     public static let openseaRinkebyAPI = "https://rinkeby-api.opensea.io/"
-    public static let openseaAPIKEY = "11ba1b4f0c4246aeb07b1f8e5a20525f" // X-API-KEY
     //Using "kat" instead of "cryptokitties" to avoid being mistakenly detected by app review as supporting CryptoKitties
     public static let katContractAddress = "0x06012c8cf97bead5deae237070f9587f8e7a266d"
 
     //xDai dapps
     static let xDaiBridge = URL(string: "https://bridge.xdaichain.com/")!
-    private static let rampApiKey = "j5wr7oqktym7z69yyf84bb8a6cqb7qfu5ynmeyvn"
-    static let buyXDaiWitRampUrl = "https://buy.ramp.network/?hostApiKey=\(rampApiKey)&hostLogoUrl=https%3A%2F%2Falphawallet.com%2Fwp-content%2Fthemes%2Falphawallet%2Fimg%2Falphawallet-logo.svg&hostAppName=AlphaWallet&swapAsset=xDai"
+    static let buyXDaiWitRampUrl = "https://buy.ramp.network/?hostApiKey=\(Constants.Credentials.rampApiKey)&hostLogoUrl=https%3A%2F%2Falphawallet.com%2Fwp-content%2Fthemes%2Falphawallet%2Fimg%2Falphawallet-logo.svg&hostAppName=AlphaWallet&swapAsset=xDai"
 
     static func buyWitRampUrl(asset: String) -> String {
-        "https://buy.ramp.network/?hostApiKey=\(rampApiKey)&hostLogoUrl=https%3A%2F%2Falphawallet.com%2Fwp-content%2Fthemes%2Falphawallet%2Fimg%2Falphawallet-logo.svg&hostAppName=AlphaWallet&swapAsset=\(asset)"
+        "https://buy.ramp.network/?hostApiKey=\(Constants.Credentials.rampApiKey)&hostLogoUrl=https%3A%2F%2Falphawallet.com%2Fwp-content%2Fthemes%2Falphawallet%2Fimg%2Falphawallet-logo.svg&hostAppName=AlphaWallet&swapAsset=\(asset)"
     }
 
     //ENS


### PR DESCRIPTION
And so we can swap those keys for production builds.