### PR TITLE
2985 improve backup screen

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -121,14 +121,14 @@
 "wallets.backupKeystoreWallet.introduction.description" = "A Keystore is a text file. You can copy its contents when you want to import your wallet. This is a safe way to back up a wallet.";
 "wallets.backupHdWallet.alertSheet.title" = "Show Seed Phrase";
 "wallets.backupHdWallet.introduction.button.title" = "Back up my Wallet";
-"wallets.backupHdWallet.introduction.title" = "Back up your Wallet with Seed Phrase";
+"wallets.backupHdWallet.introduction.title" = "Back up your Wallet\nwith Seed Phrase";
 "wallets.showSeedPhrase.introduction.button.title" = "Got it, show my seed phrase";
 "wallets.showSeedPhrase.introduction.title" = "Beware of scammers!\nDon’t share seed phrase.";
 "wallets.showSeedPhrase.introduction.subtitle" = "AlphaWallet will NEVER ask about your\nseed phrase (especially on Telegram).";
 "wallets.showSeedPhrase.subtitle2" = "Your seed phrase\n(do not share with anyone)";
 "wallets.showSeedPhrase.hideSeedPhrase" = "OK, hide my seed phrase";
 "wallets.showSeedPhrase.title" = "Your Seed Phrase";
-"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe: just write down 12 words and keep them in a secret place, offline.";
+"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe:\n just write down 12 words and\n keep them in a secret place, offline.";
 "wallets.showSeedPhrase.testSeedPhrase" = "OK, I wrote this down";
 "wallets.showSeedPhrase.doNotTakeScreenshotDescription" = "It's not a good idea to take a screenshot of your seed phrase";
 "wallets.verifySeedPhrase.title" = "Verify Seed Phrase";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -121,14 +121,14 @@
 "wallets.backupKeystoreWallet.introduction.description" = "Un almacén de claves es un archivo de texto. Puedes copiar su contenido cuando desees importar tu monedero. Se trata de una forma segura de hacer una copia de seguridad de un monedero.";
 "wallets.backupHdWallet.alertSheet.title" = "Mostrar frase semilla";
 "wallets.backupHdWallet.introduction.button.title" = "Hacer una copia de seguridad de mi monedero";
-"wallets.backupHdWallet.introduction.title" = "Haz una copia de seguridad de tu monedero con la frase semilla";
+"wallets.backupHdWallet.introduction.title" = "Haz una copia de seguridad de tu monedero\n con la frase semilla";
 "wallets.showSeedPhrase.introduction.button.title" = "Got it, show my seed phrase";
 "wallets.showSeedPhrase.introduction.title" = "Beware of scammers!\nDon’t share seed phrase.";
 "wallets.showSeedPhrase.introduction.subtitle" = "AlphaWallet will NEVER ask about your\nseed phrase (especially on Telegram).";
 "wallets.showSeedPhrase.subtitle2" = "Your seed phrase\n(do not share with anyone)";
 "wallets.showSeedPhrase.hideSeedPhrase" = "OK, hide my seed phrase";
 "wallets.showSeedPhrase.title" = "Tu frase semilla";
-"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe: just write down 12 words and keep them in a secret place, offline.";
+"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe:\n just write down 12 words and\n keep them in a secret place, offline.";
 "wallets.showSeedPhrase.testSeedPhrase" = "Vale, he escrito esto";
 "wallets.showSeedPhrase.doNotTakeScreenshotDescription" = "No es una buena idea hacer una captura de pantalla de la frase semilla";
 "wallets.verifySeedPhrase.title" = "Verificar la frase semilla";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -121,14 +121,14 @@
 "wallets.backupHdWallet.alertSheet.title" = "Show Seed Phrase";
 "settings.general.title" = "一般的な";
 "wallets.backupHdWallet.introduction.button.title" = "Back up my Wallet";
-"wallets.backupHdWallet.introduction.title" = "Back up your Wallet with Seed Phrase";
+"wallets.backupHdWallet.introduction.title" = "Back up your Wallet\n with Seed Phrase";
 "wallets.showSeedPhrase.introduction.button.title" = "Got it, show my seed phrase";
 "wallets.showSeedPhrase.introduction.title" = "Beware of scammers!\nDon’t share seed phrase.";
 "wallets.showSeedPhrase.introduction.subtitle" = "AlphaWallet will NEVER ask about your\nseed phrase (especially on Telegram).";
 "wallets.showSeedPhrase.subtitle2" = "Your seed phrase\n(do not share with anyone)";
 "wallets.showSeedPhrase.hideSeedPhrase" = "OK, hide my seed phrase";
 "wallets.showSeedPhrase.title" = "Your Seed Phrase";
