### PR TITLE
Refactor: move code that doesn't mutate state

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetContractInteractions.swift
@@ -5,9 +5,11 @@
 
 import Foundation
 import Alamofire
+import PromiseKit
 import SwiftyJSON
 
 class GetContractInteractions {
+    struct E: Error {}
 
     private let queue: DispatchQueue
 
@@ -15,144 +17,151 @@ class GetContractInteractions {
         self.queue = queue
     }
 
+    func getErc20Interactions(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil) -> Promise<[TransactionInstance]> {
+        functional.getErc20Interactions(address: address, server: server, startBlock: startBlock, queue: queue)
+    }
+
+    func getErc721Interactions(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil) -> Promise<[TransactionInstance]> {
+        functional.getErc721Interactions(address: address, server: server, startBlock: startBlock, queue: queue)
+    }
+
+    func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool) -> Promise<([AlphaWallet.Address], Int?)> {
+        functional.getContractList(address: address, server: server, startBlock: startBlock, erc20: erc20)
+    }
+}
+
+extension GetContractInteractions {
+    class functional {}
+}
+
+extension GetContractInteractions.functional {
     //TODO rename this since it might include ERC721 (blockscout and compatible like Polygon's). Or can we make this really fetch ERC20, maybe by filtering the results?
-    func getErc20Interactions(contractAddress: AlphaWallet.Address? = nil, address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) else { return }
+    static func getErc20Interactions(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, queue: DispatchQueue) -> Promise<[TransactionInstance]> {
+        guard let etherscanURL = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) else { return .value([]) }
+        return firstly {
+            Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [])
+        //TODO queue?
+        }.map(on: DispatchQueue.global()) { rawJson, _ in
+            guard let rawJson = rawJson as? [String: Any] else { throw GetContractInteractions.E() }
+            let json = JSON(rawJson)
 
-        Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
-            switch response.result {
-            case .success(let value):
-                //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
-                let json = JSON(value)
-                let filteredResult: [(String, JSON)]
-                if let contractAddress = contractAddress {
-                    //filter based on what contract you are after
-                    filteredResult = json["result"].filter {
-                        $0.1["contractAddress"].stringValue == contractAddress.eip55String.lowercased()
-                    }
-                } else {
-                    filteredResult = json["result"].filter {
-                        $0.1["to"].stringValue.hasPrefix("0x")
-                    }
-                }
-
-                let transactions: [TransactionInstance] = filteredResult.map { result in
-                    let transactionJson = result.1
-                    //Blockscout (and compatible like Polygon's) includes ERC721 transfers
-                    let operationType: OperationType
-                    //TODO check have tokenID + no "value", cos those might be ERC1155?
-                    if let tokenId = transactionJson["tokenID"].string, !tokenId.isEmpty {
-                        operationType = .erc721TokenTransfer
-                    } else {
-                        operationType = .erc20TokenTransfer
-                    }
-
-                    let localizedTokenObj = LocalizedOperationObjectInstance(
-                            from: transactionJson["from"].stringValue,
-                            to: transactionJson["to"].stringValue,
-                            contract: AlphaWallet.Address(uncheckedAgainstNullAddress: transactionJson["contractAddress"].stringValue),
-                            type: operationType.rawValue,
-                            value: transactionJson["value"].stringValue,
-                            tokenId: transactionJson["tokenID"].stringValue,
-                            symbol: transactionJson["tokenSymbol"].stringValue,
-                            name: transactionJson["tokenName"].stringValue,
-                            decimals: transactionJson["tokenDecimal"].intValue
-                    )
-
-                    return TransactionInstance(
-                            id: transactionJson["hash"].stringValue,
-                            server: server,
-                            blockNumber: transactionJson["blockNumber"].intValue,
-                            transactionIndex: transactionJson["transactionIndex"].intValue,
-                            from: transactionJson["from"].stringValue,
-                            to: transactionJson["to"].stringValue,
-                            //Must not set the value of the ERC20 token transferred as the native crypto value transferred
-                            value: "0",
-                            gas: transactionJson["gas"].stringValue,
-                            gasPrice: transactionJson["gasPrice"].stringValue,
-                            gasUsed: transactionJson["gasUsed"].stringValue,
-                            nonce: transactionJson["nonce"].stringValue,
-                            date: Date(timeIntervalSince1970: transactionJson["timeStamp"].doubleValue),
-                            localizedOperations: [localizedTokenObj],
-                            //The API only returns successful transactions
-                            state: .completed,
-                            isErc20Interaction: true
-                    )
-                }
-                let results = self.mergeTransactionOperationsIntoSingleTransaction(transactions)
-                completion(results)
-            case .failure:
-                completion([])
+            //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
+            let filteredResult: [(String, JSON)] = json["result"].filter {
+                $0.1["to"].stringValue.hasPrefix("0x")
             }
-        })
+
+            let transactions: [TransactionInstance] = filteredResult.map { result in
+                let transactionJson = result.1
+                //Blockscout (and compatible like Polygon's) includes ERC721 transfers
+                let operationType: OperationType
+                //TODO check have tokenID + no "value", cos those might be ERC1155?
+                if let tokenId = transactionJson["tokenID"].string, !tokenId.isEmpty {
+                    operationType = .erc721TokenTransfer
+                } else {
+                    operationType = .erc20TokenTransfer
+                }
+
+                let localizedTokenObj = LocalizedOperationObjectInstance(
+                        from: transactionJson["from"].stringValue,
+                        to: transactionJson["to"].stringValue,
+                        contract: AlphaWallet.Address(uncheckedAgainstNullAddress: transactionJson["contractAddress"].stringValue),
+                        type: operationType.rawValue,
+                        value: transactionJson["value"].stringValue,
+                        tokenId: transactionJson["tokenID"].stringValue,
+                        symbol: transactionJson["tokenSymbol"].stringValue,
+                        name: transactionJson["tokenName"].stringValue,
+                        decimals: transactionJson["tokenDecimal"].intValue
+                )
+
+                return TransactionInstance(
+                        id: transactionJson["hash"].stringValue,
+                        server: server,
+                        blockNumber: transactionJson["blockNumber"].intValue,
+                        transactionIndex: transactionJson["transactionIndex"].intValue,
+                        from: transactionJson["from"].stringValue,
+                        to: transactionJson["to"].stringValue,
+                        //Must not set the value of the ERC20 token transferred as the native crypto value transferred
+                        value: "0",
+                        gas: transactionJson["gas"].stringValue,
+                        gasPrice: transactionJson["gasPrice"].stringValue,
+                        gasUsed: transactionJson["gasUsed"].stringValue,
+                        nonce: transactionJson["nonce"].stringValue,
+                        date: Date(timeIntervalSince1970: transactionJson["timeStamp"].doubleValue),
+                        localizedOperations: [localizedTokenObj],
+                        //The API only returns successful transactions
+                        state: .completed,
+                        isErc20Interaction: true
+                )
+            }
+            return mergeTransactionOperationsIntoSingleTransaction(transactions)
+        }
     }
 
     //TODO Almost a duplicate of the the ERC20 version. De-dup maybe?
