### PR TITLE
New build instructions and makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ AlphaWalletTests/Snapshots/FailureDiffs
 
 # Additions
 .idea/
+/.bundle
+/vendor

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,67 @@
-.DEFAULT_GOAL := bootstrap
+bundle_cmd = /usr/bin/Bundle
+vendor_path = ./vendor/bundle
 
-exists_pod = $(shell command -v pod 2> /dev/null)
+all: target
+	@echo "Please specify a target. Please use 'make target' to show targets."
 
-install_env:
+target:
+	@echo "install_gems : install or update all the required gems."
+	@echo "install_pods : install or update all the cocoapods."
+	@echo "install_all  : install gems then pods."
+	@echo "check_gems   : check to see if all the gems in the Gemfile are installed in the vendor directory."
+	@echo "bootstrap    : same as make install_all"
+	@echo "update_pods  : update all the cocoapods."
 
-ifeq "${exists_pod}" ""
-	sudo gem install cocoapods
-endif
+check_bundle:
+	@$(bundle_cmd) --version 1>/dev/null 2>/dev/null; \
+	if [ $$? -ne 0 ]; then \
+		echo "Bundle does not exist. Please install bundle."; \
+		exit 1; \
+	fi
 
-	@echo "All dependencies was installed"
+check_gems: check_bundle
+	@$(bundle_cmd) check --gemfile=./Gemfile --path=$(vendor_path); \
+	if [ $$? -eq 0 ]; then \
+		echo "All gems installed."; \
+	else \
+		echo "Some or all gemfiles have not been installed. Please use 'make install_gems'."; \
+		exit 1; \
+	fi
 
-install:
+install_gems: check_bundle
+	@$(bundle_cmd) install --path=$(vendor_path); \
+	if [ $$? -ne 0 ]; then \
+		echo "Error installing."; \
+		exit 1; \
+	else \
+		echo "All gems installed."; \
+	fi
 
-ifeq "${exists_pod}" ""
-	@echo "Cocopods is not installed. Use `make install_env`"
-endif
+install_pods: check_gems
+	@$(bundle_cmd) exec pod install --repo-update; \
+	if [ $$? -eq 0 ]; then \
+		echo "All pods installed."; \
+	else \
+		echo "Error installing."; \
+		exit 1; \
+	fi
 
-	pod install --repo-update
+update_pods: check_gems
+	@$(bundle_cmd) exec pod update; \
+	if [ $$? -eq 0 ]; then \
+		echo "All pods updated."; \
+	else \
+		echo "Error updating."; \
+		exit 1; \
+	fi
 
-bootstrap: install
+bootstrap: install_all
+
+install_all: install_gems install_pods
+
+clean:
+	rm -rf $(vendor_path)
+	rm -rf ./Pods/*
 
 release:
 	fastlane release

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ We want to give businesses the whitelabel tools they need to develop their ether
 1. [Download  Xcode 13](https://developer.apple.com/download/more/)
 2. Clone this repository
 3. Run `make bootstrap` to install tools and dependencies.
+4. Open the AlphaWallet.xcworkspace file to begin.
+
+If you get a "Bundle does not exist. Please install bundle." error, please consult with your macOS guru because a vital part of your system is missing.
+
+This makefile has been tested to run on "Monterey"-12.0.1. It will not work on "Catalina" or "Big Sur".
+
+### Updating GemFile or Podfile
+
+After the Gemfile is updated, run `make install_gems` to update the gems in the vendor/bundle directory.
+
+After the Podfile is updated, run `make install_pods` or `make update_pods` to update the pods in the Pods directory.
 
 ### Add your token to AlphaWallet
 


### PR DESCRIPTION
Closes #3486

# New makefile instructions
I rewrote the Makefile. In a new installation, use `make bootstrap` to set up the gems and pods. 

## Commands
`make`, `make target` - Lists all the useful targets in the makefile.
`make clean` - Remove all files in the `Pods` and `vendor/bundle` directories.
`make install_gems` - Install all the gems listed in the Gemfile into the `vendor/bundle` directory.
`make install_pods` - Install all the pods listed in the Podfile into the `Pods` directory. This command uses the cocoapod binary installed via `make install_gems` otherwise we will get a version conflict in the `Podfile.lock` file.
`make install_all` - Perform `make install_gems` followed by `make install_pods`.
`make bootstrap` - Same as make install_all.

## Testing
1. In the command line, change to the root directory of the project.
2. Type "make clean".
3. Type "make install_pods".
4. **Expects** "*** [check_gems] Error 1", make fails.
5. Open Xcode and build the project.
6. **Expects** build to fail.
7. In the command line, type "make install_all".
8. In Xcode, build the project and run the tests. 
9. **Expects** build and tests to succeed.
10. In the command line, type "make clean".
11. Type "make install_gems".
12. **Expects** make to succeed.
13. Type "make install_pods".
14. **Expects** make to succeed.

### Optional

15. In Xcode, try to build the project and run the tests. 
16. **Expects** build and tests to succeed.
