### PR TITLE
Fix: detection of (non-zero) balance for NFTs, specifically ERC721

### DIFF
--- a/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/UniversalLinkCoordinator.swift
@@ -488,7 +488,7 @@ class UniversalLinkCoordinator: Coordinator {
         for i in 0..<indices.count {
             let token: String = balance[Int(indices[i])]
             //all of the indices provided should map to a valid non null token
-            if isZeroBalance(token) {
+            if isZeroBalance(token, tokenType: .erc875) {
                 //if null token at any index then the deal cannot happen
                 return [String]()
             }

--- a/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
@@ -146,7 +146,7 @@ extension NewTokenCoordinator: NewTokenViewControllerDelegate {
                 case .nonFungibleTokenComplete(let name, let symbol, let balance, let tokenType):
                     viewController.updateNameValue(name)
                     viewController.updateSymbolValue(symbol)
-                    viewController.updateBalanceValue(balance)
+                    viewController.updateBalanceValue(balance, tokenType: tokenType)
                     seal.fulfill(tokenType)
                 case .fungibleTokenComplete(let name, let symbol, let decimals):
                     viewController.updateNameValue(name)
@@ -170,8 +170,8 @@ extension NewTokenCoordinator: NewTokenViewControllerDelegate {
                 viewController.updateNameValue(name)
             case .symbol(let symbol):
                 viewController.updateSymbolValue(symbol)
-            case .balance(let balance):
-                viewController.updateBalanceValue(balance)
+            case .balance(let balance, let tokenType):
+                viewController.updateBalanceValue(balance, tokenType: tokenType)
             case .decimals(let decimals):
                 viewController.updateDecimalsValue(decimals)
             case .nonFungibleTokenComplete(_, _, _, let tokenType):

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -11,7 +11,7 @@ import Result
 enum ContractData {
     case name(String)
     case symbol(String)
-    case balance([String])
+    case balance(balance: [String], tokenType: TokenType)
     case decimals(UInt8)
     case nonFungibleTokenComplete(name: String, symbol: String, balance: [String], tokenType: TokenType)
     case fungibleTokenComplete(name: String, symbol: String, decimals: UInt8)
@@ -93,7 +93,7 @@ class SingleChainTokenCoordinator: Coordinator {
                 self?.autoDetectPartnerTokens()
             }
         }
-    } 
+    }
 
     func isServer(_ server: RPCServer) -> Bool {
         return session.server == server
@@ -760,7 +760,7 @@ func fetchContractDataFor(address: AlphaWallet.Address, storage: TokensDataStore
                 switch result {
                 case .success(let balance):
                     completedBalance = balance
-                    completion(.balance(balance))
+                    completion(.balance(balance: balance, tokenType: .erc875))
                     callCompletionOnAllData()
                 case .failure:
                     callCompletionFailed()
@@ -771,7 +771,7 @@ func fetchContractDataFor(address: AlphaWallet.Address, storage: TokensDataStore
                 switch result {
                 case .success(let balance):
                     completedBalance = balance
-                    completion(.balance(balance))
+                    completion(.balance(balance: balance, tokenType: .erc721))
                     callCompletionOnAllData()
                 case .failure:
                     callCompletionFailed()
@@ -782,7 +782,7 @@ func fetchContractDataFor(address: AlphaWallet.Address, storage: TokensDataStore
                 switch result {
                 case .success(let balance):
                     completedBalance = balance
-                    completion(.balance(balance))
+                    completion(.balance(balance: balance, tokenType: .erc721ForTickets))
                     callCompletionOnAllData()
                 case .failure:
                     callCompletionFailed()

--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -44,7 +44,7 @@ class TokenAdaptor {
             for (index, item) in balance.enumerated() {
                 //id is the value of the bytes32 token
                 let id = item.balance
-                guard isNonZeroBalance(id) else { continue }
+                guard isNonZeroBalance(id, tokenType: token.type) else { continue }
                 if let tokenInt = BigUInt(id.drop0x, radix: 16) {
                     let server = self.token.server
                     //TODO Event support, if/when designed, for non-OpenSea. Probably need `distinct` or something to that effect

--- a/AlphaWallet/Tokens/Types/TokenObject.swift
+++ b/AlphaWallet/Tokens/Types/TokenObject.swift
@@ -153,7 +153,7 @@ class TokenObject: Object {
     let balance = List<TokenBalance>()
 
     var nonZeroBalance: [TokenBalance] {
-        return Array(balance.filter { isNonZeroBalance($0.balance) })
+        return Array(balance.filter { isNonZeroBalance($0.balance, tokenType: self.type) })
     }
 
     var type: TokenType {
@@ -273,15 +273,21 @@ class TokenObject: Object {
     }
 }
 
-func isNonZeroBalance(_ balance: String) -> Bool {
-    return !isZeroBalance(balance)
+func isNonZeroBalance(_ balance: String, tokenType: TokenType) -> Bool {
+    return !isZeroBalance(balance, tokenType: tokenType)
 }
 
-func isZeroBalance(_ balance: String) -> Bool {
-    if balance == Constants.nullTokenId || balance == "0" {
-        return true
+func isZeroBalance(_ balance: String, tokenType: TokenType) -> Bool {
+    //We don't care about fungibles here, but want to make sure that *only* ERC875 balances consider string of "0" as null token, because we mark tokens that are burnt as 0, whereas ERC721 can have token ID = 0, eg. https://bscscan.com/tx/0xf6f3ddbb6719d8e47a47cf8ec66853682c02f03626cc4c4f5ece9338a8f20aee
+    switch tokenType {
+    case .nativeCryptocurrency, .erc20, .erc875:
+        if balance == Constants.nullTokenId || balance == "0" {
+            return true
+        }
+        return false
+    case .erc721, .erc721ForTickets:
+        return balance.isEmpty
     }
-    return false
 }
 
 func compositeTokenName(forContract contract: AlphaWallet.Address, fromContractName contractName: String, localizedNameFromAssetDefinition: String) -> String {

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -300,9 +300,9 @@ class NewTokenViewController: UIViewController {
     }
 
     //int is 64 bits, if this proves not enough later we can convert to BigUInt
-    public func updateBalanceValue(_ balance: [String]) {
+    public func updateBalanceValue(_ balance: [String], tokenType: TokenType) {
         //TODO this happens to work for CryptoKitty now because of how isNonZeroBalance() is implemented. But should fix
-        let filteredTokens = balance.filter { isNonZeroBalance($0) }
+        let filteredTokens = balance.filter { isNonZeroBalance($0, tokenType: tokenType) }
         viewModel.ERC875TokenBalance = filteredTokens
         balanceTextField.value = viewModel.ERC875TokenBalanceAmount.description
     }

--- a/AlphaWalletTests/Tokens/Helpers/TokenObjectTest.swift
+++ b/AlphaWalletTests/Tokens/Helpers/TokenObjectTest.swift
@@ -6,6 +6,6 @@ import Foundation
 
 class TokenObjectTest: XCTestCase {
     func testCheckNonZeroBalance() {
-        XCTAssertFalse(isNonZeroBalance(Constants.nullTokenId))
+        XCTAssertFalse(isNonZeroBalance(Constants.nullTokenId, tokenType: .erc875))
     }
 }


### PR DESCRIPTION
Part of #2972

ERC875 considered `0` as a nulled out token instance, be it burnt or transferred. But `0` is a valid ERC721 token ID. e.g. https://bscscan.com/tx/0xf6f3ddbb6719d8e47a47cf8ec66853682c02f03626cc4c4f5ece9338a8f20aee