### PR TITLE
Modify internal flow for ERC1155 detection and balance refresh to be clearer and more maintainable

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		5E7C7233A9A5F9D1A89FF569 /* TokensViewControllerTableViewSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7FB7C3FB2A9CC0CC51D7 /* TokensViewControllerTableViewSectionHeader.swift */; };
 		5E7C72402E57B627B6E56934 /* TokenInstanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75506A766DF9B746E62F /* TokenInstanceViewModel.swift */; };
 		5E7C724638271FD2FA0EB93C /* BaseTokenListFormatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C734D61C0347C1638A1F7 /* BaseTokenListFormatTableViewCell.swift */; };
+		5E7C72647EAE29158D103377 /* Erc1155TokenIdsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73553968E56A08D90D0C /* Erc1155TokenIdsFetcher.swift */; };
 		5E7C72670E16AFB8DAF64673 /* OnboardingPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E24936CC2190D2A16C2 /* OnboardingPageViewModel.swift */; };
 		5E7C726DE238609C1FB2E320 /* Constants+Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73883FBA3C4BAF889E97 /* Constants+Credentials.swift */; };
 		5E7C7270EA33CF6A99701454 /* GetWalletNameCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C769E7A78811BDF9463A3 /* GetWalletNameCoordinator.swift */; };
@@ -302,6 +303,7 @@
 		5E7C72CF145240C816BB12E2 /* DappsHomeViewControllerHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7375430F36C549EA8748 /* DappsHomeViewControllerHeaderViewViewModel.swift */; };
 		5E7C72D6C4AB97A1FCB3AA32 /* MnemonicInWordListRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78A964BD5AA02D0D9344 /* MnemonicInWordListRule.swift */; };
 		5E7C72E1D4B4B4C8443F3DA1 /* SendHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7828BD821B6F04B71C00 /* SendHeaderView.swift */; };
+		5E7C72EA10F863FCD7EED282 /* Erc1155BalanceFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7DA36F3F01AE7DDE4BC6 /* Erc1155BalanceFetcher.swift */; };
 		5E7C72EECA8154CEB7D9F46C /* ContainerViewWithShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C728B3CA6A429AB5EE5DF /* ContainerViewWithShadow.swift */; };
 		5E7C72EF748338DDBABB53F2 /* GetBlockTimestampCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75BCE63C31EC8ED403A7 /* GetBlockTimestampCoordinator.swift */; };
 		5E7C7307F0253556A6BC57A9 /* AlphaWalletAddressExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7EE6BFC8BB79CD1C5565 /* AlphaWalletAddressExtension.swift */; };
@@ -615,7 +617,6 @@
 		5E7C7EF1F2CDFA52BBF1C620 /* BrowserHistoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C712F42374C0B8DF8C64F /* BrowserHistoryCellViewModel.swift */; };
 		5E7C7F01A771565A1BCF7FFA /* SeedPhraseCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C77BCBD2C2BE682D384DB /* SeedPhraseCollectionView.swift */; };
 		5E7C7F1623D246AD32378D29 /* PromptBackupWalletViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C796C7DEA3C2A70861828 /* PromptBackupWalletViewViewModel.swift */; };
-		5E7C7F173802073A6CB79813 /* Erc1155TokenIdsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CE6CBCB68739F466132 /* Erc1155TokenIdsFetcher.swift */; };
 		5E7C7F1B297CE042114EF095 /* LockEnterPasscodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75CBBFF0273EF476F95B /* LockEnterPasscodeViewController.swift */; };
 		5E7C7F2284231870623C5605 /* TokenScriptCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79C0C9631E4DFC4A40DF /* TokenScriptCard.swift */; };
 		5E7C7F3CB1F280E6795A479C /* EventOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C740BBC5AAF5C545CCC6A /* EventOrigin.swift */; };
