### PR TITLE
Added Run SwiftLint phase to AlphaWalletShare / AlphaWalletSafariExtensions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,9 +24,13 @@ opt_in_rules:
 included:
   - AlphaWallet
   - AlphaWalletTests
+  - AlphaWalletSafariExtension
+  - AlphaWalletShare
+  - modules
 excluded:
   - AlphaWallet/Vendors
   - AlphaWallet/R.generated.swift
+  - AlphaWalletSafariExtension/Resources
 function_parameter_count:
   warning: 20
   error: 25


### PR DESCRIPTION
Closes #3459.

I am not able to test this other than by compiling the project under the AlphaWalletShare and AlphaWalletSafariExtension schemes. When I run Project > Test under the AlphaWallet scheme, I get `Cannot test target “AlphaWalletUITests” on “iPhone 12”: UITargetAppPath should be provided`. I am able to compile and run the AlphaWallet target on the simulator. 

In Xcode:
1) Select AlphaWalletShare scheme.
2) Build the extension.

**Expects**
3) Successful build.

In Xcode:
1) Select AlphaWalletSafariExtension scheme.
2) Build the extension.

**Expects**
3) Successful build.

In Xcode:
1) Select the AlphaWallet scheme.
2) Run the app.

**Expects**
3) Successful build.
4) App runs on simulator/iPhone.

The SwiftLint command is invoked via `${SRCROOT}/Pods/SwiftLint/swiftlint` instead of using `${PODS_ROOT}` because `${PODS_ROOT}` does not appear to be defined for the extensions. Adding the extensions as targets to the Podfile results in a `linking against a dylib which is not safe for use in application extensions:` warning.