### PR TITLE
Fix: Token icons should be rounded

### DIFF
--- a/AlphaWallet/UI/TokenImageView.swift
+++ b/AlphaWallet/UI/TokenImageView.swift
@@ -92,5 +92,10 @@ class TokenImageView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        imageView.cornerRadius = bounds.width / 2
+    }
 }
 


### PR DESCRIPTION
Compare the ENS token icon:

Before PR|After PR
-|-
<img width="443" alt="Screenshot 2022-01-03 at 1 28 15 PM" src="https://user-images.githubusercontent.com/56189/147901881-ade52da0-4053-41b0-b748-966d7d7d3111.png">|<img width="443" alt="Screenshot 2022-01-03 at 1 29 00 PM" src="https://user-images.githubusercontent.com/56189/147901886-89575d14-dc8d-45b9-b342-406ab5ea3537.png">
