### PR TITLE
Modifed code so that an error message is displayed if MFMailComposeViewController.canSendMail() returns false

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -784,3 +784,4 @@
 "analytics.navigationTitle" = "Analytics";
 "analytics.description" = "Help us to improve AlphaWallet by sharing anonymous data with us. This does not include any financial information.";
 "analytics.shareAnonymousData" = "Share Anonymous Data?";
+"email.not.configured" = "Your device isn't configured to send email";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -784,3 +784,4 @@
 "analytics.navigationTitle" = "Analytics";
 "analytics.description" = "Help us to improve AlphaWallet by sharing anonymous data with us. This does not include any financial information.";
 "analytics.shareAnonymousData" = "Share Anonymous Data?";
+"email.not.configured" = "Your device isn't configured to send email";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -784,3 +784,4 @@
 "analytics.navigationTitle" = "Analytics";
 "analytics.description" = "Help us to improve AlphaWallet by sharing anonymous data with us. This does not include any financial information.";
 "analytics.shareAnonymousData" = "Share Anonymous Data?";
+"email.not.configured" = "Your device isn't configured to send email";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -784,3 +784,4 @@
 "analytics.navigationTitle" = "Analytics";
 "analytics.description" = "Help us to improve AlphaWallet by sharing anonymous data with us. This does not include any financial information.";
 "analytics.shareAnonymousData" = "Share Anonymous Data?";
+"email.not.configured" = "Your device isn't configured to send email";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -784,3 +784,4 @@
 "analytics.navigationTitle" = "Analytics";
 "analytics.description" = "Help us to improve AlphaWallet by sharing anonymous data with us. This does not include any financial information.";
 "analytics.shareAnonymousData" = "Share Anonymous Data?";
+"email.not.configured" = "Your device isn't configured to send email";

--- a/AlphaWallet/Settings/Types/ServiceProvider.swift
+++ b/AlphaWallet/Settings/Types/ServiceProvider.swift
@@ -113,6 +113,8 @@ final class ContactUsEmailResolver: NSObject {
             }
 
             viewController.present(mc, animated: true)
+        } else {
+            viewController.displayError(message: R.string.localizable.emailNotConfigured())
         }
     }
 


### PR DESCRIPTION
Closes #3807 

@oa-s @hboon 

Does anyone know how to trigger `HelpContentsViewController` and `HelpViewController` are in the app? I can't find them to test. The one spot I know where to test is below:

Settings > Support > Email

![Screen Shot 2022-01-28 at 3 54 13 PM](https://user-images.githubusercontent.com/1050309/151508591-4a109e62-8e23-4c09-a8b1-4141afcfee21.png)

