### PR TITLE
Support contract deployment gas limit estimation

### DIFF
--- a/AlphaWallet/EtherClient/Requests/EstimateGasRequest.swift
+++ b/AlphaWallet/EtherClient/Requests/EstimateGasRequest.swift
@@ -7,8 +7,22 @@ import BigInt
 struct EstimateGasRequest: JSONRPCKit.Request {
     typealias Response = String
 
+    enum TransactionType {
+        case normal(to: AlphaWallet.Address)
+        case contractDeployment
+    }
+
+    private var to: AlphaWallet.Address? {
+        switch transactionType {
+        case .normal(let to):
+            return to
+        case .contractDeployment:
+            return nil
+        }
+    }
+
     let from: AlphaWallet.Address
-    let to: AlphaWallet.Address
+    let transactionType: TransactionType
     let value: BigInt
     let data: Data
 
@@ -18,14 +32,16 @@ struct EstimateGasRequest: JSONRPCKit.Request {
 
     var parameters: Any? {
         //Explicit type declaration to speed up build time. 160msec -> <100ms, as of Xcode 11.7
-        let results: [[String: String]] = [
+        var results: [[String: String]] = [
             [
                 "from": from.description,
-                "to": to.eip55String,
                 "value": "0x" + String(value, radix: 16),
                 "data": data.hexEncoded,
             ],
         ]
+        if let to: AlphaWallet.Address = to {
+            results[0]["to"] = to.eip55String
+        }
         return results
     }
 

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -152,6 +152,7 @@ class TransactionConfigurator {
         firstly {
             Session.send(EtherServiceRequest(server: session.server, batch: BatchFactory().create(request)))
         }.done { gasLimit in
+            info("Estimated gas limit with eth_estimateGas: \(gasLimit)")
             let gasLimit: BigInt = {
                 let limit = BigInt(gasLimit.drop0x, radix: 16) ?? BigInt()
                 if limit == GasLimitConfiguration.minGasLimit {
@@ -159,6 +160,7 @@ class TransactionConfigurator {
                 }
                 return min(limit + (limit * 20 / 100), GasLimitConfiguration.maxGasLimit)
             }()
+            info("Using gas limit: \(gasLimit)")
             var customConfig = self.configurations.custom
             customConfig.setEstimated(gasLimit: gasLimit)
             self.configurations.custom = customConfig
@@ -176,6 +178,7 @@ class TransactionConfigurator {
 
             self.delegate?.gasLimitEstimateUpdated(to: gasLimit, in: self)
         }.catch { e in
+            info("Error estimating gas limit: \(e)")
             error(value: e, rpcServer: self.session.server)
         }
     }

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -136,10 +136,15 @@ class TransactionConfigurator {
     }
 
     private func estimateGasLimit() {
-        guard let toAddress = toAddress else { return }
+        let transactionType: EstimateGasRequest.TransactionType
+        if let toAddress = toAddress {
+            transactionType = .normal(to: toAddress)
+        } else {
+            transactionType = .contractDeployment
+        }
         let request = EstimateGasRequest(
             from: session.account.address,
-            to: toAddress,
+            transactionType: transactionType,
             value: value,
             data: currentConfiguration.data
         )
@@ -170,9 +175,9 @@ class TransactionConfigurator {
             }
 
             self.delegate?.gasLimitEstimateUpdated(to: gasLimit, in: self)
-        }.catch({ e in
+        }.catch { e in
             error(value: e, rpcServer: self.session.server)
-        })
+        }
     }
 
     private func estimateGasPrice() {

--- a/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
+++ b/AlphaWallet/Transfer/Types/GasLimitConfiguration.swift
@@ -6,5 +6,6 @@ import BigInt
 public struct GasLimitConfiguration {
     static let defaultGasLimit = BigInt(90_000)
     static let minGasLimit = BigInt(21_000)
-    static let maxGasLimit = BigInt(1_000_000)
+    //TODO make max be 1M unless for contract deployment then bigger, maybe 2M
+    static let maxGasLimit = BigInt(2_000_000)
 }


### PR DESCRIPTION
Before the PR, because contract deployment transactions do not include a `to` address, `eth_estimateGas` calls aren't made for estimating the gas limit. PR enables it.

In addition, the hardcoded gas limit maximum of 1M is too low for contract deployment. This PR changes it to 2M. Ideally we should enforce 2 limits, a lower (1M) limit for non-deployments; leave it as a TODO.