### PR TITLE
run the camera on no active walletConnect session #2987

### DIFF
--- a/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionsViewController.swift
+++ b/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionsViewController.swift
@@ -54,6 +54,11 @@ class WalletConnectSessionsViewController: UIViewController {
         view.addSubview(spinner)
 
         sessionsToURLServersMap.subscribe { [weak self] _ in
+            if self!.sessionsValue.isEmpty {
+                DispatchQueue.main.async {
+                    self?.qrCodeButtonSelected(nil)
+                }
+            }
             self?.tableView.reloadData()
         }
 
@@ -91,7 +96,7 @@ class WalletConnectSessionsViewController: UIViewController {
         }
     }
 
-    @objc private func qrCodeButtonSelected(_ sender: UIBarButtonItem) {
+    @objc private func qrCodeButtonSelected(_ sender: UIBarButtonItem?) {
         guard let delegate = self.delegate else { return }
 
         delegate.qrCodeSelected(in: self)


### PR DESCRIPTION
Fixes https://github.com/AlphaWallet/alpha-wallet-ios/issues/2987#event-5102425399
