### PR TITLE
Fix: remove duplicate switch-case. No functional change, but could have been a bug

### DIFF
--- a/AlphaWallet/Settings/Models/SendPrivateTransactionsProvider.swift
+++ b/AlphaWallet/Settings/Models/SendPrivateTransactionsProvider.swift
@@ -30,7 +30,7 @@ enum SendPrivateTransactionsProvider: String {
             switch server {
             case .main:
                 return URL(string: "https://rpc.ethermine.org")!
-            case .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .main, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .palm, .palmTestnet:
+            case .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .palm, .palmTestnet:
                 return nil
             }
         case .eden:
@@ -39,7 +39,7 @@ enum SendPrivateTransactionsProvider: String {
                 return URL(string: "https://api.edennetwork.io/v1/rpc")!
             case .ropsten:
                 return URL(string: "https://dev-api.edennetwork.io/v1/rpc")!
-            case .xDai, .kovan, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .main, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .palm, .palmTestnet:
+            case .xDai, .kovan, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .palm, .palmTestnet:
                 return nil
             }
         }


### PR DESCRIPTION
Potential bug because removing the `case .main` would have compiled with no errors and `server  == .main` would have went down the wrong code path.

```
switch server {
case .main:
case .somethingElse, .main:
}
```