### PR TITLE
Update CODEOWNERS file to specify delicate parts of system

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @hboon @oa-s
+/AlphaWallet/Core/Initializers/ @hboon
+/AlphaWallet/KeyManagement/ @hboon


### PR DESCRIPTION
Useful when we remove the first line and thus default reviewers for most files:

> * @hboon @oa-s