### PR TITLE
Fix: "Add token failure" error when tap to add popular tokens in Add/Hide token screen

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/AddHideTokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/AddHideTokensCoordinator.swift
@@ -52,7 +52,9 @@ class AddHideTokensCoordinator: Coordinator {
         navigationController.pushViewController(viewController, animated: true)
 
         popularTokensCollection.fetchTokens().done { [weak self] tokens in
-            self?.viewController.set(popularTokens: tokens)
+            guard let strongSelf = self else { return }
+            let tokensForEnabledChains = tokens.filter { each in strongSelf.config.enabledServers.contains(each.server) }
+            self?.viewController.set(popularTokens: tokensForEnabledChains)
         }.cauterize()
     }
 


### PR DESCRIPTION
Fixes #3045 

Problem is the popular token list needs to be filtered for enabled chains.