@@ -1272,6 +1273,7 @@
 		5E7C7324C9AC776E3A7B43D1 /* MyDappCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyDappCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7346D83DE2DB22E28F16 /* ShowSeedPhraseViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowSeedPhraseViewModel.swift; sourceTree = "<group>"; };
 		5E7C734D61C0347C1638A1F7 /* BaseTokenListFormatTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTokenListFormatTableViewCell.swift; sourceTree = "<group>"; };
+		5E7C73553968E56A08D90D0C /* Erc1155TokenIdsFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Erc1155TokenIdsFetcher.swift; sourceTree = "<group>"; };
 		5E7C7365D14169D22AE1D20A /* TransactionRowCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionRowCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7375430F36C549EA8748 /* DappsHomeViewControllerHeaderViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsHomeViewControllerHeaderViewViewModel.swift; sourceTree = "<group>"; };
 		5E7C737CC822F8143DE1FDC0 /* EventActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventActivity.swift; sourceTree = "<group>"; };
@@ -1541,7 +1543,6 @@
 		5E7C7CD1FB7D353704EF3389 /* DateEntryField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DateEntryField.swift; path = Views/DateEntryField.swift; sourceTree = "<group>"; };
 		5E7C7CD7ABB18C1121D5776F /* LiveLocaleSwitcherBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveLocaleSwitcherBundle.swift; sourceTree = "<group>"; };
 		5E7C7CDB0BAD5D27D2F24F57 /* ServerViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerViewCell.swift; sourceTree = "<group>"; };
-		5E7C7CE6CBCB68739F466132 /* Erc1155TokenIdsFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Erc1155TokenIdsFetcher.swift; sourceTree = "<group>"; };
 		5E7C7CE6E3560E773D2287E2 /* ElevateWalletSecurityCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElevateWalletSecurityCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7CF1465A1DCB44371BA9 /* ConsoleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsoleViewController.swift; sourceTree = "<group>"; };
 		5E7C7CFDE7DEA8C06C4100AF /* TextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
@@ -1566,6 +1567,7 @@
 		5E7C7D8D618A8A8D55479CDF /* Dapp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dapp.swift; sourceTree = "<group>"; };
 		5E7C7D913DAA3322F1C7DD46 /* OpenSeaNonFungibleTokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenSeaNonFungibleTokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7D931F68BFB5E1DCE001 /* TokenCardRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TokenCardRowView.swift; path = Views/TokenCardRowView.swift; sourceTree = "<group>"; };
+		5E7C7DA36F3F01AE7DDE4BC6 /* Erc1155BalanceFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Erc1155BalanceFetcher.swift; sourceTree = "<group>"; };
 		5E7C7DA5F3C065F96CCB34B4 /* EthChainIdRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EthChainIdRequest.swift; sourceTree = "<group>"; };
 		5E7C7DAFCCF74F40D144CB0E /* GetNextNonce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetNextNonce.swift; sourceTree = "<group>"; };
 		5E7C7DC3AEBE4049927B7625 /* EnableServersHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnableServersHeaderView.swift; sourceTree = "<group>"; };
@@ -3778,7 +3780,8 @@
 			isa = PBXGroup;
 			children = (
 				5E7C7F9030DA27EF7C3FBDEB /* ContractDataDetector.swift */,
-				5E7C7CE6CBCB68739F466132 /* Erc1155TokenIdsFetcher.swift */,
+				5E7C7DA36F3F01AE7DDE4BC6 /* Erc1155BalanceFetcher.swift */,
+				5E7C73553968E56A08D90D0C /* Erc1155TokenIdsFetcher.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -5945,7 +5948,8 @@
 				5E7C7DE51E4829295CABDC21 /* ContractDataDetector.swift in Sources */,
 				5E7C7883FB31565411F7C928 /* NonFungibleFromJsonTokenType.swift in Sources */,
 				5E7C74D15D658E785D44CBB6 /* GetIsERC1155ContractCoordinator.swift in Sources */,
