### PR TITLE
Added canDelete check to prevent TokensViewController from deleting native tokens

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -571,7 +571,9 @@ extension TokensViewController: UITableViewDataSource {
     }
 
     private func trailingSwipeActionsConfiguration(forRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        switch viewModel.item(for: indexPath.row, section: indexPath.section) {
+        let item = viewModel.item(for: indexPath.row, section: indexPath.section)
+        guard item.canDelete else { return nil }
+        switch item {
         case .rpcServer:
             return nil
         case .tokenObject(let token):


### PR DESCRIPTION
Fixes: #3537
Closes: #3547

**Testing**
1. Delete the AlphaWallet app.
2. Install a new copy of AlphaWallet.
3. Run AlphaWallet and create a wallet.

**Expects**
4. User to be on the Wallet screen.

**Testing**
5. Tap on the ellipses (…) in the upper trailing edge corner.
6. Tap Add/Hide tokens.
7. Add any 3 popular tokens.
8. Tap the back arrow in the upper leading edge corner.

**Expects**
9. User to be on the Wallet screen. The added tokens are listed in the Wallet screen.

**Testing**
10. Swipe to delete one of the 3 added tokens. Tap the X to delete the token.

**Expects**
11. Token to be deleted.

**Testing**
12. Swipe on Ethereum/xDai/Polygon Mainnet.

**Expects**
13. Nothing to happen. 


