### PR TITLE
Updated Travis.yml and corrected code to allow tests to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode12.5
+osx_image: xcode13.1
 
 branches:
   only:
@@ -20,6 +20,7 @@ before_install:
 script:
   - set -o pipefail
   - xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 12,OS=14.5" test | xcpretty
+  - xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 12,OS=15.0" test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/AlphaWalletTests/Coordinators/LockEnterPasscodeCoordinatorTest.swift
+++ b/AlphaWalletTests/Coordinators/LockEnterPasscodeCoordinatorTest.swift
@@ -11,6 +11,7 @@ class LockEnterPasscodeCoordinatorTest: XCTestCase {
         XCTAssertTrue(coordinator.window.isHidden)
         coordinator.start()
         XCTAssertFalse(coordinator.window.isHidden)
+        coordinator.stop()
     }
     func testStop() {
         let viewModel = LockEnterPasscodeViewModel()
@@ -29,5 +30,6 @@ class LockEnterPasscodeCoordinatorTest: XCTestCase {
         XCTAssertTrue(coordinator.window.isHidden)
         coordinator.start()
         XCTAssertTrue(coordinator.window.isHidden)
+        coordinator.stop()
     }
 }


### PR DESCRIPTION
Closes #3456

The error were apparently caused by `LockEnterPasscodeCoordinator` not calling the `.stop()` function before terminating the test.