### PR TITLE
Added workaround for Makefile problems on M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ target:
 	@echo "install_all  : install gems then pods."
 	@echo "check_gems   : check to see if all the gems in the Gemfile are installed in the vendor directory."
 	@echo "bootstrap    : same as make install_all"
-	@echo "update_pods  : update all the cocoapods."
 
 check_bundle:
 	@$(bundle_cmd) --version 1>/dev/null 2>/dev/null; \
@@ -38,20 +37,11 @@ install_gems: check_bundle
 	fi
 
 install_pods: check_gems
-	@$(bundle_cmd) exec pod install --repo-update; \
+	@$(bundle_cmd) exec pod install; \
 	if [ $$? -eq 0 ]; then \
 		echo "All pods installed."; \
 	else \
 		echo "Error installing."; \
-		exit 1; \
-	fi
-
-update_pods: check_gems
-	@$(bundle_cmd) exec pod update; \
-	if [ $$? -eq 0 ]; then \
-		echo "All pods updated."; \
-	else \
-		echo "Error updating."; \
 		exit 1; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ This makefile has been tested to run on "Monterey"-12.0.1. It will not work on "
 
 After the Gemfile is updated, run `make install_gems` to update the gems in the vendor/bundle directory.
 
-After the Podfile is updated, run `make install_pods` or `make update_pods` to update the pods in the Pods directory.
+After the Podfile is updated, run `make install_pods` to update the pods in the Pods directory.
+
+### M1 Macs
+
+Currently, the project cannot run under simulators on M1 Macs. You can however run the code on your device.
 
 ### Add your token to AlphaWallet
 


### PR DESCRIPTION
Fixes #3506

## Testing
1. On an M1 Mac, type `make clean && make bootstrap` in the root directory of the project. 
2. **Expects** The gems and pods to be installed. 
3. Open the AlphaWallet.xcworkspace file and set the target to your physical device. Select run.
4. **Expects** the app to be compiled, installed, and running on your physical device.

## Workaround
The problem appears to occur when pod update or any variation of it is called. The work around simply removes or modifies all makefile targets which invokes it.