### PR TITLE
Added code to indicate rpc url error

### DIFF
--- a/AlphaWallet/Settings/Coordinators/SaveCustomRpcCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/SaveCustomRpcCoordinator.swift
@@ -33,6 +33,7 @@ class SaveCustomRpcCoordinator: NSObject, Coordinator {
     private let restartQueue: RestartTaskQueue
     private let analyticsCoordinator: AnalyticsCoordinator
     private let operation: SaveOperationType
+    private var viewController: SaveCustomRpcViewController?
     var coordinators: [Coordinator] = []
     weak var delegate: SaveCustomRpcCoordinatorDelegate?
 
@@ -47,6 +48,7 @@ class SaveCustomRpcCoordinator: NSObject, Coordinator {
     func start() {
         let viewModel = SaveCustomRpcViewModel(model: operation.customRpc)
         let viewController = SaveCustomRpcViewController(viewModel: viewModel)
+        self.viewController = viewController
         viewController.delegate = self
         setNaviationTitle(viewController: viewController)
         navigationController.pushViewController(viewController, animated: true)
@@ -99,6 +101,12 @@ extension SaveCustomRpcCoordinator: AddCustomChainDelegate {
         let alertController = UIAlertController.alertController(title: R.string.localizable.error(), message: error.message, style: .alert, in: navigationController)
         alertController.addAction(UIAlertAction(title: R.string.localizable.oK(), style: .default, handler: nil))
         navigationController.present(alertController, animated: true, completion: nil)
+    }
+
+    func notifyRpcURlHostnameFailure() {
+        DispatchQueue.main.async {
+            self.viewController?.handleRpcUrlFailure()
+        }
     }
 }
 

--- a/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SaveCustomRpcViewController.swift
@@ -49,6 +49,11 @@ class SaveCustomRpcViewController: UIViewController {
         keyboardChecker.viewWillDisappear()
     }
 
+    func handleRpcUrlFailure() {
+        editView.rpcEndPointTextField.status = .error(R.string.localizable.addrpcServerRpcUrlError())
+        editView.rpcEndPointTextField.becomeFirstResponder()
+    }
+    
     private func configure() {
         editView.chainNameTextField.value = viewModel.chainName
         editView.chainNameTextField.delegate = self


### PR DESCRIPTION
Fixes: #3482

## Pre testing
1. Delete the "expanse network" if it exists.
2. On the main screen, tap "settings", then "select active networks".

## Testing
1. Tap the + button in the upper right corner.
2. **Expects** to see "Add Custom RPC Network" screen.
3. Type "Expanse network" into the Network Name text field.
4. Type "https://node.expanse.tect" into the RPC URL text field.
5. Type "2" into the Chain ID text field.
6. Type "EXP" into the Symbol text field.
7. Type "https://expanse.tech" into the Block Explorer URL text field.
8. Tap the "Save network" button.
9. **Expects** RPC URL text field to be highlighted in red with "RPC URL is invalid" under the text field.
