### PR TITLE
Tweak user-agent in dapp browser for 1inch so the smart app banner doesn't show up

### DIFF
--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -30,7 +30,7 @@ final class BrowserViewController: UIViewController {
     }
 
     private lazy var userClient: String = {
-        return Keys.ClientName + "/" + (Bundle.main.versionNumber ?? "")
+        Keys.ClientName + "/" + (Bundle.main.versionNumber ?? "") + " 1inchWallet"
     }()
 
     private lazy var errorView: BrowserErrorView = {


### PR DESCRIPTION
Had originally wanted to open 1inch in a standalone browser instead and only modify the user-agent there, but the flow needs to change too much because the standalone browser doesn't enable switching of chains.