### PR TITLE
Removed redundant chevron from WalletSummaryTableViewCell

### DIFF
--- a/AlphaWallet/Accounts/Views/WalletSummaryTableViewCell.swift
+++ b/AlphaWallet/Accounts/Views/WalletSummaryTableViewCell.swift
@@ -36,6 +36,6 @@ class WalletSummaryTableViewCell: UITableViewCell {
         backgroundColor = viewModel.backgroundColor
         summaryView.configure(viewModel: viewModel)
 
-        accessoryView = Style.AccessoryView.chevron
+        accessoryType = .none
     }
 }


### PR DESCRIPTION
Closes #3557

![Simulator Screen Shot - iPhone 12 - 2021-12-16 at 15 36 21 copy](https://user-images.githubusercontent.com/1050309/146328425-844ac24e-5031-4d73-b5ed-ce84dd261d84.png)

