### PR TITLE
Kill the thin grey line between Navigation bar and the segmented controls in token view #3085

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -102,6 +102,16 @@ class TokenViewController: UIViewController {
         configure(viewModel: viewModel)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        hideNavigationBarTopSeparatorLine()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        showNavigationBarTopSeparatorLine()
+    }
+
     func configure(viewModel: TokenViewControllerViewModel) {
         self.viewModel = viewModel
 


### PR DESCRIPTION
Closes #3085