### PR TITLE
Workaround crash if app launches with no chain selected (no idea why that can happen)

### DIFF
--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -172,7 +172,12 @@ struct Config {
     var enabledServers: [RPCServer] {
         get {
             if let chainIds = defaults.array(forKey: Keys.enabledServers) as? [Int] {
-                return chainIds.map { .init(chainID: $0) }
+                if chainIds.isEmpty {
+                    //TODO remote log. Why is this possible? Note it's not nil (which is possible for new installs)
+                    return Constants.defaultEnabledServers
+                } else {
+                    return chainIds.map { .init(chainID: $0) }
+                }
             } else {
                 return Constants.defaultEnabledServers
             }


### PR DESCRIPTION
One of the cases we'll need to remote log and figure out the cause. But for now, just set the selected chains to be the default when that happens