### PR TITLE
Fix: app hangs are the launch screen when build and run with Xcode 13 on iOS 15 device

### DIFF
--- a/AlphaWallet/Core/Types/ThreadSafeDictionary.swift
+++ b/AlphaWallet/Core/Types/ThreadSafeDictionary.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class ThreadSafeDictionary<Key: Hashable, Value> {
     fileprivate var cache = [Key: Value]()
-    private let queue = DispatchQueue(label: "SynchronizedArrayAccess", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "SynchronizedArrayAccess", qos: .background)
 
     subscript(server: Key) -> Value? {
         get {


### PR DESCRIPTION
Could depend on existing data/wallet, and this is the minimal change to make it a non-blocker

Fixes #3321 
