### PR TITLE
Fix price for ERC20 tokens matching same CoinGecko ID not appearing correctly

### DIFF
--- a/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersFetcher.swift
@@ -230,8 +230,9 @@ class CoinTickersFetcher: CoinTickersFetcherType {
             let tickers = try response.map([CoinTicker].self, using: JSONDecoder())
             var resultTickers: [AddressAndRPCServer: CoinTicker] = [:]
             for ticker in tickers {
-                if let value = mappedCoinTickerIds.first(where: { $0.tickerId == ticker.id }) {
-                    let key = AddressAndRPCServer(address: value.contractAddress, server: value.server)
+                let matches = mappedCoinTickerIds.filter({ $0.tickerId == ticker.id })
+                for each in matches {
+                    let key = AddressAndRPCServer(address: each.contractAddress, server: each.server)
                     resultTickers[key] = ticker
                 }
             }


### PR DESCRIPTION
Includes commit from #3424.

Only 1 of the tokens will show the price.

E.g WETH on mainnet and Polygon are based on CoinGecko's "weth", only one of them (random pick) will show the price

Before PR|After PR
-|-
<img width="300" alt="Screenshot 2021-11-14 at 2 13 03 AM" src="https://user-images.githubusercontent.com/56189/141654657-bf6eaaaf-fee1-472e-884d-5e72f5e2c1bc.png">|<img width="300" alt="Screenshot 2021-11-14 at 1 53 59 AM" src="https://user-images.githubusercontent.com/56189/141654650-c9504e21-55a6-4718-9090-6fb304ca6226.png">
