### PR TITLE
The "<N> <Symbol>" subtitle under collection in Wallet tab Collectible sub-tab is clipped off at the bottom #3599

### DIFF
--- a/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/OpenSea/OpenSeaNonFungibleTokenViewCell.swift
@@ -38,8 +38,8 @@ class OpenSeaNonFungibleTokenView: UIView {
             background.anchorsConstraint(to: self, edgeInsets: .zero),
 
             stackView.anchorsConstraint(to: background),
-            imageHolder.widthAnchor.constraint(equalTo: imageHolder.heightAnchor),
             imageView.anchorsConstraint(to: imageHolder),
+            textsStackView.heightAnchor.constraint(equalToConstant: 40)
         ])
         translatesAutoresizingMaskIntoConstraints = false
     }


### PR DESCRIPTION
Closes #3599