### PR TITLE
Do not show What's New after wallet creation as it crashes with the back up prompt

### DIFF
--- a/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
+++ b/AlphaWallet/Wallet/Coordinators/WalletCoordinator.swift
@@ -87,6 +87,9 @@ class WalletCoordinator: Coordinator {
             guard let strongSelf = self else { return }
             switch result {
             case .success(let account):
+                //Not the best implementation, since there's some coupling, but it's clean. We need this so we don't show the What's New UI right after a wallet is created and clash with the pop up prompting user to back up the new wallet, for new installs and creating new wallets for existing installs
+                WhatsNewExperimentCoordinator.lastCreatedWalletTimestamp = Date()
+
                 let wallet = Wallet(type: WalletType.real(account))
                 //Bit of delay to wait for the UI animation to almost finish
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {

--- a/AlphaWallet/WhatsNew/Coordinators/WhatsNewExperimentCoordinator.swift
+++ b/AlphaWallet/WhatsNew/Coordinators/WhatsNewExperimentCoordinator.swift
@@ -8,6 +8,9 @@ protocol WhatsNewExperimentCoordinatorDelegate: AnyObject {
 
 class WhatsNewExperimentCoordinator: Coordinator {
     static private let key = "experiments.whatsnew.1"
+    static private let walletLastCreatedWindowSkipWhatsNew = TimeInterval(3)
+
+    static var lastCreatedWalletTimestamp: Date?
 
     private let navigationController: UINavigationController
     private let viewModel = HelpUsViewModel()
@@ -34,6 +37,10 @@ class WhatsNewExperimentCoordinator: Coordinator {
     }
 
     func start() {
+        //We don't want to show the user What's New right after a wallet is created (not imported) because this will crash with the UI which we used to prompt users to back up the new wallet
+        if let lastCreatedWalletTimestamp = Self.lastCreatedWalletTimestamp, Date().timeIntervalSince(lastCreatedWalletTimestamp) < Self.walletLastCreatedWindowSkipWhatsNew {
+            return
+        }
         guard !hasRan else {
             delegate?.didEnd(in: self)
             return


### PR DESCRIPTION
i.e. fix #3502 so it doesn't clash with the following:

<img width="487" alt="Screenshot 2021-12-13 at 1 54 11 PM" src="https://user-images.githubusercontent.com/56189/145760660-435f2e16-6438-4375-91d3-72740e070df1.png">
 