### PR TITLE
Turn on Preserve Vector Data in the pdf. #3762

### DIFF
--- a/AlphaWallet/Assets.xcassets/HT-HECO mainnet.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/HT-HECO mainnet.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/HT-HECO testnet.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/HT-HECO testnet.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/activityFailed.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/activityFailed.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/activityPending.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/activityPending.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/activityReceive.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/activityReceive.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/activitySend.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/activitySend.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/add_hide_tokens.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/add_hide_tokens.imageset/Contents.json
@@ -19,6 +19,7 @@
     "version" : 1
   },
   "properties" : {
+      "preserves-vector-representation" : true,
     "template-rendering-intent" : "original"
   }
 }

--- a/AlphaWallet/Assets.xcassets/arbitrum.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/arbitrum.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/awLogoSmall.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/awLogoSmall.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/backWhite.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/backWhite.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/backupCircle.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/backupCircle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/biometric-lock.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/biometric-lock.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/biometrics.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/biometrics.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/browse.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/browse.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/calendar.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/calendar.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/category.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/category.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/changeWallet.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/changeWallet.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/close.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/close.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/conversionDaiSai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/conversionDaiSai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/cooldown.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/cooldown.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/copy.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/copy.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/developerMode.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/developerMode.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/eth-small.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/eth-small.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/eth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/eth.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/expand.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/expand.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/expandMore.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/expandMore.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/gasWarning.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/gasWarning.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/generation.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/generation.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/group.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/group.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/hd-introduction.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/hd-introduction.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/hideToken.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/hideToken.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/history.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/history.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-settings-eden.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-settings-eden.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-settings-ethermine.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-settings-ethermine.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-0-x.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-0-x.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-aave.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-aave.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-bat.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-bat.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-busd.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-busd.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-dai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-dai.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-enj.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-enj.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-knc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-knc.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-lend.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-lend.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-link.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-link.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-mana.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-mana.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-mkr.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-mkr.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-rep.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-rep.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-sai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-sai.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-snx.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-snx.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-susd.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-susd.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-tusd.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-tusd.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-uni-link-eth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-uni-link-eth.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-usdc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-usdc.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-usdt.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-usdt.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-wbtc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-wbtc.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-weth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-weth.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/icons-tokens-a-yfi.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/icons-tokens-a-yfi.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsCheckmark.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsCheckmark.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsIllustrationsAlert2.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsIllustrationsAlert2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsIllustrationsEmptyWalletConnect.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsIllustrationsEmptyWalletConnect.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsIllustrationsSearchResults.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsIllustrationsSearchResults.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsDiscord.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsDiscord.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsDisplayedEns.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsDisplayedEns.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsEmail.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsEmail.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsGithub.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsGithub.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsSeed2.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsSeed2.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSettingsWalletConnect.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSettingsWalletConnect.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemAddBorderCircle.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemAddBorderCircle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemCircleMinue.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemCircleMinue.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemDown.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemDown.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemExpandMore.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemExpandMore.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemGrid.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemGrid.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemHome.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemHome.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemList.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemList.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemPlus.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemPlus.imageset/Contents.json
@@ -19,6 +19,7 @@
     "version" : 1
   },
   "properties" : {
+      "preserves-vector-representation" : true,
     "template-rendering-intent" : "original"
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsSystemUp.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsSystemUp.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensAvalanche.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensAvalanche.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensEthereumTestnet.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensEthereumTestnet.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensFantom.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensFantom.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensOptimistic.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensOptimistic.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensOptimisticKovan.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensOptimisticKovan.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/iconsTokensPolygon.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/iconsTokensPolygon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/info_accessory.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/info_accessory.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/light.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/light.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/location.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/location.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/more.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/more.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/myDapps.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/myDapps.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/networksCircle.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/networksCircle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/not_expand.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/not_expand.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/notificationsCircle.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/notificationsCircle.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/onboarding_complete.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/onboarding_complete.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/onboarding_contact.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/onboarding_contact.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/openSeaNonFungibleAttribute.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/openSeaNonFungibleAttribute.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/openSeaNonFungibleButtonArrow.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/openSeaNonFungibleButtonArrow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/pending.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/pending.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/plus.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/plus.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/price_down.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/price_down.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/price_up.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/price_up.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/qrRounded.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/qrRounded.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/qrRoundedWhite.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/qrRoundedWhite.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/qr_code_icon.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/qr_code_icon.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/received.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/received.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/sent.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/sent.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_analytics.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_analytics.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_clear_dapp_cache.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_clear_dapp_cache.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_console.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_console.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_currency.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_currency.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_facebook.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_facebook.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_faq.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_faq.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_language.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_language.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_reddit.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_reddit.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_telegram.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_telegram.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_tokenscript_overrides.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_tokenscript_overrides.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/settings_twitter.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/settings_twitter.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/statement.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/statement.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/successOverlay.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/successOverlay.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/support.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/support.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/tab_browser.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/tab_browser.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/tab_settings.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/tab_settings.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/tab_transactions.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/tab_transactions.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/tab_wallet.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/tab_wallet.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/ticket.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/ticket.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/ticket_bundle_checked.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/ticket_bundle_checked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/ticket_bundle_unchecked.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/ticket_bundle_unchecked.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/toggle-password.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/toggle-password.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-artis.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-artis.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-bnb.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-bnb.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-callisto.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-callisto.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-cdai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-cdai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-cofi.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-cofi.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-cofix.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-cofix.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-dai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-dai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-eos.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-eos.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-etc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-etc.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-idai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-idai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-link.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-link.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-nest.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-nest.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-pbtc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-pbtc.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-pdai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-pdai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-peos.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-peos.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-peth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-peth.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-pltc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-pltc.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-poa.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-poa.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-psai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-psai.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-pusdt.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-pusdt.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sada.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sada.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-saud.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-saud.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sbtc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sbtc.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-schf.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-schf.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sdefi.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sdefi.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-seth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-seth.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-seur.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-seur.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sgbp.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sgbp.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sjpy.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sjpy.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-slink.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-slink.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sltc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sltc.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-snikkei.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-snikkei.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-susd.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-susd.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sxau.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sxau.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sxmr.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sxmr.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-sxtz.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-sxtz.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-teo.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-teo.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-usdc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-usdc.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-wbtc.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-wbtc.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/token-weth.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/token-weth.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/tokenPlaceholderLarge.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/tokenPlaceholderLarge.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/toolbar-back.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/toolbar-back.imageset/Contents.json
@@ -19,6 +19,7 @@
     "version" : 1
   },
   "properties" : {
+      "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/AlphaWallet/Assets.xcassets/toolbar-forward.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/toolbar-forward.imageset/Contents.json
@@ -19,6 +19,7 @@
     "version" : 1
   },
   "properties" : {
+      "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/AlphaWallet/Assets.xcassets/toolbar-menu.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/toolbar-menu.imageset/Contents.json
@@ -19,6 +19,7 @@
     "version" : 1
   },
   "properties" : {
+      "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/AlphaWallet/Assets.xcassets/transaction-accessory.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/transaction-accessory.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/unverified.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/unverified.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/usaFlag.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/usaFlag.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/verified.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/verified.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/walletAddress.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/walletAddress.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/walletConnect-icon.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/walletConnect-icon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/white.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/white.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }

--- a/AlphaWallet/Assets.xcassets/xDai.imageset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/xDai.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+      "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
[issues3762](https://github.com/AlphaWallet/alpha-wallet-ios/issues/3762)

closes #3762

## problem
In the pdf, PreserveVectorData was turned on in 7 cases, while it was turned off in 176 cases.

## try
In order to eliminate human error, I created a program to correct the preserve_vector_data of the pdf to be on.
In order to turn preserve_vector_data on, it was necessary to add the following property values to Contents.json, which is associated with the corresponding image, so the program was created to add them.

```
"properties" : {
    "preserves-vector-representation" : true
 }
```


I place it in alpha-wallet-ios/AlphaWallet/Assets.xcassets/search_pdf.py and ran that program and turned on PreserveVectorData for all the pdfs, there are 183 of them.

## Test Results
Of course, I checked everything visually and made sure PreserveVectorData was turned on in the pdf image.

※ search_pdf.py is not included in the commit.

Here is the program
```python
import os
from pathlib import Path

def updatePreserveVectorDataExistProperties(filePath):
    read_path = Path(filePath)
    content = read_path.read_text()

    # replace
    content = content.replace(
'''
  },
  "properties" : {
''',
'''
  },
  "properties" : {
      "preserves-vector-representation" : true
'''
)
    # write
    read_path.write_text(content)

def updatePreserveVectorData(filePath):
    read_path = Path(filePath)
    content = read_path.read_text()

    # replace
    content = content.replace(
'''
  },
  "properties" : {
''',
'''
  },
  "properties" : {
      "preserves-vector-representation" : true,
'''
)


    # replace
    content = content.replace(
'''
  "info" : {
    "author" : "xcode",
    "version" : 1
  }
''',
'''
  "info" : {
    "author" : "xcode",
    "version" : 1
  },
  "properties" : {
      "preserves-vector-representation" : true
  }
'''
)

    content = content.replace(
'''
  "info" : {
    "version" : 1,
    "author" : "xcode"
  }
''',
'''
  "info" : {
    "version" : 1,
    "author" : "xcode"
  },
  "properties" : {
      "preserves-vector-representation" : true
  }
'''
)
  
    # write
    read_path.write_text(content)

preserve_vector_data_on_pdf_count = 0
preserve_vector_data_off_pdf_count = 0
for files in os.listdir("./"):
    if os.path.isdir(files):
        for file in os.listdir("./" + files):
            base, ext = os.path.splitext(file)
            if ext == '.pdf':
                with open("./" + files + "/Contents.json") as f:
                    if '"preserves-vector-representation" : true' in f.read():
                        preserve_vector_data_on_pdf_count += 1
                    elif '"properties" : {' in f.read():
                        preserve_vector_data_off_pdf_count += 1
                        updatePreserveVectorDataExistProperties("./" + files + "/Contents.json")
                        print("./" + files + "/Contents.json") # preserves-vector-representation" : false ファイル
                    else:
                        preserve_vector_data_off_pdf_count += 1
                        updatePreserveVectorData("./" + files + "/Contents.json")
                        print("./" + files + "/Contents.json") # preserves-vector-representation" : false ファイル

print("::: preserve_vector_data_off_pdf_count : ", preserve_vector_data_off_pdf_count)
print(":::::: preserve_vector_data_on_pdf_count", preserve_vector_data_on_pdf_count)


```