### PR TITLE
Remove most "-" displayed in Wallet tab when price is not available to reduce clutter

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		5E7C783EA4C21609101A0F99 /* EmptyDapps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C0AC267283F3F2A6E37 /* EmptyDapps.swift */; };
 		5E7C78407F6DCB0EDD562DF6 /* NonFungibleTokenViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C731B6F01534683227123 /* NonFungibleTokenViewCellViewModel.swift */; };
 		5E7C784B592A446BE35D3DE9 /* AlphaWalletAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F8F3CB3847D0E4E977B /* AlphaWalletAddress.swift */; };
+		5E7C784BA700ED0E4878D0E0 /* UiTweaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C85E24A82DBF37E3F76 /* UiTweaks.swift */; };
 		5E7C7855E46A6604B2028C9D /* BrowserErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7F718714A0EA529664E7 /* BrowserErrorView.swift */; };
 		5E7C785C39CC8243BEC1219C /* PromptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E50E9184C7F0FE3966C /* PromptViewModel.swift */; };
 		5E7C786AD8E4877C36D3B14A /* TokenAdaptorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C775FD95FE80B0F1CEA33 /* TokenAdaptorTest.swift */; };
@@ -1589,6 +1590,7 @@
 		5E7C7C781CCE43B6451671B9 /* TokenListFormatTableViewCellWithoutCheckbox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenListFormatTableViewCellWithoutCheckbox.swift; sourceTree = "<group>"; };
 		5E7C7C7CB95B7EE4B2547585 /* EnabledServersCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnabledServersCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7C83B57FC8FAE9AF8F26 /* TokenCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenCollection.swift; sourceTree = "<group>"; };
+		5E7C7C85E24A82DBF37E3F76 /* UiTweaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UiTweaks.swift; sourceTree = "<group>"; };
 		5E7C7C8CA3706DC14167786C /* BrowserURLParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserURLParserTests.swift; sourceTree = "<group>"; };
 		5E7C7CAA3D0C19444005EA83 /* TokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7CBCC0A74A084AC2F053 /* ABIType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ABIType.swift; sourceTree = "<group>"; };
@@ -2726,6 +2728,7 @@
 				874DED1824C1BD2C006C8FCE /* SelectTokenViewModel.swift */,
 				8762002B266E150B0059B05A /* WalletTokenViewCellViewModel.swift */,
 				8762002D266E15310059B05A /* PopularTokenViewCellViewModel.swift */,
+				5E7C7C85E24A82DBF37E3F76 /* UiTweaks.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -6217,6 +6220,7 @@
 				5E7C7DB7B431837C0D7031B1 /* ChooseSendPrivateTransactionsProviderViewModel.swift in Sources */,
 				5E7C77A652206E62A682D6EE /* SelectionTableViewCell.swift in Sources */,
 				5E7C79E124DB52FB927CECE8 /* SendPrivateTransactionsProvider.swift in Sources */,
