### PR TITLE
Add backend support for 24-word seed phrases. Not enabled in UI

### DIFF
--- a/AlphaWalletTests/Core/Types/HDWalletTest.swift
+++ b/AlphaWalletTests/Core/Types/HDWalletTest.swift
@@ -5,22 +5,40 @@ import XCTest
 import WalletCore
 
 class HDWalletTest: XCTestCase {
-    func testComputeSeedFromEnglishMnemonic() {
+    private func _testComputeSeedFromEnglishMnemonic(seedPhraseCount: HDWallet.SeedPhraseCount) {
         let emptyPassphrase = ""
-        for _ in 1...100 {
-            let wallet1 = HDWallet(strength: 128, passphrase: emptyPassphrase)
+        for _ in 1...1000 {
+            let wallet1 = HDWallet(strength: seedPhraseCount.strength, passphrase: emptyPassphrase)!
             let seed = HDWallet.computeSeedWithChecksum(fromSeedPhrase: wallet1.mnemonic)
-            let wallet2 = HDWallet(seed: seed, passphrase: emptyPassphrase)
+            let wallet2 = HDWallet(seed: seed, passphrase: emptyPassphrase)!
             XCTAssertEqual(wallet1.mnemonic, wallet2.mnemonic)
         }
     }
 
-    func testComputeSeedFromSpecificEnglishMnemonic() {
+    func testComputeSeedFromEnglish12WordMnemonic() {
+        let seedPhraseCount: HDWallet.SeedPhraseCount = .word12
+        _testComputeSeedFromEnglishMnemonic(seedPhraseCount: seedPhraseCount)
+    }
+
+    func testComputeSeedFromEnglish24WordMnemonic() {
+        let seedPhraseCount: HDWallet.SeedPhraseCount = .word24
+        _testComputeSeedFromEnglishMnemonic(seedPhraseCount: seedPhraseCount)
+    }
+
+    func testComputeSeedFromSpecificEnglish12WordMnemonic() {
         let emptyPassphrase = ""
         //This seed phrase is known to generate the wrong seed phrase when computed from its seed if we do it wrongly, as: spoon spy hungry put siren harbor echo trumpet olympic ordinary alert orient
         let seedPhrase = "artwork essay plunge priority hold repair lounge write situate clap call border"
         let seed = HDWallet.computeSeedWithChecksum(fromSeedPhrase: seedPhrase)
-        let wallet = HDWallet(seed: seed, passphrase: emptyPassphrase)
+        let wallet = HDWallet(seed: seed, passphrase: emptyPassphrase)!
+        XCTAssertEqual(seedPhrase, wallet.mnemonic)
+    }
+
+    func testComputeSeedFromSpecificEnglish24WordMnemonic() {
+        let emptyPassphrase = ""
+        let seedPhrase = "lawsuit rib market click repair require used frog universe label shoot message dad range bonus guitar table long bronze honey mountain plunge virus lunch"
+        let seed = HDWallet.computeSeedWithChecksum(fromSeedPhrase: seedPhrase)
+        let wallet = HDWallet(seed: seed, passphrase: emptyPassphrase)!
         XCTAssertEqual(seedPhrase, wallet.mnemonic)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,7 @@ target 'AlphaWallet' do
   pod 'PromiseKit/CorePromise'
   pod 'PromiseKit/Alamofire'
   pod "Kanna", :git => 'https://github.com/tid-kijyun/Kanna.git', :commit => '06a04bc28783ccbb40efba355dee845a024033e8'
-  pod 'TrustWalletCore', '2.3.3'
+  pod 'TrustWalletCore', '2.6.34'
   pod 'AWSSNS', '2.18.0'
   pod 'Mixpanel-swift', '2.8.0'
   pod 'UnstoppableDomainsResolution', '0.1.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -100,11 +100,11 @@ PODS:
     - CryptoSwift (~> 1.0)
     - secp256k1_ios (~> 0.1.0)
     - TrezorCrypto
-  - TrustWalletCore (2.3.3):
-    - TrustWalletCore/Core (= 2.3.3)
-  - TrustWalletCore/Core (2.3.3):
+  - TrustWalletCore (2.6.34):
+    - TrustWalletCore/Core (= 2.6.34)
+  - TrustWalletCore/Core (2.6.34):
     - TrustWalletCore/Types
-  - TrustWalletCore/Types (2.3.3):
+  - TrustWalletCore/Types (2.6.34):
     - SwiftProtobuf
   - UnstoppableDomainsResolution (0.1.6):
     - Base58Swift (~> 2.1)
@@ -156,7 +156,7 @@ DEPENDENCIES:
   - SwiftyJSON (= 5.0.0)
   - TrezorCrypto (from `https://github.com/AlphaWallet/trezor-crypto-ios.git`, commit `50c16ba5527e269bbc838e80aee5bac0fe304cc7`)
   - TrustKeystore (from `https://github.com/alpha-wallet/trust-keystore.git`, commit `c0bdc4f6ffc117b103e19d17b83109d4f5a0e764`)
-  - TrustWalletCore (= 2.3.3)
+  - TrustWalletCore (= 2.6.34)
   - UnstoppableDomainsResolution (= 0.1.6)
   - WalletConnectSwift (from `https://github.com/WalletConnect/WalletConnectSwift.git`)
   - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `cce12b1c421f18b5768e5249a8343932737a51fe`)
@@ -312,11 +312,11 @@ SPEC CHECKSUMS:
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   TrezorCrypto: bfeea47a052dca2c77d4a39e1e183865e52de14d
   TrustKeystore: 3d8b4571c66648fb985015c96b3185440bb837fe
-  TrustWalletCore: 84a87886e55b4efa875b452926d3ba58a32359c8
+  TrustWalletCore: a92d85baa15932279cce925559e93695558cafdd
   UnstoppableDomainsResolution: dc89a8d9e51f3786b46274b457875a231d5bdbb8
   WalletConnectSwift: 046ae74e8cb69445be9c94c66ef66f9cb019b68f
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
 
-PODFILE CHECKSUM: 72f2302e77abc5d59a96eff57825e918889327a1
+PODFILE CHECKSUM: bb392f12f7e9a8a473a0ffc8b19dda73b8c1104f
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
Offer support for implementing #3447.

No functional change introduced but:

* Updated TrustWalletCore
* Backend can handle (store, read, sign with) wallets created with 24-word seed phrases
* Can import 24-word seed phrases, but the UI doesn't enable this yet
* Added tests for wallets using 12-word and 24-word seed phrases

@oa-s this is a delicated part of the system; would you help to test this?

At least this:

* Test signing with existing wallets that were imported prior to this PR, that are 12-word seed phrases
* Create new wallet (12-words)
* Import private key-based wallet
* Import 12-words seed phrase
* Test signing