### PR TITLE
Fix: Travis not running tests at all because R.generated.swift is not present in clean builds

### DIFF
--- a/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWallet.xcscheme
+++ b/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWallet.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "touch &quot;$SRCROOT/AlphaWallet/R.generated.swift&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2912CCF41F6A830700C6CBE3"
+                     BuildableName = "AlphaWallet.app"
+                     BlueprintName = "AlphaWallet"
+                     ReferencedContainer = "container:AlphaWallet.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWalletTests.xcscheme
+++ b/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWalletTests.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "touch &quot;$SRCROOT/AlphaWallet/R.generated.swift&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2912CD0A1F6A830700C6CBE3"
+                     BuildableName = "AlphaWalletTests.xctest"
+                     BlueprintName = "AlphaWalletTests"
+                     ReferencedContainer = "container:AlphaWallet.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
This PR adds a pre-build script to get rid of this error which causes tests not to run at all:

> ❌  error: Build input file cannot be found: '/Users/travis/build/AlphaWallet/alpha-wallet-ios/AlphaWallet/R.generated.swift' (in target 'AlphaWallet' from project 'AlphaWallet')