### PR TITLE
Add blockchain explorer key support to polygonscan API integration

### DIFF
--- a/AlphaWallet/Settings/Types/Constants+Credentials.swift
+++ b/AlphaWallet/Settings/Types/Constants+Credentials.swift
@@ -7,6 +7,7 @@ extension Constants {
         static let infuraKey = "da3717f25f824cc1baa32d812386d93f"
         static let etherscanKey = "1PX7RG8H4HTDY8X55YRMCAKPZK476M23ZR"
         static let binanceSmartChainExplorerApiKey: String? = nil
+        static let polygonScanExplorerApiKey: String? = nil
         static let analyticsKey = ""
         static let paperTrail = (host: "", port: UInt(0))
         static let mailChimpListSpecificKey = ""

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -290,9 +290,11 @@ enum RPCServer: Hashable, CaseIterable {
         case .binance_smart_chain:
             //Key not needed for testnet (empirically)
             return Constants.Credentials.binanceSmartChainExplorerApiKey
-        case .fantom, .heco, .heco_testnet, .binance_smart_chain_testnet, .polygon:
+        case .polygon, .mumbai_testnet:
+            return Constants.Credentials.polygonScanExplorerApiKey
+        case .fantom, .heco, .heco_testnet, .binance_smart_chain_testnet:
             return nil
-        case .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .mumbai_testnet, .callisto, .fantom_testnet, .avalanche, .avalanche_testnet, .cronosTestnet, .palm, .palmTestnet, .custom:
+        case .poa, .sokol, .classic, .xDai, .artis_sigma1, .artis_tau1, .callisto, .fantom_testnet, .avalanche, .avalanche_testnet, .cronosTestnet, .palm, .palmTestnet, .custom:
             return nil
         }
     }


### PR DESCRIPTION
Polygonscan doesn't seem to require them. So just going to use them for app submissions, just in case they enforce it