### PR TITLE
Refactor: Extract code to access Fiat On-ramp

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 		5E7C786AD8E4877C36D3B14A /* TokenAdaptorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C775FD95FE80B0F1CEA33 /* TokenAdaptorTest.swift */; };
 		5E7C786DB5B71302FF66CBAD /* SendTransactionErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BB7DBFDF5A5E4F2DDC0 /* SendTransactionErrorViewModel.swift */; };
 		5E7C7883FB31565411F7C928 /* NonFungibleFromJsonTokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78EBC7D0A09B8EAACBE3 /* NonFungibleFromJsonTokenType.swift */; };
+		5E7C788C6ACB6E5AA24216A6 /* FiatOnRampCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7AF60DF9E7FBD2933C32 /* FiatOnRampCoordinator.swift */; };
 		5E7C788C8830A7CF05B9189A /* OpenSea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C0CFD047ED7C488FB45 /* OpenSea.swift */; };
 		5E7C7896E99049F4B124FDF5 /* OpenSeaNonFungibleTokenDisplayHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7A9876B43B1D9D17A9A9 /* OpenSeaNonFungibleTokenDisplayHelper.swift */; };
 		5E7C78A31A16600FBA5C9956 /* ScanQRCodeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7721E0E4D4EFDD35E196 /* ScanQRCodeCoordinator.swift */; };
@@ -1529,6 +1530,7 @@
 		5E7C7AE608A39793F8BA3911 /* Eip681Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Eip681Parser.swift; sourceTree = "<group>"; };
 		5E7C7AE6FAE0DF969B4F52E9 /* ContactUsBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsBannerView.swift; sourceTree = "<group>"; };
 		5E7C7AEDAAE638601C7122A5 /* DefaultActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultActivityView.swift; sourceTree = "<group>"; };
+		5E7C7AF60DF9E7FBD2933C32 /* FiatOnRampCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FiatOnRampCoordinator.swift; sourceTree = "<group>"; };
 		5E7C7AF9A592D7224ED58016 /* OnboardingPageStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingPageStyle.swift; sourceTree = "<group>"; };
 		5E7C7B06D3FBE83BBC00555F /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		5E7C7B080E387A79058430B9 /* ConfirmSignMessageTableViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfirmSignMessageTableViewCellViewModel.swift; sourceTree = "<group>"; };
@@ -2167,6 +2169,7 @@
 				5E7C72373620D0B5825AA69C /* Gas */,
 				5E7C7651253551EB14A26F7C /* Donations */,
 				5E7C7F1CC5699A58ED5D4E74 /* WhatsNew */,
+				5E7C74F0A1BB877A6FE35F37 /* FiatOnRamp */,
 			);
 			path = AlphaWallet;
 			sourceTree = "<group>";
@@ -3575,6 +3578,14 @@
 			path = Analytics;
 			sourceTree = "<group>";
 		};
+		5E7C74F0A1BB877A6FE35F37 /* FiatOnRamp */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C75962E846E6696B07C20 /* Coordinators */,
+			);
+			path = FiatOnRamp;
+			sourceTree = "<group>";
+		};
 		5E7C75019080D822E6BE9E92 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3608,6 +3619,14 @@
 				5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		5E7C75962E846E6696B07C20 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C7AF60DF9E7FBD2933C32 /* FiatOnRampCoordinator.swift */,
