### PR TITLE
Fix: Polygon native token not showing price

### DIFF
--- a/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
@@ -44,7 +44,7 @@ class CoinTickersFetcher: CoinTickersFetcherType {
 
     private let pricesCacheLifetime: TimeInterval = 60 * 60
     private let dayChartHistoryCacheLifetime: TimeInterval = 60 * 60
-    private var isFetchingPrices = false 
+    private var isFetchingPrices = false
 
     private static let queue: DispatchQueue = DispatchQueue(label: "com.CoinTickersFetcher.updateQueue")
 
@@ -255,6 +255,9 @@ fileprivate struct Ticker: Codable {
         case platforms
     }
 
+    //https://polygonscan.com/address/0x0000000000000000000000000000000000001010
+    static private let polygonMaticContract = AlphaWallet.Address(string: "0x0000000000000000000000000000000000001010")!
+
     let id: String
     let symbol: String
     let name: String
@@ -277,6 +280,8 @@ fileprivate struct Ticker: Codable {
             if contract.sameContract(as: Constants.nullAddress) {
                 return symbol.localizedLowercase == tokenObject.symbol.localizedLowercase
             } else if contract.sameContract(as: tokenObject.contractAddress) {
+                return true
+            } else if tokenObject.server == .polygon && tokenObject.contractAddress == Constants.nativeCryptoAddressInDatabase && contract.sameContract(as: Self.polygonMaticContract) {
                 return true
             } else {
                 return false


### PR DESCRIPTION
Note that we cache the matched price data for 1 hour. So the effects of the PR is not visible immediately if the cache is warm.