### PR TITLE
Make visible textfields, hidden by keyboard, when becoming first responder

### DIFF
--- a/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
@@ -140,6 +140,12 @@ extension SaveCustomRpcViewController: TextFieldDelegate {
         return true
     }
 
+    func didBeginEditing(in textField: TextField) {
+        DispatchQueue.main.async {
+            self.editView.unobscure(textField: textField)
+        }
+    }
+
     func doneButtonTapped(for textField: TextField) {
         //no-op
     }

--- a/AlphaWallet/Settings/Views/SaveCustomRpcView.swift
+++ b/AlphaWallet/Settings/Views/SaveCustomRpcView.swift
@@ -133,6 +133,8 @@ class SaveCustomRpcView: UIView {
 
             footerBar.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             footerBar.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            footerBar.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            footerBar.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
             footerBar.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
         ] + roundedBackground.createConstraintsWithContainer(view: self))
     }
@@ -152,6 +154,15 @@ class SaveCustomRpcView: UIView {
         for field in allTextFields {
             field.status = .none
         }
+    }
+
+    func unobscure(textField: TextField) {
+        guard textField != allTextFields.first else {
+            self.scrollView.setContentOffset(.zero, animated: true)
+            return
+        }
+        let rect = self.scrollView.convert(textField.bounds, from: textField)
+        self.scrollView.scrollRectToVisible(rect, animated: true)
     }
 
     private func configureInputAccessoryView() {
@@ -205,6 +216,7 @@ fileprivate func defaultTextField(_ type: UIKeyboardType, placeHolder: String, l
     textField.keyboardType = type
     textField.textField.autocorrectionType = .no
     textField.textField.autocapitalizationType = .none
+    textField.textField.spellCheckingType = .no
     textField.returnKeyType = .next
     textField.placeholder = placeHolder
     textField.label.text = label

--- a/AlphaWallet/Tokens/Views/TextField.swift
+++ b/AlphaWallet/Tokens/Views/TextField.swift
@@ -7,11 +7,15 @@ protocol TextFieldDelegate: AnyObject {
     func doneButtonTapped(for textField: TextField)
     func nextButtonTapped(for textField: TextField)
     func shouldChangeCharacters(inRange range: NSRange, replacementString string: String, for textField: TextField) -> Bool
+    func didBeginEditing(in textField: TextField)
 }
 
 extension TextFieldDelegate {
     func shouldChangeCharacters(inRange range: NSRange, replacementString string: String, for textField: TextField) -> Bool {
         return true
+    }
+    func didBeginEditing(in textField: TextField) {
+        return
     }
 }
 
@@ -235,6 +239,7 @@ extension TextField: UITextFieldDelegate {
         backgroundColor = Colors.appWhite
 
         dropShadow(color: borderColor, radius: DataEntry.Metric.shadowRadius)
+        delegate?.didBeginEditing(in: self)
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
Closes #3453

## Summary
If a textfield in the edit custom rpc screen becomes first responder and is hidden, it will be scrolled into view.

## Testing
### Prerequisites 
Requires a custom rpc to be added. Refer to "enter network data" section of this [pull request](https://github.com/AlphaWallet/alpha-wallet-ios/pull/3465) for instructions on how to add one.
### Instructions
1. When on the main screen of app, tap the settings tab bar icon.
2. Tap select active networks option on the Settings screen.
3. Slide the custom rpc (normally Expanse Network) to the left to expose the edit button.
4. Tap the edit button and the edit custom rpc network screen should appear.
5. Tap on the Symbol text field. A keyboard will appear at the bottom of the screen and hide the Block Explorer URL text field.
6. Tap the next button on the keyboard.
### Expects
7. The Block Explorer URL text field should slide up from the bottom.
### Tested 
Tested on
1. iPhone 12, iOS 14.5 (simulator)
2. iPhone 13, iOS 15.0 (simulator)
3. iPhone X, iOS 15.0 (hardware)
4. iPad Pro 9 inch, iOS 15.0 (hardware)

