### PR TITLE
Improve error logged when accessing blockchain explorer API if it's 404. Make it clearer

### DIFF
--- a/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/SingleChainTransactionEtherscanDataCoordinator.swift
@@ -503,10 +503,16 @@ extension SingleChainTransactionEtherscanDataCoordinator.functional {
 
     static func fetchTransactions(for address: AlphaWallet.Address, startBlock: Int, endBlock: Int = 999_999_999, sortOrder: AlphaWalletService.SortOrder, session: WalletSession, alphaWalletProvider: MoyaProvider<AlphaWalletService>, tokensStorage: TokensDataStore, tokenProvider: TokenProviderType, queue: DispatchQueue) -> Promise<[TransactionInstance]> {
         let target: AlphaWalletService = .getTransactions(config: session.config, server: session.server, address: address, startBlock: startBlock, endBlock: endBlock, sortOrder: sortOrder)
-
         return firstly {
             alphaWalletProvider.request(target)
         }.map(on: queue) { response -> [Promise<TransactionInstance?>] in
+            if response.statusCode == 404 {
+                //Clearer than a JSON deserialization error when it's a 404
+                enum E: Error {
+                    case statusCode404
+                }
+                throw E.statusCode404
+            }
             return try response.map(ArrayResponse<RawTransaction>.self).result.map {
                 TransactionInstance.from(transaction: $0, tokensStorage: tokensStorage, tokenProvider: tokenProvider)
             }


### PR DESCRIPTION
Don't say it's because of deserialization.

Before PR:

> main() server: custom(AlphaWallet.CustomRPC(chainID: 2, nativeCryptoTokenName: Optional("Unnamed"), chainName: "a", symbol: Optional("EXP"), rpcEndpoint: "https://node.expanse.tech", explorerEndpoint: Optional("https://expanse.tech"), etherscanCompatibleType: AlphaWallet.RPCServer.EtherscanCompatibleType.unknown, isTestnet: true)) address: 0x97446491E282EC33CEB6f114D88aaFA40FdEc4e6 objectMapping(Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "JSON text did not start with array or object and option to allow fragments not set." UserInfo={NSDebugDescription=JSON text did not start with array or object and option to allow fragments not set.}))), Status Code: 404, Data Length: 41626) from: error(value:pref:function:rpcServer:address:)

After PR:

> main() server: custom(AlphaWallet.CustomRPC(chainID: 2, nativeCryptoTokenName: Optional("Expanse Network Ether"), chainName: "Expanse Network", symbol: Optional("EXP"), rpcEndpoint: "https://node.expanse.tech", explorerEndpoint: Optional("https://expanse.tech"), etherscanCompatibleType: AlphaWallet.RPCServer.EtherscanCompatibleType.unknown, isTestnet: false)) address: 0xbbce83173d5c1D122AE64856b4Af0D5AE07Fa362 statusCode404 from: error(value:pref:function:rpcServer:address:)
