### PR TITLE
Fix: fiat value displayed for ERC20 tokens in single token view is wrong

### DIFF
--- a/AlphaWallet/Core/Types/ERC20BalanceViewModel.swift
+++ b/AlphaWallet/Core/Types/ERC20BalanceViewModel.swift
@@ -43,8 +43,9 @@ struct ERC20BalanceViewModel: BalanceBaseViewModel {
     }
 
     var currencyAmountWithoutSymbol: Double? {
-        guard let rate = ticker?.rate else { return nil }
-        let symbol = mapSymbolToVersionInRates(server.symbol.lowercased())
+        guard let ticker = ticker else { return nil }
+        let rate = ticker.rate
+        let symbol = mapSymbolToVersionInRates(ticker.symbol.lowercased())
         guard let currentRate = (rate.rates.filter { $0.code == symbol }.first), currentRate.price > 0, amount > 0 else { return nil }
         return amount * currentRate.price
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -209,13 +209,13 @@ class TokenViewController: UIViewController {
             session.refresh(.ethBalance)
         case .erc20Token(let token, _, _):
             let amount = EtherNumberFormatter.short.string(from: token.valueBigInt, decimals: token.decimals)
-            //Note that if we want to display the token name directly from token.name, we have to be careful that DAI token's name has trailing \0
             tokenInfoPageView.viewModel.title = "\(amount) \(token.symbolInPluralForm(withAssetDefinitionStore: assetDefinitionStore))"
-
             tokenInfoPageView.viewModel.ticker = session.balanceCoordinator.coinTicker(token.addressAndRPCServer)
-            tokenInfoPageView.viewModel.currencyAmount = session.balanceCoordinator.ethBalanceViewModel.currencyAmount
-
-            configure(viewModel: viewModel)
+            session.balanceCoordinator.subscribableTokenBalance(token.addressAndRPCServer).subscribe { [weak self] viewModel in
+                guard let strongSelf = self, let viewModel = viewModel else { return }
+                strongSelf.tokenInfoPageView.viewModel.currencyAmount = viewModel.currencyAmount
+                strongSelf.configure(viewModel: strongSelf.viewModel)
+            }
         case .erc875Token, .erc875TokenOrder, .erc721Token, .erc721ForTicketToken, .erc1155Token, .dapp, .tokenScript, .claimPaidErc875MagicLink:
             break
         }


### PR DESCRIPTION
Fix: fiat value displayed for ERC20 tokens in single token view is wrong

Polygon WETH is using Matic's fiat value:

Before PR|After PR
-|-
<img width="300" alt="Screenshot 2021-11-12 at 3 05 45 PM" src="https://user-images.githubusercontent.com/56189/141425837-5cc21991-50df-4f0f-88c0-89f0eaaecbb5.png">|<img width="300" alt="Screenshot 2021-11-12 at 3 07 15 PM" src="https://user-images.githubusercontent.com/56189/141425860-3d74c2a2-4c5e-4552-ba82-db47ea9138b2.png">
