### PR TITLE
Fix: remove duplicate ETH token for Optimistic mainnet and testnet — remove the native token when the ERC20 equivalent is in the database

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -283,6 +283,16 @@ enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    //Some chains like Optimistic have the native token share the same balance as a distinct ERC20 token. On such chains, we must not show both of them at the same time
+    var erc20AddressForNativeToken: AlphaWallet.Address? {
+        switch self {
+        case .optimistic, .optimisticKovan:
+            return AlphaWallet.Address(string: "0x4200000000000000000000000000000000000006")!
+        case .main, .ropsten, .rinkeby, .kovan, .goerli, .fantom, .heco, .heco_testnet, .binance_smart_chain, .binance_smart_chain_testnet, .polygon, .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .mumbai_testnet, .callisto, .cronosTestnet, .fantom_testnet, .avalanche, .avalanche_testnet, .custom:
+            return nil
+        }
+    }
+
     func getEtherscanURLForGeneralTransactionHistory(for address: AlphaWallet.Address, startBlock: Int?) -> URL? {
          etherscanURLForGeneralTransactionHistory.flatMap {
              let apiKeyParameter: String

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -118,9 +118,14 @@ class TokensDataStore {
 
     //TODO might be good to change `enabledObject` to just return the streaming list from Realm instead of a Swift native Array and other properties/callers can convert to Array if necessary
     var enabledObject: [TokenObject] {
-        return Array(realm.threadSafe.objects(TokenObject.self)
+        let result = Array(realm.threadSafe.objects(TokenObject.self)
                 .filter("chainId = \(self.chainId)")
                 .filter("isDisabled = false"))
+        if let erc20AddressForNativeToken = server.erc20AddressForNativeToken, result.contains(where: { $0.contractAddress.sameContract(as: erc20AddressForNativeToken) }) {
+            return result.filter { !$0.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) }
+        } else {
+            return result
+        }
     }
 
     var deletedContracts: [DeletedContract] {


### PR DESCRIPTION
Part of #2979 

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/128137687-1a627621-db23-488a-9875-e7c7b33f3cb5.png'>|<img width='200' src='https://user-images.githubusercontent.com/56189/128137695-c715f79e-9772-441d-8713-9483e2dc19bd.png'>
