### PR TITLE
Overlay chain icons in-app instead of using preprocessed token icons with the overlay

### DIFF
--- a/AlphaWallet/Style/AppStyle.swift
+++ b/AlphaWallet/Style/AppStyle.swift
@@ -158,6 +158,8 @@ enum Metrics {
             static let shadowColor = UIColor.black
         }
     }
+
+    static let tokenChainOverlayDimension = CGFloat(16)
 }
 
 enum GroupedTable {

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -227,7 +227,7 @@ extension TokensCoordinator: TokensViewControllerDelegate {
     func whereAreMyTokensSelected(in viewController: UIViewController) {
         delegate?.whereAreMyTokensSelected(in: self)
     }
-    
+
     private func getWalletName() {
         let viewModel = tokensViewController.viewModel
 
@@ -509,7 +509,7 @@ extension TokensCoordinator: EditPriceAlertCoordinatorDelegate {
 }
 
 extension TokensCoordinator: SingleChainTokenCoordinatorDelegate {
-    
+
     func didSendTransaction(_ transaction: SentTransaction, inCoordinator coordinator: TransactionConfirmationCoordinator) {
         delegate?.didSendTransaction(transaction, inCoordinator: coordinator)
     }

--- a/AlphaWallet/UI/TokenImageView.swift
+++ b/AlphaWallet/UI/TokenImageView.swift
@@ -37,6 +37,10 @@ class TokenImageView: UIView {
         let imageView = WebImageView()
         return imageView
     }()
+    private lazy var chainOverlayImageView: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
 
     private var tokenImagePlaceholder: UIImage? {
         return R.image.tokenPlaceholderLarge()
@@ -51,6 +55,7 @@ class TokenImageView: UIView {
             if let subscribable = subscribable {
                 if subscribable.value == nil {
                     imageView.setImage(url: nil, placeholder: tokenImagePlaceholder)
+                    chainOverlayImageView.image = nil
                 }
 
                 subscriptionKey = subscribable.subscribe { [weak self] imageAndSymbol in
@@ -63,6 +68,7 @@ class TokenImageView: UIView {
                     case .none:
                         strongSelf.imageView.setImage(url: nil, placeholder: strongSelf.tokenImagePlaceholder)
                     }
+                    strongSelf.chainOverlayImageView.image = imageAndSymbol?.overlayServerIcon
                     strongSelf.symbolLabel.text = imageAndSymbol?.symbol ?? ""
                 }
             } else {
@@ -79,6 +85,9 @@ class TokenImageView: UIView {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(imageView)
 
+        chainOverlayImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(chainOverlayImageView)
+
         symbolLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(symbolLabel)
 
@@ -86,6 +95,10 @@ class TokenImageView: UIView {
             symbolLabel.anchorsConstraint(to: imageView),
 
             imageView.anchorsConstraint(to: self, edgeInsets: edgeInsets),
+            chainOverlayImageView.leftAnchor.constraint(equalTo: imageView.leftAnchor, constant: 0),
+            chainOverlayImageView.bottomAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 0),
+            chainOverlayImageView.widthAnchor.constraint(equalToConstant: Metrics.tokenChainOverlayDimension),
+            chainOverlayImageView.heightAnchor.constraint(equalTo: chainOverlayImageView.widthAnchor),
         ])
     }
 

--- a/AlphaWallet/UI/TokenImageView.swift
+++ b/AlphaWallet/UI/TokenImageView.swift
@@ -92,5 +92,10 @@ class TokenImageView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        imageView.cornerRadius = bounds.width / 2
+    }
 }
 

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -106,7 +106,7 @@ class AmountTextField: UIControl {
             case .cryptoCurrency(let tokenObject):
                 return tokenObject.icon
             case .usd:
-                return .init((image: .image(R.image.usaFlag()!), symbol: "", isFinal: true))
+                return .init((image: .image(R.image.usaFlag()!), symbol: "", isFinal: true, overlayServerIcon: nil))
             }
         }
     }


### PR DESCRIPTION
Closes #3542

Contains commit in #3626. With this PR, the chain icon overlay on the token icons are generated in the app. A fork of the token icons without the preprocessed overlay icons in https://github.com/AlphaWallet/iconassets/tree/with-chain-overlay-removed are used. The native tokens on each chain do not show the chain overlay.

Once both iOS and Android app implements this PR and have rolled out sufficiently, we can update `iconassets` repo's `master` branch with `with-chain-overlay-removed` and switch both apps back to accessing `master`.

<img width="443" alt="Screenshot 2022-01-03 at 1 51 57 PM" src="https://user-images.githubusercontent.com/56189/147902784-8f0c9e80-14d7-42a9-a137-ef8b0616ea64.png">

