### PR TITLE
Changed the default uitableview colour separators, uinavigation bar shadow image, uitabbar shadow image to colour mercury

### DIFF
--- a/AlphaWallet/Style/AppStyle.swift
+++ b/AlphaWallet/Style/AppStyle.swift
@@ -7,6 +7,8 @@ func applyStyle() {
     UIBarButtonItem.appearance(whenContainedInInstancesOf: [UIDocumentBrowserViewController.self]).tintColor = Colors.navigationButtonTintColor
     UIWindow.appearance().tintColor = Colors.appTint
     UITabBar.appearance().tintColor = Colors.appTint
+    UITabBar.appearance().shadowImage = UIImage(color: Style.TabBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
+    UITabBar.appearance().backgroundImage = UIImage(color: Style.TabBar.Background.color)
     UINavigationBar.appearance().barTintColor = R.color.white()!
     UINavigationBar.appearance().backIndicatorImage = R.image.backWhite()
     UINavigationBar.appearance().backIndicatorTransitionMaskImage = R.image.backWhite()
@@ -18,7 +20,7 @@ func applyStyle() {
         .foregroundColor: Colors.navigationTitleColor,
         .font: Fonts.bold(size: 36) as Any,
     ]
-
+    UINavigationBar.appearance().shadowImage = UIImage(color: Style.NavigationBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
     // NOTE: Fixes iOS 15 navigation bar black background
     if #available(iOS 15.0, *) {
         let appearance = UINavigationBarAppearance()
@@ -68,6 +70,8 @@ func applyStyle() {
     UIRefreshControl.appearance().tintColor = Colors.navigationTitleColor
 
     UISwitch.appearance().onTintColor = Colors.appTint
+
+    UITableView.appearance().separatorColor = Style.TableView.Separator.color
 }
 
 func applyStyle(viewController: UIViewController) {
@@ -356,6 +360,35 @@ enum Style {
                 imageView.heightAnchor.constraint(equalToConstant: 24.0)
             ])
             return imageView
+        }
+    }
+    enum TableView {
+        enum Separator {
+            static let color: UIColor = R.color.mercury()!
+        }
+    }
+    enum TabBar {
+        enum Background {
+            static let color: UIColor = {
+                if #available(iOS 13.0, *) {
+                    return UIColor.systemBackground
+                } else {
+                    return R.color.white()!
+                }
+            }()
+        }
+        enum Separator {
+            static let color: UIColor = R.color.mercury()!
+        }
+    }
+    enum SegmentedControl {
+        enum Separator {
+            static let color: UIColor = R.color.mercury()!
+        }
+    }
+    enum NavigationBar {
+        enum Separator {
+            static let color: UIColor = R.color.mercury()!
         }
     }
 }

--- a/AlphaWallet/Tokens/ViewModels/SegmentedControlViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/SegmentedControlViewModel.swift
@@ -46,7 +46,8 @@ struct SegmentedControlViewModel {
 	}
 
 	var unselectedBarColor: UIColor {
-		return R.color.alto()!
+        return Style.SegmentedControl.Separator.color
+		// return R.color.alto()!
 	}
 
 	var selectedBarColor: UIColor {


### PR DESCRIPTION
Closes #3524

I'm not sure how to verify this. What I did was make the colours Yellow instead of Mercury and the changes showed up on the simulator. Now that I've changed them all to Mercury I can't tell the difference between any of the lines. @colourfreak 

![Simulator Screen Shot - iPhone 12 - 2021-12-16 at 16 30 53 copy](https://user-images.githubusercontent.com/1050309/146337400-be0d1c60-6a1d-443b-bbbd-5dbaff9f388e.png)
Screen 1

![Simulator Screen Shot - iPhone 12 - 2021-12-16 at 16 31 07 copy](https://user-images.githubusercontent.com/1050309/146337421-0757abd5-93f9-429e-8731-d9e7be87ee2f.png)
Screen 2

![Simulator Screen Shot - iPhone 12 - 2021-12-16 at 16 31 25 copy](https://user-images.githubusercontent.com/1050309/146337423-2741bc69-8c69-4940-a233-dc32b4a38621.png)
Screen 3
