### PR TITLE
Fixed ModalViewController dismissal animation missing from WhatsNewListingViewController.

### DIFF
--- a/AlphaWallet/WhatsNew/ViewControllers/WhatsNewListingViewController.swift
+++ b/AlphaWallet/WhatsNew/ViewControllers/WhatsNewListingViewController.swift
@@ -45,7 +45,8 @@ extension WhatsNewListingViewController: ModalViewControllerDelegate {
     }
 
     func didClose(_ controller: ModalViewController) {
-        controller.dismiss(animated: true)
-        whatsNewListingDelegate?.didDismiss(controller: self)
+        controller.dismissViewAnimated {
+            self.whatsNewListingDelegate?.didDismiss(controller: self)
+        }
     }
 }


### PR DESCRIPTION
Fixes #3493

The ModalViewController required it's own dismissal function instead of the standard one.