### PR TITLE
Add debug flag to read clipboard for WalletConnect URL and use it when camera button in Wallet tab is tapped

### DIFF
--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -249,6 +249,8 @@ struct Config {
     ///Debugging flag. Set to false to disable auto fetching prices, etc to cut down on network calls
     let isAutoFetchingDisabled = false
 
+    let shouldReadClipboardForWalletConnectUrl = false
+
     func addToWalletAddressesAlreadyPromptedForBackup(address: AlphaWallet.Address) {
         var addresses: [String]
         if let value = defaults.array(forKey: Keys.walletAddressesAlreadyPromptedForBackUp) {

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -249,7 +249,13 @@ extension TokensCoordinator: TokensViewControllerDelegate {
     }
 
     func scanQRCodeSelected(in viewController: UIViewController) {
-        launchUniversalScanner(fromSource: .walletScreen)
+        if config.shouldReadClipboardForWalletConnectUrl {
+            if let s = UIPasteboard.general.string ?? UIPasteboard.general.url?.absoluteString, let url = WalletConnectURL(s) {
+                walletConnectCoordinator.openSession(url: url)
+            }
+        } else {
+            launchUniversalScanner(fromSource: .walletScreen)
+        }
     }
 }
 


### PR DESCRIPTION
To use it:

1. Set `Config.shouldReadClipboardForWalletConnectUrl` to `true` (do not commit)
2. Copy a WalletConnect URL to clipboard
3. Tap Camera button in Wallet tab and it'll try to connect

Probably should set up to read launch arguments and UserDefaults for such flags as a followup