### PR TITLE
Fixed and improved Keyboard behaviour in SaveCustomRpc series.

### DIFF
--- a/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
@@ -71,14 +71,19 @@ class SaveCustomRpcViewController: UIViewController {
         editView.addBackgroundGestureRecognizer(tap)
         editView.isTestNetworkView.configure(viewModel: SwitchViewViewModel(text: R.string.localizable.addrpcServerIsTestnetTitle(), isOn: viewModel.isTestnet))
         editView.configureKeyboard(keyboardChecker: keyboardChecker)
-        editView.addSaveButtonTarget(self, action: #selector(saveCustomRPC))
+        editView.addSaveButtonTarget(self, action: #selector(handleSaveCustomRPC))
+        editView.chainNameTextField.becomeFirstResponder()
     }
 
     @objc private func tapSelected(_ sender: UITapGestureRecognizer) {
         view.endEditing(true)
     }
 
-    @objc private func saveCustomRPC(_ sender: UIButton) {
+    @objc private func handleSaveCustomRPC(_ sender: UIButton) {
+        saveCustomRPC()
+    }
+
+    private func saveCustomRPC() {
         let result = viewModel.validate(
             chainName: editView.chainNameTextField.value,
             rpcEndpoint: editView.rpcEndPointTextField.value,
@@ -114,9 +119,11 @@ class SaveCustomRpcViewController: UIViewController {
                 editView.chainIDTextField.status = .error(R.string.localizable.editCustomRPCChainIDErrorDuplicate(preferredLanguages: nil))
             }
         }
+        editView.allTextFields.first(where: { !$0.statusLabel.text.isEmpty })?.becomeFirstResponder()
     }
 
     private func handleValidationSuccess(customRPC: CustomRPC) {
+        editView.resetAllTextFieldStatus()
         delegate?.didFinish(in: self, customRpc: customRPC)
     }
 }
@@ -124,18 +131,11 @@ class SaveCustomRpcViewController: UIViewController {
 extension SaveCustomRpcViewController: TextFieldDelegate {
     func shouldReturn(in textField: TextField) -> Bool {
         switch textField {
-        case editView.chainNameTextField:
-            editView.rpcEndPointTextField.becomeFirstResponder()
-        case editView.rpcEndPointTextField:
-            editView.chainIDTextField.becomeFirstResponder()
-        case editView.chainIDTextField:
-            editView.symbolTextField.becomeFirstResponder()
-        case editView.symbolTextField:
-            editView.explorerEndpointTextField.becomeFirstResponder()
         case editView.explorerEndpointTextField:
             view.endEditing(true)
+            saveCustomRPC()
         default:
-            view.endEditing(true)
+            editView.gotoNextResponder()
         }
         return true
     }


### PR DESCRIPTION
Closes #3475

# Testing

## Pre-test

On the main screen, tap the "Settings" tab option followed by the "Select Active Networks" option.
delete "Expanse Network" if it exists.

## Testing

1. Tap the add button in the upper right corner.
2. **Expects** Add Custom RPC screen to appear with Network name field as first responder and an alphabetical keyboard at the bottom. The enter key should read "next". There should be a "<" and ">" button on top of the keyboard.
3. Enter "expanse network" and tap the ">" button.
4. **Expects** RPC URL field to be first responder. A url keyboard should appear.  The enter key should read "next". There should be  "<", ">", "https://" buttons on top of the keyboard.
5. Enter "node.expanse.tech" and tap the "https://" button.
6. **Expects** RPC URL field to display "https://node.expanse.tech".
7. Tap the "https://" button again.
8. **Expects** no change.
9. Tap the ">" button.
10. **Expects** Channel ID field to be first responder. A decimal pad keyboard should appear. There should be "<", ">" buttons on top of the keyboard.
11. Enter "2" and tap ">".
12. **Expects** Symbol field to be first responder. An alphabetical keyboard should appear.  The enter key should read "next". There should be "<", ">" buttons on top of the keyboard.
13. Enter "exp" and tap ">".
14. **Expects** Block Explorer URL field as first responder. A url keyboard should appear.  The enter key should read "done". There should be "<", ">", "https://" buttons on top of the keyboard.
15. Enter "https://expanse.tech" and tap "https://".
16. **Expects** the block explorer url field not to change.
17. tap "<".
18. **Expects** Symbol field to be first responder.
19. tap "<".
20. **Expects** Chain ID field to be first responder.
21. tap "<".
22. **Expects** RPC URL field to be first responder.
23. tap "<".
24. **Expects** Network Name field to be first responder.
25. tap "<".
26. **Expects** Block Explorer URL field to be first responder.
27. tap ">".
28. **Expects** Network Name field to be first responder.
29. Delete the text of the Network Name field.
30. Scroll the screen down until you see the big green button.
31. Tap the big green button.
32. **Expects** Network Name field to be first responder and error status showing the error in the text field.
33. Enter "expanse network" in Network Name field and tap ">".
34. **Expects** RPC URL field to be first responder.
35. Tap ">".
36. **Expects** Chain ID to be first responder.
37. Delete the text of Chain ID field.
38. Tap ">".
39. **Expects** Symbol field to be first responder.
38. Scroll down and tap the big green button.
39. **Expects** Chain ID field to be first responder and error status showing the error in the text field.

## Side note:
When all the fields are valid but the rpc url does not point to a valid location, the app gives a long error which is cryptic to normal people.

![error](https://user-images.githubusercontent.com/1050309/143544838-b8201025-9264-4704-8bd9-3412ef6a57bf.png)


