### PR TITLE
Fix: when auto-detected icons show up on the screen the first time in the Wallet tab (and cells are re-used), the token image shown might be wrong, from another token

### DIFF
--- a/AlphaWallet/UI/TokenImageView.swift
+++ b/AlphaWallet/UI/TokenImageView.swift
@@ -25,6 +25,7 @@ class TokenImageView: UIView {
             }
 
             if let subscribable = subscribable {
+                imageView.image = nil
                 subscriptionKey = subscribable.subscribe { [weak self] imageAndSymbol  in
                     guard let strongSelf = self else { return }
                     strongSelf.imageView.image = imageAndSymbol?.image


### PR DESCRIPTION
Basically, image is not cleared upon cell re-use

eg. API3 in screenshot is showing the wrong icon:

<img width="460" alt="Screenshot 2021-08-05 at 3 07 18 PM" src="https://user-images.githubusercontent.com/56189/128313718-d106be6a-3a0c-442f-8f89-e47e94853b6e.png">
