### PR TITLE
Fix: OpenSea API doesn't allow limits that are too big to be passed to it anymore

### DIFF
--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -106,7 +106,7 @@ class OpenSea {
 
     private func fetchPage(forOwner owner: AlphaWallet.Address, offset: Int, sum: [AlphaWallet.Address: [OpenSeaNonFungible]] = [:], completion: @escaping (ResultResult<[AlphaWallet.Address: [OpenSeaNonFungible]], AnyError>.t) -> Void) {
         let baseURL = getBaseURLForOpensea()
-        guard let url = URL(string: "\(baseURL)api/v1/assets/?owner=\(owner.eip55String)&order_by=current_price&order_direction=asc&limit=200&offset=\(offset)") else {
+        guard let url = URL(string: "\(baseURL)api/v1/assets/?owner=\(owner.eip55String)&order_by=current_price&order_direction=asc&limit=50&offset=\(offset)") else {
             completion(.failure(AnyError(OpenSeaError(localizedDescription: "Error calling \(baseURL) API \(Thread.isMainThread)"))))
             return
         }


### PR DESCRIPTION
Before the PR, we passed `limit=200`. The API endpoint used to apply the max (`50`) it can take. It now error outs

After the PR, we send `limit=50` instead.