### PR TITLE
Fixed code on Wallet main screen that crashed when token row was swiped to delete

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -613,11 +613,12 @@ extension TokensViewController: UITableViewDataSource {
             let hideAction = UIContextualAction(style: .destructive, title: title) { [weak self] (_, _, completion) in
                 guard let strongSelf = self else { return }
 
+                let deletedIndexPathArray = strongSelf.viewModel.indexPathArrayForDeletingAt(indexPath: indexPath)
                 strongSelf.delegate?.didHide(token: token, in: strongSelf)
 
                 let didHideToken = strongSelf.viewModel.markTokenHidden(token: token)
                 if didHideToken {
-                    strongSelf.tableView.deleteRows(at: [indexPath], with: .automatic)
+                    strongSelf.tableView.deleteRows(at: deletedIndexPathArray, with: .automatic)
                 } else {
                     strongSelf.reloadTableData()
                 }

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -234,7 +234,54 @@ class TokensViewModel {
             return nil
         }
     }
+
+    func indexPathArrayForDeletingAt(indexPath current: IndexPath) -> [IndexPath] {
+        let canRemoveCurrentItem: Bool  = item(for: current.row, section: current.section).isRemovable
+        let canRemovePreviousItem: Bool = current.row > 0 ? item(for: current.row - 1, section: current.section).isRemovable : false
+        let canRemoveNextItem: Bool = {
+            guard (current.row + 1) < filteredTokens.count else { return false }
+            return item(for: current.row + 1, section: current.section).isRemovable
+        }()
+        switch (canRemovePreviousItem, canRemoveCurrentItem, canRemoveNextItem) {
+            // Truth table for deletion
+            // previous, current, next
+            // 0, 0, 0
+            // return []
+            // 0, 0, 1
+            // return []
+            // 0, 1, 0
+            // return [current.previous, current]
+            // 0, 1, 1
+            // return [current]
+            // 1, 0, 0
+            // return []
+            // 1, 0, 1
+            // return []
+            // 1, 1, 0
+            // return [current]
+            // 1, 1, 1
+            // return [current]
+        case (_, false, _):
+            return []
+        case (false, true, false):
+            return [current.previous, current]
+        default:
+            return [current]
+        }
+    }
 }
+
+fileprivate extension TokenObjectOrRpcServerPair {
+    var isRemovable: Bool {
+        switch self {
+        case .rpcServer:
+            return false
+        case .tokenObject:
+            return true
+        }
+    }
+}
+
 
 fileprivate extension WalletFilter {
     static var orderedTabs: [WalletFilter] {
@@ -306,5 +353,11 @@ extension TokensViewModel.functional {
                 return true
             }
         }
+    }
+}
+
+fileprivate extension IndexPath {
+    var previous: IndexPath {
+        IndexPath(row: row - 1, section: section)
     }
 }


### PR DESCRIPTION
Fixes #3537.

## Prerequisites
You need some items to display on the Wallet main screen. Add some if you have none.
## Testing
1. Swipe left on a token displayed in the Wallet main screen.
2. **Expects** delete icon "X" appears.
3. Tap on "X".
4. **Expects** deleted token disappears from Wallet main screen.

![Screen Shot 2021-12-15 at 7 32 28 AM copy](https://user-images.githubusercontent.com/1050309/146096278-7926788c-9fc4-4393-9ed8-d70950c811fb.png)

## Side note:
The token rows displayed on the view controller consists of an array of `TokenObjectOrRpcServerPair` objects. `TokenObject` is used to represent a token while `RpcServerPair` is used to represent the header. We need to consider a minimum of 3 rows (previous to the swiped row, the swiped row, next to the swiped row) in order to determine the outcome. If a row does not exist, it is treated as Not removable. If the row is a `RpcServerPair`, the row is treated as Not removable. If the row is a `TokenObject`, it is treated as removable for this case,

| Previous | Current | Next | Outcome | Notes |
| --- | --- | --- | --- | --- |
| Not removable | Not removable | Not removable | Don't remove | Possibly an error condition but we do some defensive programming |
| Not removable | Not removable | Removable | Don't remove | Possibly an error condition but we do some defensive programming |
| Not removable | Removable | Not removable | Remove Previous and Current | The only token row in the section |
| Not removable | Removable | Removable | Remove Current | First row in a section with two or more token rows |
| Removable | Not removable | Not removable | Don't remove | Possibly an error condition but we do some defensive programming |
| Removable | Not removable | Removable | Don't remove | Possibly an error condition but we do some defensive programming|
| Removable | Removable | Not removable | Remove Current | Last row in a section with two or more token rows |
| Removable | Removable | Removable | Remove Current | Not the first or last row in a section with two or more token rows |

We cannot use 2 rows to determine the outcome. A not removable followed by a removable row can indicate one of two outcomes (remove current row or remove previous and current row) as you can see in the table above.
