### PR TITLE
Prevent "." from being entered in ChainIDTextField of SaveCustomRpcManualEntryViewController

### DIFF
--- a/AlphaWallet/Settings/ViewControllers/SaveCustomRpcManualEntryViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SaveCustomRpcManualEntryViewController.swift
@@ -171,6 +171,12 @@ extension SaveCustomRpcManualEntryViewController: TextFieldDelegate {
         //no-op
     }
 
+    func shouldChangeCharacters(inRange range: NSRange, replacementString string: String, for textField: TextField) -> Bool {
+        if textField == editView.chainIDTextField {
+            return string.isNumeric()
+        }
+        return true
+    }
 }
 
 extension SaveCustomRpcManualEntryViewController: HandleAddMultipleCustomRpcViewControllerResponse {

--- a/AlphaWallet/Settings/Views/SaveCustomRpcManualEntryView.swift
+++ b/AlphaWallet/Settings/Views/SaveCustomRpcManualEntryView.swift
@@ -38,7 +38,7 @@ class SaveCustomRpcManualEntryView: UIView {
 
     var chainIDTextField: TextField = {
         let textField = defaultTextField(
-            .decimalPad,
+            .numberPad,
             placeHolder: R.string.localizable.chainID(),
             label: R.string.localizable.chainID())
         return textField


### PR DESCRIPTION
Closes #3752 

Settings > Select Active Network > + 

Try and cut and paste floating point numbers or non-integer strings to the ChainIDTextField.