### PR TITLE
Modified InCoordinator and TokensCoordinator to switch wallets when a QR code is scanned and placed on the watch wallets list in the Wallet screen.

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -1101,6 +1101,11 @@ extension InCoordinator: TokensCoordinatorDelegate {
     func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource) {
         openFiatOnRamp(wallet: wallet, server: server, inViewController: viewController, source: source)
     }
+
+    func didSelectAccount(account: Wallet, in coordinator: TokensCoordinator) {
+        guard keystore.currentWallet != account else { return }
+        restartUI(withReason: .walletChange, account: account)
+    }
 }
 
 extension InCoordinator: PaymentCoordinatorDelegate {

--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -17,6 +17,7 @@ protocol TokensCoordinatorDelegate: CanOpenURL, SendTransactionDelegate {
     func openFiatOnRamp(wallet: Wallet, server: RPCServer, inCoordinator coordinator: TokensCoordinator, viewController: UIViewController, source: Analytics.FiatOnRampSource)
 
     func whereAreMyTokensSelected(in coordinator: TokensCoordinator)
+    func didSelectAccount(account: Wallet, in coordinator: TokensCoordinator)
 }
 
 private struct NoContractDetailsDetected: Error {
@@ -514,6 +515,7 @@ extension TokensCoordinator: WalletCoordinatorDelegate {
         removeCoordinator(coordinator)
 
         coordinator.navigationController.dismiss(animated: true)
+        delegate?.didSelectAccount(account: account, in: self)
     }
 
     func didCancel(in coordinator: WalletCoordinator) {


### PR DESCRIPTION
Closes #3825 

1. On Wallet screen, tap QR code scanner in upper right corner.
2. Scan Wallet QR code.
3. Tap Watch Wallet when pop up appears.
4. **Expects** Scanned Wallet to be the displayed wallet in the Wallet screen.