-"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe: just write down 12 words and keep them in a secret place, offline.";
+"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe:\n just write down 12 words and\n keep them in a secret place, offline.";
 "wallets.showSeedPhrase.testSeedPhrase" = "OK, I wrote this down";
 "wallets.showSeedPhrase.doNotTakeScreenshotDescription" = "It's not a good idea to take a screenshot of your seed phrase";
 "wallets.verifySeedPhrase.title" = "Verify Seed Phrase";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -120,14 +120,14 @@
 "wallets.backupKeystoreWallet.introduction.description" = "A Keystore is a text file. You can copy its contents when you want to import your wallet. This is a safe way to back up a wallet.";
 "wallets.backupHdWallet.alertSheet.title" = "Show Seed Phrase";
 "wallets.backupHdWallet.introduction.button.title" = "Back up my Wallet";
-"wallets.backupHdWallet.introduction.title" = "Back up your Wallet with Seed Phrase";
+"wallets.backupHdWallet.introduction.title" = "Back up your Wallet\n with Seed Phrase";
 "wallets.showSeedPhrase.introduction.button.title" = "Got it, show my seed phrase";
 "wallets.showSeedPhrase.introduction.title" = "Beware of scammers!\nDon’t share seed phrase.";
 "wallets.showSeedPhrase.introduction.subtitle" = "AlphaWallet will NEVER ask about your\nseed phrase (especially on Telegram).";
 "wallets.showSeedPhrase.subtitle2" = "Your seed phrase\n(do not share with anyone)";
 "wallets.showSeedPhrase.hideSeedPhrase" = "OK, hide my seed phrase";
 "wallets.showSeedPhrase.title" = "Your Seed Phrase";
-"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe: just write down 12 words and keep them in a secret place, offline.";
+"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe:\n just write down 12 words and\n keep them in a secret place, offline.";
 "wallets.showSeedPhrase.testSeedPhrase" = "OK, I wrote this down";
 "wallets.showSeedPhrase.doNotTakeScreenshotDescription" = "It's not a good idea to take a screenshot of your seed phrase";
 "wallets.verifySeedPhrase.title" = "Verify Seed Phrase";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -128,7 +128,7 @@
 "wallets.showSeedPhrase.subtitle2" = "Your seed phrase\n(do not share with anyone)";
 "wallets.showSeedPhrase.hideSeedPhrase" = "OK, hide my seed phrase";
 "wallets.showSeedPhrase.title" = "您的助记词";
-"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe: just write down 12 words and keep them in a secret place, offline.";
+"wallets.showSeedPhrase.subtitle" = "Making backup is very simple and safe:\n just write down 12 words and\n keep them in a secret place, offline.";
 "wallets.showSeedPhrase.testSeedPhrase" = "好的，我记下来了";
 "wallets.showSeedPhrase.doNotTakeScreenshotDescription" = "切勿将助记词保存为屏幕截图";
 "wallets.verifySeedPhrase.title" = "验证助记词";

--- a/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
@@ -18,7 +18,7 @@ class SeedPhraseBackupIntroductionViewController: UIViewController {
     let buttonsBar = ButtonsBar(configuration: .green(buttons: 1))
 
     private var imageViewDimension: CGFloat {
-        return ScreenChecker.size(big: 250, medium: 180, small: 180)
+        return ScreenChecker.size(big: 250, medium: 250, small: 220)
     }
 
     weak var delegate: SeedPhraseBackupIntroductionViewControllerDelegate?
@@ -62,6 +62,20 @@ class SeedPhraseBackupIntroductionViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         return nil
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        navigationController?.navigationBar.shadowImage = UIImage()
+        navigationController?.navigationBar.layoutIfNeeded()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.setBackgroundImage(nil, for: .default)
+        navigationController?.navigationBar.shadowImage = nil
+        navigationController?.navigationBar.layoutIfNeeded()
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
Fixes https://github.com/AlphaWallet/alpha-wallet-ios/issues/2985

[x] kill the thin, top, gray line
[x] break down the text into
[x] Increase the picture size
[x] Make the text break accordingly
[ ] Move the bottom button a bit more to the top -> Remain out of scope because of dependency on other views.