-    func getErc721Interactions(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, completion: @escaping ([TransactionInstance]) -> Void) {
-        guard let etherscanURL = server.getEtherscanURLForERC721TransactionHistory(for: address, startBlock: startBlock) else { return }
+    //TODO what's the point of passing in a queue here? Should be controlled by this class, not the user of this class
+    static func getErc721Interactions(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, queue: DispatchQueue) -> Promise<[TransactionInstance]> {
+        guard let etherscanURL = server.getEtherscanURLForERC721TransactionHistory(for: address, startBlock: startBlock) else { return .value([]) }
+        return firstly {
+            Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [])
+        //TODO queue?
+        }.map(on: DispatchQueue.global()) { rawJson, _ in
+            guard let rawJson = rawJson as? [String: Any] else { throw GetContractInteractions.E() }
+            let json = JSON(rawJson)
 
-        Alamofire.request(etherscanURL).validate().responseJSON(queue: queue, options: [], completionHandler: { response in
-            switch response.result {
-            case .success(let value):
-                //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
-                let json = JSON(value)
-                let filteredResult: [(String, JSON)] = json["result"].filter {
-                    $0.1["to"].stringValue.hasPrefix("0x")
-                }
-
-                let transactions: [TransactionInstance] = filteredResult.map { result in
-                    let transactionJson = result.1
-                    //Blockscout (and compatible like Polygon's) includes ERC721 transfers
-                    let operationType: OperationType
-                    //TODO check have tokenID + no "value", cos those might be ERC1155?
-                    if let tokenId = transactionJson["tokenID"].string, !tokenId.isEmpty {
-                        operationType = .erc721TokenTransfer
-                    } else {
-                        //TODO do we and do we need to filter these way since we only want ERC721?
-                        operationType = .erc20TokenTransfer
-                    }
-
-                    let localizedTokenObj = LocalizedOperationObjectInstance(
-                            from: transactionJson["from"].stringValue,
-                            to: transactionJson["to"].stringValue,
-                            contract: AlphaWallet.Address(uncheckedAgainstNullAddress: transactionJson["contractAddress"].stringValue),
-                            type: operationType.rawValue,
-                            value: transactionJson["value"].stringValue,
-                            tokenId: transactionJson["tokenID"].stringValue,
-                            symbol: transactionJson["tokenSymbol"].stringValue,
-                            name: transactionJson["tokenName"].stringValue,
-                            decimals: transactionJson["tokenDecimal"].intValue
-                    )
-
-                    return TransactionInstance(
-                            id: transactionJson["hash"].stringValue,
-                            server: server,
-                            blockNumber: transactionJson["blockNumber"].intValue,
-                            transactionIndex: transactionJson["transactionIndex"].intValue,
-                            from: transactionJson["from"].stringValue,
-                            to: transactionJson["to"].stringValue,
-                            //Must not set the value of the ERC20 token transferred as the native crypto value transferred
-                            value: "0",
-                            gas: transactionJson["gas"].stringValue,
-                            gasPrice: transactionJson["gasPrice"].stringValue,
-                            gasUsed: transactionJson["gasUsed"].stringValue,
-                            nonce: transactionJson["nonce"].stringValue,
-                            date: Date(timeIntervalSince1970: transactionJson["timeStamp"].doubleValue),
-                            localizedOperations: [localizedTokenObj],
-                            //The API only returns successful transactions
-                            state: .completed,
-                            isErc20Interaction: true
-                    )
-                }
-                let results = self.mergeTransactionOperationsIntoSingleTransaction(transactions)
-                completion(results)
-            case .failure:
-                completion([])
+            //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
+            let filteredResult: [(String, JSON)] = json["result"].filter {
+                $0.1["to"].stringValue.hasPrefix("0x")
             }
-        })
+
+            let transactions: [TransactionInstance] = filteredResult.map { result in
+                let transactionJson = result.1
+                //Blockscout (and compatible like Polygon's) includes ERC721 transfers
+                let operationType: OperationType
+                //TODO check have tokenID + no "value", cos those might be ERC1155?
+                if let tokenId = transactionJson["tokenID"].string, !tokenId.isEmpty {
+                    operationType = .erc721TokenTransfer
+                } else {
+                    //TODO do we and do we need to filter these way since we only want ERC721?
+                    operationType = .erc20TokenTransfer
+                }
+
+                let localizedTokenObj = LocalizedOperationObjectInstance(
+                        from: transactionJson["from"].stringValue,
+                        to: transactionJson["to"].stringValue,
+                        contract: AlphaWallet.Address(uncheckedAgainstNullAddress: transactionJson["contractAddress"].stringValue),
+                        type: operationType.rawValue,
+                        value: transactionJson["value"].stringValue,
+                        tokenId: transactionJson["tokenID"].stringValue,
+                        symbol: transactionJson["tokenSymbol"].stringValue,
+                        name: transactionJson["tokenName"].stringValue,
+                        decimals: transactionJson["tokenDecimal"].intValue
+                )
+
+                return TransactionInstance(
+                        id: transactionJson["hash"].stringValue,
+                        server: server,
+                        blockNumber: transactionJson["blockNumber"].intValue,
+                        transactionIndex: transactionJson["transactionIndex"].intValue,
+                        from: transactionJson["from"].stringValue,
+                        to: transactionJson["to"].stringValue,
+                        //Must not set the value of the ERC20 token transferred as the native crypto value transferred
+                        value: "0",
+                        gas: transactionJson["gas"].stringValue,
+                        gasPrice: transactionJson["gasPrice"].stringValue,
+                        gasUsed: transactionJson["gasUsed"].stringValue,
+                        nonce: transactionJson["nonce"].stringValue,
+                        date: Date(timeIntervalSince1970: transactionJson["timeStamp"].doubleValue),
+                        localizedOperations: [localizedTokenObj],
+                        //The API only returns successful transactions
+                        state: .completed,
+                        isErc20Interaction: true
+                )
+            }
+            return mergeTransactionOperationsIntoSingleTransaction(transactions)
+        }
     }
 
-    private func mergeTransactionOperationsIntoSingleTransaction(_ transactions: [TransactionInstance]) -> [TransactionInstance] {
+    static func mergeTransactionOperationsIntoSingleTransaction(_ transactions: [TransactionInstance]) -> [TransactionInstance] {
         var results: [TransactionInstance] = .init()
         for each in transactions {
             if let index = results.firstIndex(where: { $0.blockNumber == each.blockNumber }) {
@@ -166,53 +175,48 @@ class GetContractInteractions {
         return results
     }
 
-    func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool, completion: @escaping ([AlphaWallet.Address], Int?) -> Void) {
+    static func getContractList(address: AlphaWallet.Address, server: RPCServer, startBlock: Int? = nil, erc20: Bool) -> Promise<([AlphaWallet.Address], Int?)> {
         let etherscanURL: URL
         if erc20 {
             if let url = server.getEtherscanURLForTokenTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
-                return
+                return Promise(error: GetContractInteractions.E())
             }
         } else {
             if let url = server.getEtherscanURLForGeneralTransactionHistory(for: address, startBlock: startBlock) {
                 etherscanURL = url
             } else {
-                return
+                return Promise(error: GetContractInteractions.E())
             }
         }
-        Alamofire.request(etherscanURL).validate().responseJSON { response in
-            switch response.result {
-            case .success(let value):
-                //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
-                DispatchQueue.global().async {
-                    let json = JSON(value)
-                    let contracts: [(String, Int?)] = json["result"].map { _, transactionJson in
-                        let blockNumber = transactionJson["blockNumber"].string.flatMap { Int($0) }
-                        if transactionJson["input"] != "0x" {
-                            //every transaction that has input is by default a transaction to a contract
-                            //Note: etherscan API only returns contractAddress for this call
-                            //if it is an initialisation of a contract
-                            if transactionJson["contractAddress"].stringValue == "" {
-                                return (transactionJson["to"].stringValue, blockNumber)
-                            } else {
-                                return (transactionJson["contractAddress"].stringValue, blockNumber)
-                            }
-                        }
-                        return ("", blockNumber)
-                    }
-                    let nonEmptyContracts = contracts
-                            .map { $0.0 }
-                            .filter { !$0.isEmpty }
-                    let uniqueNonEmptyContracts = Set(nonEmptyContracts).compactMap { AlphaWallet.Address(uncheckedAgainstNullAddress: $0) }
-                    let maxBlockNumber = contracts.compactMap { $0.1 } .max()
-                    DispatchQueue.main.async {
-                        completion(uniqueNonEmptyContracts, maxBlockNumber)
+        return firstly {
+            Alamofire.request(etherscanURL).validate().responseJSON()
+        //TODO queue?
+        }.map(on: DispatchQueue.global()) { rawJson, _ in
+            guard let rawJson = rawJson as? [String: Any] else { throw GetContractInteractions.E() }
+            //Performance: process in background so UI don't have a chance of blocking if there's a long list of contracts
+            let json = JSON(rawJson)
+            let contracts: [(String, Int?)] = json["result"].map { _, transactionJson in
+                let blockNumber = transactionJson["blockNumber"].string.flatMap { Int($0) }
+                if transactionJson["input"] != "0x" {
+                    //every transaction that has input is by default a transaction to a contract
+                    //Note: etherscan API only returns contractAddress for this call
+                    //if it is an initialisation of a contract
+                    if transactionJson["contractAddress"].stringValue == "" {
+                        return (transactionJson["to"].stringValue, blockNumber)
+                    } else {
+                        return (transactionJson["contractAddress"].stringValue, blockNumber)
                     }
                 }
-            case .failure:
-                completion([], nil)
+                return ("", blockNumber)
             }
+            let nonEmptyContracts = contracts
+                    .map { $0.0 }
+                    .filter { !$0.isEmpty }
+            let uniqueNonEmptyContracts = Set(nonEmptyContracts).compactMap { AlphaWallet.Address(uncheckedAgainstNullAddress: $0) }
+            let maxBlockNumber = contracts.compactMap { $0.1 } .max()
+            return (uniqueNonEmptyContracts, maxBlockNumber)
         }
     }
 }


### PR DESCRIPTION
Also switching the affected code from completion blocks to PromiseKit. I think it makes clearer that [GetContractInteractions.swift](https://github.com/AlphaWallet/alpha-wallet-ios/compare/refactor-extract-out-functional-code-promisekit?expand=1#diff-5c0f118276d9837f1d1a72bd3dd3fbe44f946b696c33fd351431f677d7c71caf) doesn't mutate state, since the interface functions only call functional code (without having to change the callers to call the static functions directly. I'm hoping the functional interfaces are never/seldom exposed.)

Some parts like [this](https://github.com/AlphaWallet/alpha-wallet-ios/compare/refactor-extract-out-functional-code-promisekit?expand=1#diff-4902c50a135f139a6c1960fb7a536bfcba64af0a20777c986ea276b64a459e95R100) in `SingleChainTransactionEtherscanDataCoordinator` is clearer too, as we can see more clearly in the promise processing chain which parts don't mutate state [1].

Do you think it reads better?

Unfortunately, I have changed some of the flow/handling when switching from completion to PromiseKit, so I hope I didn't introduce any bugs.

[1] Like we mentioned earlier, it's not perfect because even if we "mark" code inside a `functional` inner-class, we can still pass in reference objects and modify them. So we'll just have to be disciplined with that.