### PR TITLE
Fixed show/hide navigationBarTopSeparatorLine functions, removed gray line under navigation bar of TokensCardViewController, consolidated UINavigationBar appearance code in applyStyle function #3765

### DIFF
--- a/AlphaWallet/Style/AppStyle.swift
+++ b/AlphaWallet/Style/AppStyle.swift
@@ -9,23 +9,12 @@ func applyStyle() {
     UITabBar.appearance().tintColor = Colors.appTint
     UITabBar.appearance().shadowImage = UIImage(color: Style.TabBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
     UITabBar.appearance().backgroundImage = UIImage(color: Style.TabBar.Background.color)
-    UINavigationBar.appearance().barTintColor = R.color.white()!
-    UINavigationBar.appearance().backIndicatorImage = R.image.backWhite()
-    UINavigationBar.appearance().backIndicatorTransitionMaskImage = R.image.backWhite()
-    UINavigationBar.appearance().titleTextAttributes = [
-        .foregroundColor: Colors.navigationTitleColor,
-        .font: Fonts.semibold(size: 17) as Any
-    ]
-    UINavigationBar.appearance().largeTitleTextAttributes = [
-        .foregroundColor: Colors.navigationTitleColor,
-        .font: Fonts.bold(size: 36) as Any,
-    ]
     UINavigationBar.appearance().shadowImage = UIImage(color: Style.NavigationBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
-    // NOTE: Fixes iOS 15 navigation bar black background
-    if #available(iOS 15.0, *) {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = R.color.white()!
+        appearance.shadowColor = Style.NavigationBar.Separator.color
+        appearance.shadowImage = nil
         appearance.setBackIndicatorImage(R.image.backWhite(), transitionMaskImage: R.image.backWhite())
         appearance.titleTextAttributes = [
             .foregroundColor: R.color.black()!,
@@ -35,13 +24,10 @@ func applyStyle() {
             .foregroundColor: R.color.black()!,
             .font: Fonts.bold(size: 36) as Any,
         ]
+        UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
-    } else {
-        // Fallback on earlier versions
-    }
 
-    if #available(iOS 13.0, *) {
         //NOTE: Hides back button text
         let titleTextAttributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.clear
@@ -49,9 +35,6 @@ func applyStyle() {
         UINavigationBar.appearance().standardAppearance.backButtonAppearance.normal.titleTextAttributes = titleTextAttributes
         UINavigationBar.appearance().compactAppearance?.backButtonAppearance.normal.titleTextAttributes = titleTextAttributes
         UINavigationBar.appearance().scrollEdgeAppearance?.backButtonAppearance.normal.titleTextAttributes = titleTextAttributes
-    } else {
-        // Fallback on earlier versions
-    }
 
     //We could have set the backBarButtonItem with an empty title for every view controller, but we don't have a place to do it for Eureka view controllers. Using appearance here, while a hack is still more convenient though, since we don't have to do it for every view controller instance
     UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffset(horizontal: -200, vertical: 0), for: .default)

--- a/AlphaWallet/Tokens/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
@@ -121,11 +121,13 @@ class TokensCardCollectionViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         keyboardChecker.viewWillAppear()
+        hideNavigationBarTopSeparatorLine()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         keyboardChecker.viewWillDisappear()
+        showNavigationBarTopSeparatorLine()
     }
 
     func configure(viewModel value: TokensCardCollectionViewControllerViewModel? = .none) {

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -107,11 +107,13 @@ class TokensCardViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         keyboardChecker.viewWillAppear()
+        hideNavigationBarTopSeparatorLine()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         keyboardChecker.viewWillDisappear()
+        showNavigationBarTopSeparatorLine()
     }
 
     override func viewDidLoad() {

--- a/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
@@ -106,14 +106,22 @@ class SeedPhraseBackupIntroductionViewController: UIViewController {
 
 extension UIViewController {
     func hideNavigationBarTopSeparatorLine() {
-        navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
-        navigationController?.navigationBar.shadowImage = UIImage()
-        navigationController?.navigationBar.layoutIfNeeded()
+        guard let navigationBar = navigationController?.navigationBar else { return }
+        let appearance = navigationBar.standardAppearance
+        appearance.shadowColor = .clear
+        appearance.shadowImage = nil
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
+        navigationBar.standardAppearance = appearance
     }
 
     func showNavigationBarTopSeparatorLine() {
-        navigationController?.navigationBar.setBackgroundImage(nil, for: .default)
-        navigationController?.navigationBar.shadowImage = nil
-        navigationController?.navigationBar.layoutIfNeeded()
+        guard let navigationBar = navigationController?.navigationBar else { return }
+        let appearance = navigationBar.standardAppearance
+        appearance.shadowColor = Style.NavigationBar.Separator.color
+        appearance.shadowImage = nil
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
+        navigationBar.standardAppearance = appearance
     }
 }


### PR DESCRIPTION
Closes #3765

This

![image](https://user-images.githubusercontent.com/1050309/150622366-c46782dd-bbe9-49c0-ab9e-c520ece04591.png)

And

![image](https://user-images.githubusercontent.com/1050309/150622402-674ee1a2-aa8f-4ef4-ab69-1e3ce2aefc53.png)
