### PR TITLE
Add an app-enforced timeout for WalletConnect while waiting to make new connections

### DIFF
--- a/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
+++ b/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
@@ -52,6 +52,7 @@ enum Analytics {
         case walletConnectConnect = "WalletConnect Connect"
         case walletConnectCancel = "WalletConnect Cancel"
         case walletConnectDisconnect = "WalletConnect Disconnect"
+        case walletConnectConnectionTimeout = "WalletConnect Connection Timeout"
         case clearBrowserCache = "Clear Browser Cache"
         case rectifySendTransactionErrorInActionSheet = "Rectify Send Txn Error"
         case nameWallet = "Name Wallet"
@@ -161,4 +162,8 @@ enum Analytics {
         case `import`
         case watch
     }
+
+   enum WalletConnectAction: String {
+       case bridgeUrl
+   }
 }

--- a/AlphaWallet/Core/Features.swift
+++ b/AlphaWallet/Core/Features.swift
@@ -15,4 +15,5 @@ enum Features {
     static let isAlertsEnabled = false
     static let isErc1155Enabled = true
     static let isUsingPrivateNetwork = false
+    static let isUsingAppEnforcedTimeoutForMakingWalletConnectConnections = false
 }


### PR DESCRIPTION
So the user doesn't wait forever in the current screen. Instead we'll show an informative message, asking the user to refresh the dapp and scan a fresh QR code.

Looks like this. But this functionality is disabled until proper UI is available in #3275

<img width="300" alt="Screenshot 2021-10-07 at 1 31 57 PM" src="https://user-images.githubusercontent.com/56189/136325591-24003e26-eec2-4b38-b8d5-1f4dd099975b.png">