-				5E7C7F173802073A6CB79813 /* Erc1155TokenIdsFetcher.swift in Sources */,
+				5E7C72EA10F863FCD7EED282 /* Erc1155BalanceFetcher.swift in Sources */,
+				5E7C72647EAE29158D103377 /* Erc1155TokenIdsFetcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -2,6 +2,8 @@
 import UIKit
 import AWSSNS
 import AWSCore
+import PromiseKit
+
 import UserNotifications
 
 @UIApplicationMain

--- a/AlphaWallet/Core/Ethereum/ABI/ERC1155.json
+++ b/AlphaWallet/Core/Ethereum/ABI/ERC1155.json
@@ -63,5 +63,27 @@
     ],
     "type" : "event",
     "anonymous" : false
+  },
+
+  {
+    "name" : "balanceOfBatch",
+    "constant": true,
+    "type" : "function",
+    "inputs" : [
+      {
+        "type" : "address[]",
+        "name" : "_owners"
+      },
+      {
+        "type" : "uint256[]",
+        "name" : "_ids"
+      },
+    ],
+    "outputs" : [
+      {
+        "type" : "uint256[]",
+        "name" : ""
+      }
+    ]
   }
 ]

--- a/AlphaWallet/EtherClient/OpenSea.swift
+++ b/AlphaWallet/EtherClient/OpenSea.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import Alamofire
+import BigInt
 import PromiseKit
 import Result
 import SwiftyJSON
@@ -134,6 +135,14 @@ class OpenSea {
                 let contractName = each["asset_contract"]["name"].stringValue
                 //So if it's null in OpenSea, we get a 0, as expected. And 0 works for ERC721 too
                 let decimals = each["decimals"].intValue
+                let value: BigInt
+                switch tokenType {
+                case .erc721:
+                    value = 1
+                case .erc1155:
+                    //OpenSea API doesn't include value for ERC1155, so we'll have to batch fetch it later for each contract
+                    value = 0
+                }
                 let symbol = each["asset_contract"]["symbol"].stringValue
                 let name = each["name"].stringValue
                 let description = each["description"].stringValue
@@ -155,7 +164,7 @@ class OpenSea {
                     traits.append(trait)
                 }
                 if let contract = AlphaWallet.Address(string: each["asset_contract"]["address"].stringValue) {
-                    let cat = OpenSeaNonFungible(tokenId: tokenId, tokenType: tokenType, contractName: contractName, decimals: decimals, symbol: symbol, name: name, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, contractImageUrl: contractImageUrl, externalLink: externalLink, backgroundColor: backgroundColor, traits: traits)
+                    let cat = OpenSeaNonFungible(tokenId: tokenId, tokenType: tokenType, value: value, contractName: contractName, decimals: decimals, symbol: symbol, name: name, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, contractImageUrl: contractImageUrl, externalLink: externalLink, backgroundColor: backgroundColor, traits: traits)
                     if var list = results[contract] {
                         list.append(cat)
                         results[contract] = list

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -225,7 +225,7 @@ extension TokensCoordinator: TokensViewControllerDelegate {
         case .erc875, .erc721ForTickets:
             coordinator.showTokenList(for: .send(type: .ERC875Token(token)), token: token, navigationController: navigationController)
         case .erc1155:
-            coordinator.showTokenList(for: .send(type: .ERC721Token(token)), token: token, navigationController: navigationController)
+            coordinator.showTokenList(for: .send(type: .ERC1155Token(token)), token: token, navigationController: navigationController)
         }
     }
 

--- a/AlphaWallet/Tokens/Logic/Erc1155BalanceFetcher.swift
+++ b/AlphaWallet/Tokens/Logic/Erc1155BalanceFetcher.swift
@@ -1,0 +1,39 @@
+// Copyright © 2021 Stormbird PTE. LTD.
+
+import Foundation
+import BigInt
+import Result
+import PromiseKit
+import web3swift
+
+///Fetching ERC1155 tokens in 2 steps:
+///
+///A. Fetch known contracts and tokenIds owned (now or previously) for each, writing them to JSON. tokenIds are never removed (so we can easily discover their balance is 0 in the next step)
+///B. Fetch balance for each tokenId owned (now or previously. For the latter value would be 0)
+///
+///This class performs (B)
+class Erc1155BalanceFetcher {
+    private let address: AlphaWallet.Address
+    private let server: RPCServer
+
+    init(address: AlphaWallet.Address, server: RPCServer) {
+        self.address = address
+        self.server = server
+    }
+
+    func fetch(contract: AlphaWallet.Address, tokenIds: Set<BigInt>) -> Promise<[BigInt: BigUInt]> {
+        //tokenIds must be unique (hence arg is a Set) so `Dictionary(uniqueKeysWithValues:)` wouldn't crash
+        let tokenIds = Array(tokenIds)
+        let address = EthereumAddress(address.eip55String)!
+        let addresses: [EthereumAddress] = Array<EthereumAddress>(repeating: address, count: tokenIds.count)
+        return firstly {
+            callSmartContract(withServer: server, contract: contract, functionName: "balanceOfBatch", abiString: AlphaWallet.Ethereum.ABI.erc1155String, parameters: [addresses, tokenIds] as [AnyObject], timeout: TokensDataStore.fetchContractDataTimeout)
+        }.map { result in
+            if let balances = result["0"] as? [BigUInt], balances.count == tokenIds.count {
+                return Dictionary(uniqueKeysWithValues: zip(tokenIds, balances))
+            } else {
+                throw AnyError(ABIError.invalidArgumentType)
+            }
+        }
+    }
+}

--- a/AlphaWallet/Tokens/Logic/Erc1155TokenIdsFetcher.swift
+++ b/AlphaWallet/Tokens/Logic/Erc1155TokenIdsFetcher.swift
@@ -6,9 +6,9 @@ import PromiseKit
 import web3swift
 
 struct Erc1155TokenIds: Codable {
-    typealias ContractsTokenIdsAndValues = [AlphaWallet.Address: [BigUInt: BigInt]]
+    typealias ContractsAndTokenIds = [AlphaWallet.Address: Set<BigUInt>]
 
-    let tokens: ContractsTokenIdsAndValues
+    let tokens: ContractsAndTokenIds
     let lastBlockNumber: BigUInt
 }
 
@@ -40,6 +40,12 @@ fileprivate struct Erc1155TransferEvent: Comparable {
     }
 }
 
+///Fetching ERC1155 tokens in 2 steps:
+///
+///A. Fetch known contracts and tokenIds owned (now or previously) for each, writing them to JSON. tokenIds are never removed (so we can easily discover their balance is 0 in the next step)
+///B. Fetch balance for each tokenId owned (now or previously. For the latter value would be 0)
+///
+///This class performs (A)
 class Erc1155TokenIdsFetcher {
     static let documentDirectory = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]).appendingPathComponent("erc1155TokenIds")
 
@@ -52,17 +58,12 @@ class Erc1155TokenIdsFetcher {
         try? FileManager.default.createDirectory(at: Self.documentDirectory, withIntermediateDirectories: true)
     }
 
-    func refreshBalance() -> Promise<Void> {
-        let fromBlockNumber: BigUInt
-        let old: Erc1155TokenIds
-        if let lastFetched: Erc1155TokenIds = readJson() {
-            old = lastFetched
-        } else {
-            //Should really be -1 instead 0, but so we don't fight with the type system (negative) and doesn't matter in practice being off by 1 at the start
-            old = .init(tokens: .init(), lastBlockNumber: 0)
-        }
-        fromBlockNumber = old.lastBlockNumber + 1
-
+    func detectContractsAndTokenIds() -> Promise<Erc1155TokenIds> {
+        let address = address
+        let server = server
+        //Should really be -1 instead 0, but so we don't fight with the type system (negative) and doesn't matter in practice being off by 1 at the start
+        let fromPreviousRead: Erc1155TokenIds = readJson() ?? .init(tokens: .init(), lastBlockNumber: 0)
+        let fromBlockNumber = fromPreviousRead.lastBlockNumber + 1
         let toBlock: EventFilter.Block
         if server == .binance_smart_chain || server == .binance_smart_chain_testnet || server == .heco {
             //NOTE: binance_smart_chain does not allow range more than 5000
@@ -83,30 +84,16 @@ class Erc1155TokenIdsFetcher {
                 let lastBlockNumber = BigUInt(num)
                 return Erc1155TokenIds(tokens: tokens, lastBlockNumber: lastBlockNumber)
             }
-        }.get {
-            let tokens = $0.tokens
-        }.map { delta in
-            let updatedTokens = self.computeUpdatedBalance(fromOld: old.tokens, delta: delta.tokens)
-            return Erc1155TokenIds(tokens: updatedTokens, lastBlockNumber: delta.lastBlockNumber)
-        }.then {
-            self.writeJson(contractsTokenIdsAndValue: $0)
+        }.then { deltaSinceLastCheck -> Promise<Erc1155TokenIds> in
+            let updatedTokens = functional.computeUpdatedTokenIds(fromPreviousRead: fromPreviousRead.tokens, deltaSinceLastCheck: deltaSinceLastCheck.tokens)
+            let contractsAndTokenIds = Erc1155TokenIds(tokens: updatedTokens, lastBlockNumber: deltaSinceLastCheck.lastBlockNumber)
+            return self.writeJson(contractsAndTokenIds: contractsAndTokenIds).map { contractsAndTokenIds }
         }
     }
 
-    private func computeUpdatedBalance(fromOld old: Erc1155TokenIds.ContractsTokenIdsAndValues, delta: Erc1155TokenIds.ContractsTokenIdsAndValues) -> Erc1155TokenIds.ContractsTokenIdsAndValues {
-        var updatedTokens: Erc1155TokenIds.ContractsTokenIdsAndValues = old
-        for (contract, deltaTokenIdsAndValue) in delta {
-            if var updateTokenIdsAndValue = updatedTokens[contract] {
-                for (tokenId, deltaValue) in deltaTokenIdsAndValue {
-                    let oldValue = updateTokenIdsAndValue[tokenId] ?? 0
-                    updateTokenIdsAndValue[tokenId] = oldValue + deltaValue
-                }
-                updatedTokens[contract] = updateTokenIdsAndValue
-            } else {
-                updatedTokens[contract] = deltaTokenIdsAndValue
-            }
-        }
-        return updatedTokens
+    func knownErc1155Contracts() -> Set<AlphaWallet.Address>? {
+        guard let contractsAndTokenIds = readJson() else { return nil }
+        return Set(contractsAndTokenIds.tokens.keys)
     }
 
     //MARK: Serialization
@@ -115,14 +102,14 @@ class Erc1155TokenIdsFetcher {
         return documentDirectory.appendingPathComponent("\(address.eip55String)-\(server.chainID).json")
     }
 
-    func readJson() -> Erc1155TokenIds? {
+    private func readJson() -> Erc1155TokenIds? {
         guard let data = try? Data(contentsOf: Self.fileUrl(forWallet: address, server: server)) else { return nil }
         return try? JSONDecoder().decode(Erc1155TokenIds.self, from: data)
     }
 
-    private func writeJson(contractsTokenIdsAndValue: Erc1155TokenIds) -> Promise<Void> {
+    private func writeJson(contractsAndTokenIds: Erc1155TokenIds) -> Promise<Void> {
         Promise { seal in
-            if let data = try? JSONEncoder().encode(contractsTokenIdsAndValue) {
+            if let data = try? JSONEncoder().encode(contractsAndTokenIds) {
                 do {
                     try data.write(to: Self.fileUrl(forWallet: address, server: server), options: .atomicWrite)
                     seal.fulfill(())
@@ -154,43 +141,36 @@ extension Erc1155TokenIdsFetcher.functional {
         let nullFilter: [EventFilterable]? = nil
         let singleTransferEventName = "TransferSingle"
         let batchTransferEventName = "TransferBatch"
-
         let sendParameterFilters: [[EventFilterable]?] = [nullFilter, [recipientAddress], nullFilter]
         let receiveParameterFilters: [[EventFilterable]?] = [nullFilter, nullFilter, [recipientAddress]]
-        let sendSinglePromise = firstly {
-            fetchEvents(server: server, transferType: .send, eventName: singleTransferEventName, parameterFilters: sendParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
-        }
-        let receiveSinglePromise = firstly {
-            fetchEvents(server: server, transferType: .receive, eventName: singleTransferEventName, parameterFilters: receiveParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
-        }
-
-        let sendBulkPromise = firstly {
-            fetchEvents(server: server, transferType: .send, eventName: batchTransferEventName, parameterFilters: sendParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
-        }
-        let receiveBulkPromise = firstly {
-            fetchEvents(server: server, transferType: .receive, eventName: batchTransferEventName, parameterFilters: receiveParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
-        }
+        let sendSinglePromise = fetchEvents(server: server, transferType: .send, eventName: singleTransferEventName, parameterFilters: sendParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
+        let receiveSinglePromise = fetchEvents(server: server, transferType: .receive, eventName: singleTransferEventName, parameterFilters: receiveParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
+        let sendBulkPromise = fetchEvents(server: server, transferType: .send, eventName: batchTransferEventName, parameterFilters: sendParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
+        let receiveBulkPromise = fetchEvents(server: server, transferType: .receive, eventName: batchTransferEventName, parameterFilters: receiveParameterFilters, fromBlock: fromBlock, toBlock: toBlock)
         return firstly {
             when(fulfilled: sendSinglePromise, receiveSinglePromise, sendBulkPromise, receiveBulkPromise)
         }.map { a, b, c, d -> Erc1155TokenIds in
             let all: [Erc1155TransferEvent] = (a + b + c + d).sorted()
-            var contractsTokenIdsAndValue: Erc1155TokenIds.ContractsTokenIdsAndValues = .init()
-            for each in all {
-                let tokenId = each.tokenId
-                let value = BigInt(each.value)
-                var tokenIdsAndValue = contractsTokenIdsAndValue[each.contract] ?? .init()
-                let oldValue = tokenIdsAndValue[tokenId] ?? 0
-                switch each.transferType {
-                case .send:
-                    //We need to track negatives even if old value is 0 because we are computing the deltas since the last fetch
-                    tokenIdsAndValue[tokenId] = oldValue - value
-                case .receive:
-                    tokenIdsAndValue[tokenId] = oldValue + value
-                }
-                contractsTokenIdsAndValue[each.contract] = tokenIdsAndValue
+            let contractsAndTokenIds: Erc1155TokenIds.ContractsAndTokenIds = all.reduce(Erc1155TokenIds.ContractsAndTokenIds()) { result, each in
+                var result = result
+                var tokenIds = result[each.contract] ?? .init()
+                tokenIds.insert(each.tokenId)
+                result[each.contract] = tokenIds
+                return result
             }
-            let biggestBlockNumber: BigUInt = all.last?.blockNumber ?? 0
-            return Erc1155TokenIds(tokens: contractsTokenIdsAndValue, lastBlockNumber: biggestBlockNumber)
+            let biggestBlockNumber: BigUInt
+            if let blockNumber = all.last?.blockNumber {
+                biggestBlockNumber = blockNumber
+            } else {
+                switch fromBlock {
+                case .latest, .pending:
+                    //TODO should set to the latest blockNumber on the blockchain instead
+                    biggestBlockNumber = 0
+                case .blockNumber(let blockNumber):
+                    biggestBlockNumber = BigUInt(blockNumber)
+                }
+            }
+            return Erc1155TokenIds(tokens: contractsAndTokenIds, lastBlockNumber: biggestBlockNumber)
         }
     }
 
@@ -198,13 +178,10 @@ extension Erc1155TokenIdsFetcher.functional {
         Promise { seal in
             //We just need any contract for the Swift API to get events, it's not actually used
             let dummyContract = Constants.nullAddress
-
-            let queue: DispatchQueue = .main
-
             let eventFilter = EventFilter(fromBlock: fromBlock, toBlock: toBlock, addresses: nil, parameterFilters: parameterFilters)
             firstly {
-                getEventLogs(withServer: server, contract: dummyContract, eventName: eventName, abiString: AlphaWallet.Ethereum.ABI.erc1155String, filter: eventFilter, queue: queue)
-            }.done(on: queue, { events in
+                getEventLogs(withServer: server, contract: dummyContract, eventName: eventName, abiString: AlphaWallet.Ethereum.ABI.erc1155String, filter: eventFilter, queue: .main)
+            }.done { events in
                 let events = events.filter { $0.eventLog != nil }
                 let sortedEvents = events.sorted(by: { a, b in
                     if a.eventLog!.blockNumber == b.eventLog!.blockNumber {
@@ -234,9 +211,22 @@ extension Erc1155TokenIdsFetcher.functional {
                     }
                 }
                 seal.fulfill(results)
-            }).catch { error in
-                //TODO should log remotely
+            }.catch { error in
+                //TODO log error
             }
         }
+    }
+
+    //Even if a tokenId now has a balance/value of 0, it will be included in the results
+    static func computeUpdatedTokenIds(fromPreviousRead old: Erc1155TokenIds.ContractsAndTokenIds, deltaSinceLastCheck delta: Erc1155TokenIds.ContractsAndTokenIds) -> Erc1155TokenIds.ContractsAndTokenIds {
+        var updatedTokenIds: Erc1155TokenIds.ContractsAndTokenIds = old
+        for (contract, newTokenIds) in delta {
+            if let tokenIds = updatedTokenIds[contract] {
+                updatedTokenIds[contract] = Set(Array(tokenIds) + Array(newTokenIds))
+            } else {
+                updatedTokenIds[contract] = newTokenIds
+            }
+        }
+        return updatedTokenIds
     }
 }

--- a/AlphaWallet/Tokens/Types/NonFungibleFromTokenUri.swift
+++ b/AlphaWallet/Tokens/Types/NonFungibleFromTokenUri.swift
@@ -1,11 +1,13 @@
 // Copyright © 2021 Stormbird PTE. LTD.
 
 import Foundation
+import BigInt
 
 //To store the output from ERC721's `tokenURI()`. The output has to be massaged to fit here as the properties was designed for OpenSea
 struct NonFungibleFromTokenUri: Codable, NonFungibleFromJson {
     let tokenId: String
     let tokenType: NonFungibleFromJsonTokenType
+    var value: BigInt
     let contractName: String
     let decimals: Int
     let symbol: String
@@ -54,8 +56,8 @@ struct NonFungibleFromTokenUriBeforeErc1155Support: Codable {
         nil
     }
 
-    var asPostErc1155Support: NonFungibleFromJson {
-        let result = NonFungibleFromTokenUri(tokenId: tokenId, tokenType: .erc721, contractName: contractName, decimals: 0, symbol: symbol, name: name, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, externalLink: externalLink)
+    func asPostErc1155Support(tokenType: NonFungibleFromJsonTokenType?) -> NonFungibleFromJson {
+        let result = NonFungibleFromTokenUri(tokenId: tokenId, tokenType: tokenType ?? .erc721, value: 1, contractName: contractName, decimals: 0, symbol: symbol, name: name, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, externalLink: externalLink)
         return result
     }
 }

--- a/AlphaWallet/Tokens/Types/OpenSeaNonFungible.swift
+++ b/AlphaWallet/Tokens/Types/OpenSeaNonFungible.swift
@@ -1,6 +1,7 @@
 // Copyright © 2018 Stormbird PTE. LTD.
 
 import Foundation
+import BigInt
 
 //Some fields are duplicated across token IDs within the same contract like the contractName, symbol, contractImageUrl, etc. The space savings in the database aren't work the normalization
 struct OpenSeaNonFungible: Codable, NonFungibleFromJson {
@@ -10,6 +11,7 @@ struct OpenSeaNonFungible: Codable, NonFungibleFromJson {
 
     let tokenId: String
     let tokenType: NonFungibleFromJsonTokenType
+    var value: BigInt
     let contractName: String
     let decimals: Int
     let symbol: String
@@ -56,8 +58,8 @@ struct OpenSeaNonFungibleBeforeErc1155Support: Codable {
         return traits.first { $0.type == OpenSeaNonFungible.generationTraitName }
     }
 
-    var asPostErc1155Support: NonFungibleFromJson {
-        let result = OpenSeaNonFungible(tokenId: tokenId, tokenType: .erc721, contractName: contractName, decimals: 0, symbol: symbol, name: name, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, contractImageUrl: contractImageUrl, externalLink: externalLink, backgroundColor: backgroundColor, traits: traits)
+    func asPostErc1155Support(tokenType: NonFungibleFromJsonTokenType?) -> NonFungibleFromJson {
+        let result = OpenSeaNonFungible(tokenId: tokenId, tokenType: tokenType ?? .erc721, value: 1, contractName: contractName, decimals: 0, symbol: symbol, name: name, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, contractImageUrl: contractImageUrl, externalLink: externalLink, backgroundColor: backgroundColor, traits: traits)
         return result
     }
 }

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -472,7 +472,7 @@ class TokensDataStore: NSObject {
 
         return result
     }
-} 
+}
 // swiftlint:enable type_body_length
 
 extension TokenObject {
@@ -497,4 +497,4 @@ extension TokensDataStore.functional {
         }
     }
 }
-// swiftlint:enable file_length 
+// swiftlint:enable file_length

--- a/AlphaWallet/Tokens/ViewControllers/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
@@ -40,7 +40,7 @@ class TokensCardCollectionViewController: UIViewController {
     private var activitiesPageView: ActivitiesPageView
     private var assetsPageView: AssetsPageView
     var isReadOnly: Bool = false
-    
+
     private let activitiesService: ActivitiesServiceType
     private let containerView: PagesContainerView
 

--- a/AlphaWallet/Tokens/ViewControllers/Collectibles/Views/TokenAssetTableViewCell.swift
+++ b/AlphaWallet/Tokens/ViewControllers/Collectibles/Views/TokenAssetTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class SimplifiedTokenCardRowView: TokenCardRowViewProtocol & UIView & SelectionPositioningView {
-    
+
     var checkboxImageView: UIImageView = UIImageView()
     var stateLabel: UILabel = UILabel()
     var tokenView: TokenView


### PR DESCRIPTION
This PR changes the internal flow for ERC1155 detection and balance so it's clearer and easier to maintain like this:

Fetching ERC1155 tokens in 2 steps:

A. Fetch known contracts and tokenIds owned (now or previously) for each, writing them to JSON. tokenIds are never removed (so we can easily discover their balance is 0 in the next step)
B. Fetch balance for each tokenId owned (now or previously. For the latter value would be 0)