+			);
+			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		5E7C75F7FC107AE3CF396331 /* TokenScriptClient */ = {
@@ -6208,6 +6227,7 @@
 				5E7C7CC1E06FFC3A5BEBF1EC /* WhatsNewViews.swift in Sources */,
 				5E7C71967C34DD3F207F8126 /* WhatsNewExperimentCoordinator.swift in Sources */,
 				5E7C7062A44AF416B110008A /* PingInfuraCoordinator.swift in Sources */,
+				5E7C788C6ACB6E5AA24216A6 /* FiatOnRampCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
+++ b/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
@@ -185,4 +185,11 @@ enum Analytics {
     enum HelpUrl: String {
         case insufficientFunds
     }
+
+    enum FiatOnRampSource: String {
+        case token
+        case transactionActionSheetInsufficientFunds
+        case speedupTransactionInsufficientFunds
+        case cancelTransactionInsufficientFunds
+    }
 }

--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -16,6 +16,7 @@ protocol DappBrowserCoordinatorDelegate: class, CanOpenURL {
     func handleCustomUrlScheme(_ url: URL, forCoordinator coordinator: DappBrowserCoordinator)
     func restartToAddEnableAndSwitchBrowserToServer(inCoordinator coordinator: DappBrowserCoordinator)
     func restartToEnableAndSwitchBrowserToServer(inCoordinator coordinator: DappBrowserCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: DappBrowserCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 final class DappBrowserCoordinator: NSObject, Coordinator {
@@ -475,6 +476,10 @@ extension DappBrowserCoordinator: TransactionConfirmationCoordinatorDelegate {
             strongSelf.removeCoordinator(coordinator)
             strongSelf.navigationController.dismiss(animated: true)
         }
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/FiatOnRamp/Coordinators/FiatOnRampCoordinator.swift
+++ b/AlphaWallet/FiatOnRamp/Coordinators/FiatOnRampCoordinator.swift
@@ -1,0 +1,40 @@
+// Copyright © 2021 Stormbird PTE. LTD.
+
+import UIKit
+
+protocol FiatOnRampCoordinatorDelegate: AnyObject, CanOpenURL {
+}
+
+class FiatOnRampCoordinator: Coordinator {
+    private let wallet: Wallet
+    private let server: RPCServer
+    private let sourceViewController: UIViewController
+    private let source: Analytics.FiatOnRampSource
+    private let analyticsCoordinator: AnalyticsCoordinator
+
+    var coordinators: [Coordinator] = []
+    weak var delegate: FiatOnRampCoordinatorDelegate?
+
+    init(wallet: Wallet, server: RPCServer, viewController: UIViewController, source: Analytics.FiatOnRampSource, analyticsCoordinator: AnalyticsCoordinator) {
+        self.wallet = wallet
+        self.server = server
+        self.sourceViewController = viewController
+        self.source = source
+        self.analyticsCoordinator = analyticsCoordinator
+    }
+
+    func start() {
+        let ramp = Ramp(account: wallet)
+        if let url = ramp.url(token: TokenActionsServiceKey(tokenObject: TokensDataStore.etherToken(forServer: server))) {
+            FiatOnRampCoordinator.logStartOnRamp(name: "Ramp", source: source, analyticsCoordinator: analyticsCoordinator)
+            delegate?.didPressOpenWebPage(url, in: sourceViewController)
+        } else {
+            let fallbackUrl = URL(string: "https://alphawallet.com/browser-item-category/utilities/")!
+            delegate?.didPressOpenWebPage(fallbackUrl, in: sourceViewController)
+        }
+    }
+
+    static func logStartOnRamp(name: String, source: Analytics.FiatOnRampSource, analyticsCoordinator: AnalyticsCoordinator) {
+        analyticsCoordinator.log(navigation: Analytics.Navigation.onRamp, properties: [Analytics.Properties.name.rawValue: name, Analytics.Properties.source.rawValue: source.rawValue])
+    }
+}

--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -800,17 +800,27 @@ class InCoordinator: NSObject, Coordinator {
             showPaymentFlow(for: .request, server: config.anyEnabledServer(), navigationController: navigationController)
         }
     }
+
+    private func openFiatOnRamp(wallet: Wallet, server: RPCServer, inViewController viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        let coordinator = FiatOnRampCoordinator(wallet: wallet, server: server, viewController: viewController, source: source, analyticsCoordinator: analyticsCoordinator)
+        coordinator.delegate = self
+        coordinator.start()
+    }
 }
 
 // swiftlint:enable type_body_length
 extension InCoordinator: WalletConnectCoordinatorDelegate {
+    func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: TransactionConfirmationCoordinator) {
+        handlePendingTransaction(transaction: transaction)
+    }
+
     func universalScannerSelected(in coordinator: WalletConnectCoordinator) {
         tokensCoordinator?.launchUniversalScanner(fromSource: .walletScreen)
     }
 
-    func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: WalletConnectCoordinator) {
-        handlePendingTransaction(transaction: transaction)
-    }
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: .transactionActionSheetInsufficientFunds)
+    } 
 }
 
 extension InCoordinator: CanOpenURL {
@@ -1078,6 +1088,10 @@ extension InCoordinator: TokensCoordinatorDelegate {
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: TokensCoordinator) {
         handlePendingTransaction(transaction: transaction)
     }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
+    }
 }
 
 extension InCoordinator: PaymentCoordinatorDelegate {
@@ -1106,6 +1120,13 @@ extension InCoordinator: PaymentCoordinatorDelegate {
 
         removeCoordinator(coordinator)
     }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: PaymentCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
+    }
+}
+
+extension InCoordinator: FiatOnRampCoordinatorDelegate {
 }
 
 extension InCoordinator: DappBrowserCoordinatorDelegate {
@@ -1131,6 +1152,10 @@ extension InCoordinator: DappBrowserCoordinatorDelegate {
 
     func restartToEnableAndSwitchBrowserToServer(inCoordinator coordinator: DappBrowserCoordinator) {
         processRestartQueueAndRestartUI()
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: DappBrowserCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
     }
 }
 
@@ -1176,6 +1201,10 @@ extension InCoordinator: ClaimOrderCoordinatorDelegate {
         claimOrderCoordinatorCompletionBlock?(true)
         claimOrderCoordinatorCompletionBlock = nil
         removeCoordinator(coordinator)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: ClaimPaidOrderCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
     }
 }
 
@@ -1226,6 +1255,10 @@ extension InCoordinator: ReplaceTransactionCoordinatorDelegate {
         case .sentRawTransaction, .signedTransaction:
             break
         }
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: ReplaceTransactionCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
     }
 }
 

--- a/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
@@ -12,6 +12,7 @@ protocol ClaimOrderCoordinatorDelegate: class, CanOpenURL {
     func coordinator(_ coordinator: ClaimPaidOrderCoordinator, didFailTransaction error: AnyError)
     func didClose(in coordinator: ClaimPaidOrderCoordinator)
     func coordinator(_ coordinator: ClaimPaidOrderCoordinator, didCompleteTransaction result: TransactionConfirmationResult)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: ClaimPaidOrderCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class ClaimPaidOrderCoordinator: Coordinator {
@@ -223,6 +224,10 @@ extension ClaimPaidOrderCoordinator: TransactionConfirmationCoordinatorDelegate 
             strongSelf.delegate?.coordinator(strongSelf, didCompleteTransaction: .confirmationResult(result))
         }
         removeCoordinator(coordinator)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/SingleChainTokenCoordinator.swift
@@ -23,6 +23,7 @@ protocol SingleChainTokenCoordinatorDelegate: class, CanOpenURL {
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: SingleChainTokenCoordinator)
     func didTapAddAlert(for tokenObject: TokenObject, in cordinator: SingleChainTokenCoordinator)
     func didTapEditAlert(for tokenObject: TokenObject, alert: PriceAlert, in cordinator: SingleChainTokenCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: SingleChainTokenCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 // swiftlint:disable type_body_length
@@ -624,6 +625,10 @@ extension SingleChainTokenCoordinator: TokensCardCoordinatorDelegate {
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: TokensCardCoordinator) {
         delegate?.didPostTokenScriptTransaction(transaction, in: self)
     }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCardCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
+    }
 }
 
 extension SingleChainTokenCoordinator: TokenViewControllerDelegate {
@@ -723,6 +728,10 @@ extension SingleChainTokenCoordinator: TransactionConfirmationCoordinatorDelegat
 
             coordinator.start()
         }
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -13,6 +13,7 @@ protocol TokensCoordinatorDelegate: class, CanOpenURL {
     func openConsole(inCoordinator coordinator: TokensCoordinator)
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: TokensCoordinator)
     func blockieSelected(in coordinator: TokensCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 private struct NoContractDetailsDetected: Error {
@@ -533,6 +534,10 @@ extension TokensCoordinator: SingleChainTokenCoordinatorDelegate {
 
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: SingleChainTokenCoordinator) {
         delegate?.didPostTokenScriptTransaction(transaction, in: self)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: SingleChainTokenCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
     }
 }
 

--- a/AlphaWallet/Tokens/ViewControllers/Collectibles/Coordinators/TokensCardCollectionCoordinator.swift
+++ b/AlphaWallet/Tokens/ViewControllers/Collectibles/Coordinators/TokensCardCollectionCoordinator.swift
@@ -15,6 +15,7 @@ import BigInt
 protocol TokensCardCollectionCoordinatorDelegate: class, CanOpenURL {
     func didCancel(in coordinator: TokensCardCollectionCoordinator)
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: TokensCardCollectionCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCardCollectionCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class TokensCardCollectionCoordinator: NSObject, Coordinator {
@@ -359,6 +360,10 @@ extension TokensCardCollectionCoordinator: TransferNFTCoordinatorDelegate {
             coordinator.start()
         }
     }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransferNFTCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
+    }
 }
 
 extension TokensCardCollectionCoordinator: SetTransferTokensCardExpiryDateViewControllerDelegate {
@@ -499,6 +504,10 @@ extension TokensCardCollectionCoordinator: TransactionConfirmationCoordinatorDel
 
             coordinator.start()
         }
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -348,6 +348,6 @@ extension TokenViewController: ActivitiesPageViewDelegate {
 // MARK: Analytics
 extension TokenViewController {
     private func logStartOnRamp(name: String) {
-        analyticsCoordinator.log(navigation: Analytics.Navigation.onRamp, properties: [Analytics.Properties.name.rawValue: name])
+        FiatOnRampCoordinator.logStartOnRamp(name: name, source: .token, analyticsCoordinator: analyticsCoordinator)
     }
 }

--- a/AlphaWallet/Transactions/Coordinators/ReplaceTransactionCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/ReplaceTransactionCoordinator.swift
@@ -7,6 +7,7 @@ import Result
 protocol ReplaceTransactionCoordinatorDelegate: class, CanOpenURL {
     func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: ReplaceTransactionCoordinator)
     func didFinish(_ result: ConfirmResult, in coordinator: ReplaceTransactionCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: ReplaceTransactionCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class ReplaceTransactionCoordinator: Coordinator {
@@ -145,6 +146,17 @@ extension ReplaceTransactionCoordinator: TransactionConfirmationCoordinatorDeleg
 
     func didClose(in coordinator: TransactionConfirmationCoordinator) {
         removeCoordinator(coordinator)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        let source: Analytics.FiatOnRampSource
+        switch mode {
+        case .speedup:
+            source = .speedupTransactionInsufficientFunds
+        case .cancel:
+            source = .cancelTransactionInsufficientFunds
+        }
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
     }
 }
 

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -15,6 +15,7 @@ import BigInt
 protocol TokensCardCoordinatorDelegate: class, CanOpenURL {
     func didCancel(in coordinator: TokensCardCoordinator)
     func didPostTokenScriptTransaction(_ transaction: SentTransaction, in coordinator: TokensCardCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCardCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 // swiftlint:disable type_body_length
@@ -588,6 +589,10 @@ extension TokensCardCoordinator: TransferNFTCoordinatorDelegate {
             coordinator.start()
         }
     }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransferNFTCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
+    }
 }
 
 extension TokensCardCoordinator: GenerateSellMagicLinkViewControllerDelegate {
@@ -753,6 +758,10 @@ extension TokensCardCoordinator: TransactionConfirmationCoordinatorDelegate {
 
             coordinator.start()
         }
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/PaymentCoordinator.swift
@@ -7,6 +7,7 @@ protocol PaymentCoordinatorDelegate: class, CanOpenURL {
     func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: PaymentCoordinator)
     func didFinish(_ result: ConfirmResult, in coordinator: PaymentCoordinator)
     func didCancel(in coordinator: PaymentCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: PaymentCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class PaymentCoordinator: Coordinator {
@@ -112,6 +113,10 @@ extension PaymentCoordinator: SendCoordinatorDelegate {
     func didCancel(in coordinator: SendCoordinator) {
         removeCoordinator(coordinator)
         cancel()
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: SendCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: source)
     }
 }
 

--- a/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendCoordinator.swift
@@ -8,6 +8,7 @@ protocol SendCoordinatorDelegate: class, CanOpenURL {
     func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: SendCoordinator)
     func didFinish(_ result: ConfirmResult, in coordinator: SendCoordinator)
     func didCancel(in coordinator: SendCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: SendCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class SendCoordinator: Coordinator {
@@ -164,6 +165,10 @@ extension SendCoordinator: TransactionConfirmationCoordinatorDelegate {
 
     func didClose(in coordinator: TransactionConfirmationCoordinator) {
         removeCoordinator(coordinator)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 

--- a/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransferNFTCoordinator.swift
@@ -7,6 +7,7 @@ import Result
 protocol TransferNFTCoordinatorDelegate: class, CanOpenURL {
     func didClose(in coordinator: TransferNFTCoordinator)
     func didCompleteTransfer(withTransactionConfirmationCoordinator transactionConfirmationCoordinator: TransactionConfirmationCoordinator, result: TransactionConfirmationResult, inCoordinator coordinator: TransferNFTCoordinator)
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransferNFTCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 }
 
 class TransferNFTCoordinator: Coordinator {
@@ -72,6 +73,10 @@ extension TransferNFTCoordinator: TransactionConfirmationCoordinatorDelegate {
 
     func didFinish(_ result: ConfirmResult, in coordinator: TransactionConfirmationCoordinator) {
         delegate?.didCompleteTransfer(withTransactionConfirmationCoordinator: coordinator, result: .confirmationResult(result), inCoordinator: self)
+    }
+
+    func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TransactionConfirmationCoordinator, viewController: UIViewController) {
+        delegate?.openFiatOnRamp(wallet: wallet, server: server, inCoordinator: self, viewController: viewController, source: .transactionActionSheetInsufficientFunds)
     }
 }
 


### PR DESCRIPTION
This refactor is to enable us to call up Fiat On-Ramp (current the ramp.network webpage) in other places. In the future we might replace it with a native UI.

~@vladyslav-iosdev would you help to implement the part marked with `//hhh1`?~

~No idea how to do it for transaction sending initiated with WalletConnect~