### PR TITLE
Changed font attributes for token value in EthTokenViewCell #3766

### DIFF
--- a/AlphaWallet/Style/AppStyle.swift
+++ b/AlphaWallet/Style/AppStyle.swift
@@ -93,7 +93,7 @@ struct Colors {
     static let navigationTitleColor = UIColor.black
     static let navigationButtonTintColor = R.color.mine()!
     static let appWhite = UIColor.white
-    static let appText = UIColor(red: 47, green: 47, blue: 47)
+    static let appText = R.color.black()!
     static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)
     static let appHighlightGreen = UIColor(red: 117, green: 185, blue: 67)
     static let appActionButtonGreen = UIColor(red: 105, green: 200, blue: 0)
@@ -311,7 +311,7 @@ enum Screen {
             static let blockChainName = Fonts.semibold(size: 12)
             static let valueChangeLabel = Fonts.regular(size: 15)
             static let placeholderLabel = Fonts.regular(size: 17)
-            static let valueChangeValue = Fonts.semibold(size: 17)
+            static let valueChangeValue = Fonts.semibold(size: 20)
         }
 
         enum Color {

--- a/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
+++ b/AlphaWallet/Tokens/Views/EthTokenViewCell.swift
@@ -117,7 +117,7 @@ class EthTokenViewCell: UITableViewCell {
             tokenIconImageView.heightAnchor.constraint(equalToConstant: 40),
             tokenIconImageView.widthAnchor.constraint(equalToConstant: 40),
             row1.heightAnchor.constraint(greaterThanOrEqualToConstant: 20),
-            stackView.anchorsConstraint(to: background, edgeInsets: .init(top: 12, left: 20, bottom: 16, right: 12)),
+            stackView.anchorsConstraint(to: background, edgeInsets: .init(top: 12, left: 16, bottom: 15, right: 16)),
             background.anchorsConstraint(to: contentView)
         ])
     }


### PR DESCRIPTION
Closes #3766

I cannot get the line height to be 34 as it throws the entire horizontal alignment off (unless I redo the layout of the EthTokenViewCell).
![Simulator Screen Shot - iPhone 12 - 2022-01-22 at 15 58 02 copy](https://user-images.githubusercontent.com/1050309/150630154-14d84b80-cc4a-49dc-bbc2-006576dc1129.png)

<img width="720" alt="Screenshot 2022-01-22 at 3 56 45 PM copy" src="https://user-images.githubusercontent.com/1050309/150630134-d05b5497-a636-4541-a4de-f287c4b74ea0.png">

