### PR TITLE
Add app as custom URL scheme handler for wc: (WalletConnect)

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -152,6 +152,11 @@ class AppCoordinator: NSObject, Coordinator {
         if handled {
             return true
         }
+        //TODO clean up handling of custom URL schemes:
+        if url.scheme == "wc", let wcUrl = WalletConnectURL(url.absoluteString), let inCoordinator = inCoordinator {
+            inCoordinator.openWalletConnectSession(url: wcUrl)
+            return true
+        }
 
         let shouldBeHandledByCustomUrlSchemeCoordinator = CustomUrlSchemeCoordinator.canHandleOpen(url: url) && inCoordinator != nil
         //NOTE: avoid displaying error from `assetDefinitionStoreCoordinator.handleOpen(url` while handling eip681 url

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -57,6 +57,14 @@
 				<string>ethereum1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>WalletConnect Links</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wc</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>


### PR DESCRIPTION
Probably not very effective due to how custom URL scheme handlers are set up in iOS, but if it does work for a user + device, scanning a WalletConnect QR code will launch AlphaWallet