### PR TITLE
Tweak copy for private transactions to remove mention of "Ethermine" least users (or Apple!) think this is about mining on the device

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -89,7 +89,7 @@
 "settings.backupWallet.button.title" = "Back up this Wallet";
 "settings.showSeedPhrase.button.title" = "Show Seed Phrase";
 "settings.walletConnect.button.title" = "WalletConnect";
-"settings.useEthermineNetwork.button.title" = "Use Ethermine for Ethereum";
+"settings.useEthermineNetwork.button.title" = "Private ETH transactions";
 "settings.language.useSystem.title" = "Use System Setting";
 "settings.version.label.title" = "Version";
 "settings.tokenScriptStandard.title" = "TokenScript Compatibility";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -89,7 +89,7 @@
 "settings.backupWallet.button.title" = "Hacer una copia de seguridad de este monedero";
 "settings.showSeedPhrase.button.title" = "Show Seed Phrase";
 "settings.walletConnect.button.title" = "WalletConnect";
-"settings.useEthermineNetwork.button.title" = "Use Ethermine for Ethereum";
+"settings.useEthermineNetwork.button.title" = "Private ETH transactions";
 "settings.language.useSystem.title" = "Usar la configuración del sistema";
 "settings.version.label.title" = "Versión";
 "settings.tokenScriptStandard.title" = "Compatibilidad de TokenScript";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -89,7 +89,7 @@
 "settings.backupWallet.button.title" = "Back up this Wallet";
 "settings.showSeedPhrase.button.title" = "Show Seed Phrase";
 "settings.walletConnect.button.title" = "WalletConnect";
-"settings.useEthermineNetwork.button.title" = "Use Ethermine for Ethereum";
+"settings.useEthermineNetwork.button.title" = "Private ETH transactions";
 "settings.language.useSystem.title" = "システム設定を使用";
 "settings.version.label.title" = "バージョン";
 "settings.tokenScriptStandard.title" = "TokenScript Compatibility";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -89,7 +89,7 @@
 "settings.backupWallet.button.title" = "Back up this Wallet";
 "settings.showSeedPhrase.button.title" = "Show Seed Phrase";
 "settings.walletConnect.button.title" = "WalletConnect";
-"settings.useEthermineNetwork.button.title" = "Use Ethermine for Ethereum";
+"settings.useEthermineNetwork.button.title" = "Private ETH transactions";
 "settings.language.useSystem.title" = "시스템 설정 사용";
 "settings.version.label.title" = "버전";
 "settings.tokenScriptStandard.title" = "TokenScript Compatibility";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -89,7 +89,7 @@
 "settings.backupWallet.button.title" = "备份此钱包";
 "settings.showSeedPhrase.button.title" = "Show Seed Phrase";
 "settings.walletConnect.button.title" = "WalletConnect";
-"settings.useEthermineNetwork.button.title" = "Use Ethermine for Ethereum";
+"settings.useEthermineNetwork.button.title" = "Private ETH transactions";
 "settings.language.useSystem.title" = "使用系统设置";
 "settings.version.label.title" = "版本";
 "settings.tokenScriptStandard.title" = "TokenScript 兼容性";


### PR DESCRIPTION
Before PR|After PR
-|-
<img width="200" alt="Screenshot 2021-11-01 at 4 02 26 PM" src="https://user-images.githubusercontent.com/56189/139642494-bda4d347-f33a-42c5-b117-3968704d3419.png">|<img width="200" alt="Screenshot 2021-11-01 at 4 19 00 PM" src="https://user-images.githubusercontent.com/56189/139642517-b6badb19-6805-4826-a857-2c90eb3297fe.png">