+				5E7C784BA700ED0E4878D0E0 /* UiTweaks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -82,7 +82,11 @@ struct EthTokenViewCellViewModel {
             case .depreciate(let percentageChange24h):
                 return "\(percentageChange24h)%"
             case .none:
-                return "-"
+                if priceChangeUSDValue == UiTweaks.noPriceMarker {
+                    return UiTweaks.noPriceMarker
+                } else {
+                    return "-"
+                }
             }
         }()
 
@@ -94,9 +98,9 @@ struct EthTokenViewCellViewModel {
 
     private var priceChangeUSDValue: String {
         if let result = EthCurrencyHelper(ticker: ticker).valueChanged24h(value: token.optionalDecimalValue) {
-            return NumberFormatter.usd(format: .priceChangeFormat).string(from: result) ?? "-"
+            return NumberFormatter.usd(format: .priceChangeFormat).string(from: result) ?? UiTweaks.noPriceMarker
         } else {
-            return "-"
+            return UiTweaks.noPriceMarker
         }
     }
 
@@ -109,14 +113,14 @@ struct EthTokenViewCellViewModel {
 
     private var amountAccordingRPCServer: String? {
         if token.server.isTestnet {
-            return nil
+            return UiTweaks.noPriceMarker
         } else {
-            return currencyAmount.flatMap { NumberFormatter.usd(format: .fiatFormat).string(from: $0) ?? "-" }
+            return currencyAmount.flatMap { NumberFormatter.usd(format: .fiatFormat).string(from: $0) ?? UiTweaks.noPriceMarker }
         }
     }
 
     var fiatValueAttributedString: NSAttributedString {
-        return NSAttributedString(string: amountAccordingRPCServer ?? "-", attributes: [
+        return NSAttributedString(string: amountAccordingRPCServer ?? UiTweaks.noPriceMarker, attributes: [
             .foregroundColor: Screen.TokenCard.Color.title,
             .font: Screen.TokenCard.Font.valueChangeValue
         ])
@@ -162,10 +166,17 @@ struct EthTokenViewCellViewModel {
     }
 
     var apprecationViewModel: ApprecationViewModel {
-        .init(icon: apprecation24hoursImage, valueAttributedString: apprecation24hoursAttributedString, backgroundColor: apprecation24hoursBackgroundColor)
+        let backgroundColor: UIColor = {
+            if apprecation24hoursAttributedString.string.isEmpty {
+                return .clear
+            } else {
+                return apprecation24hoursBackgroundColor
+            }
+        }()
+        return .init(icon: apprecation24hoursImage, valueAttributedString: apprecation24hoursAttributedString, backgroundColor: backgroundColor)
     }
 
     private func valuePercentageChangeColor(ticker: CoinTicker?) -> UIColor {
         return Screen.TokenCard.Color.valueChangeValue(ticker: ticker)
-    } 
+    }
 }

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
@@ -57,7 +57,14 @@ struct FungibleTokenViewCellViewModel {
     }
 
     var apprecationViewModel: ApprecationViewModel {
-        .init(icon: apprecation24hoursImage, valueAttributedString: apprecation24hoursAttributedString, backgroundColor: apprecation24hoursBackgroundColor)
+        let backgroundColor: UIColor = {
+            if apprecation24hoursAttributedString.string.isEmpty {
+                return .clear
+            } else {
+                return apprecation24hoursBackgroundColor
+            }
+        }()
+        return .init(icon: apprecation24hoursImage, valueAttributedString: apprecation24hoursAttributedString, backgroundColor: backgroundColor)
     }
 
     private var apprecation24hoursAttributedString: NSAttributedString {
@@ -68,7 +75,11 @@ struct FungibleTokenViewCellViewModel {
             case .depreciate(let percentageChange24h):
                 return "\(percentageChange24h)%"
             case .none:
-                return "-"
+                if priceChangeUSDValue == UiTweaks.noPriceMarker {
+                    return UiTweaks.noPriceMarker
+                } else {
+                    return "-"
+                }
             }
         }()
 
@@ -91,9 +102,9 @@ struct FungibleTokenViewCellViewModel {
 
     private var priceChangeUSDValue: String {
         if let result = EthCurrencyHelper(ticker: ticker).valueChanged24h(value: token.optionalDecimalValue) {
-            return NumberFormatter.usd(format: .priceChangeFormat).string(from: result) ?? "-"
+            return NumberFormatter.usd(format: .priceChangeFormat).string(from: result) ?? UiTweaks.noPriceMarker
         } else {
-            return "-"
+            return UiTweaks.noPriceMarker
         }
     }
 
@@ -106,9 +117,9 @@ struct FungibleTokenViewCellViewModel {
 
     private var fiatValue: String {
         if let fiatValue = EthCurrencyHelper(ticker: ticker).fiatValue(value: token.optionalDecimalValue) {
-            return NumberFormatter.usd(format: .fiatFormat).string(from: fiatValue) ?? "-"
+            return NumberFormatter.usd(format: .fiatFormat).string(from: fiatValue) ?? UiTweaks.noPriceMarker
         } else {
-            return "-"
+            return UiTweaks.noPriceMarker
         }
     }
 

--- a/AlphaWallet/Tokens/ViewModels/UiTweaks.swift
+++ b/AlphaWallet/Tokens/ViewModels/UiTweaks.swift
@@ -1,0 +1,8 @@
+// Copyright © 2021 Stormbird PTE. LTD.
+
+import Foundation
+
+struct UiTweaks {
+    //This used to be "-", just not displaying anything should make Wallet tab look less cluttered
+    static let noPriceMarker = ""
+}

--- a/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/FungibleTokenViewCell.swift
@@ -91,4 +91,4 @@ class FungibleTokenViewCell: UITableViewCell {
 
         priceChangeLabel.layer.cornerRadius = 2.0
     }
-} 
+}

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -203,8 +203,13 @@ struct TokenInfoPageViewModel {
     }
 
     private var tokenValueAttributedString: NSAttributedString? {
-        let string = R.string.localizable.aWalletTokenValue(currencyAmount ?? "-")
-
+        let string: String = {
+            if let currencyAmount = currencyAmount {
+                return R.string.localizable.aWalletTokenValue(currencyAmount)
+            } else {
+                return UiTweaks.noPriceMarker
+            }
+        }()
         return NSAttributedString(string: string, attributes: [
             .font: Screen.TokenCard.Font.placeholderLabel,
             .foregroundColor: R.color.dove()!


### PR DESCRIPTION
Introduced `UiTweaks.swift` (for now since there's nothing to generalize) with a variable to replace the "-" with "" (empty string). So we can revert this or tweak it further more easily.


Before|Before
-|-
<img width="300" alt="Screenshot 2021-11-24 at 3 42 03 PM" src="https://user-images.githubusercontent.com/56189/143378627-abf09534-f7f8-4c38-827b-295aaec9b4d0.png">|<img width="300" alt="Screenshot 2021-11-24 at 4 29 36 PM" src="https://user-images.githubusercontent.com/56189/143378651-18e92f5e-35c1-41c9-b41a-616cc1e1482f.png">
After|After
<img width="300" alt="Screenshot 2021-11-25 at 12 11 45 PM" src="https://user-images.githubusercontent.com/56189/143378656-be971b3d-0c2a-4e5f-af26-ea9eb4eb151b.png">|<img width="300" alt="Screenshot 2021-11-25 at 12 12 02 PM" src="https://user-images.githubusercontent.com/56189/143378659-27e26538-944b-47f0-9e30-bec1035c6077.png">

