### PR TITLE
Added NavigationBarTopSeparatorLine code in Erc1155TokenInstanceViewController to remove the gray line #3813

### DIFF
--- a/AlphaWallet/Tokens/Collectibles/ViewControllers/Erc1155TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewControllers/Erc1155TokenInstanceViewController.swift
@@ -84,11 +84,13 @@ class Erc1155TokenInstanceViewController: UIViewController, TokenVerifiableStatu
     override func viewWillAppear(_ animated: Bool) {
         title = viewModel.navigationTitle
         super.viewWillAppear(animated)
+        hideNavigationBarTopSeparatorLine()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         title = ""
         super.viewWillDisappear(animated)
+        showNavigationBarTopSeparatorLine()
     }
 
     private func generateSubviews(viewModel: Erc1155TokenInstanceViewModel) {


### PR DESCRIPTION
Closes #3813 

See this [comment](https://github.com/AlphaWallet/alpha-wallet-ios/issues/3813#issuecomment-1022790761).