### PR TITLE
Add development flag `Config.development.shouldPretendIsRealWallet` so we can force watch wallets to proceed to sign (and fail), etc

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -517,11 +517,15 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
         case .real(let account):
             return performDappAction(account: account)
         case .watch(let account):
-            switch action {
-            case .signTransaction, .sendTransaction, .signMessage, .signPersonalMessage, .signTypedMessage, .signTypedMessageV3, .unknown, .sendRawTransaction:
-                return rejectDappAction()
-            case .walletAddEthereumChain, .walletSwitchEthereumChain, .ethCall:
+            if config.development.shouldPretendIsRealWallet {
                 return performDappAction(account: account)
+            } else {
+                switch action {
+                case .signTransaction, .sendTransaction, .signMessage, .signPersonalMessage, .signTypedMessage, .signTypedMessageV3, .unknown, .sendRawTransaction:
+                    return rejectDappAction()
+                case .walletAddEthereumChain, .walletSwitchEthereumChain, .ethCall:
+                    return performDappAction(account: account)
+                }
             }
         }
     }

--- a/AlphaWallet/Redeem/ViewControllers/TokenCardRedemptionViewController.swift
+++ b/AlphaWallet/Redeem/ViewControllers/TokenCardRedemptionViewController.swift
@@ -114,16 +114,25 @@ class TokenCardRedemptionViewController: UIViewController, TokenVerifiableStatus
         case .erc721, .erc721ForTickets:
             redeemData = redeem.redeemMessage(tokenIds: viewModel.tokenHolder.tokens.map({ $0.id }))
         }
-        switch session.account.type {
-        case .real(let account):
+        func _generateQr(account: AlphaWallet.Address) {
             do {
-                guard let decimalSignature = try SignatureHelper.signatureAsDecimal(for: redeemData.message, account: account, analyticsCoordinator: analyticsCoordinator) else { break }
+                guard let decimalSignature = try SignatureHelper.signatureAsDecimal(for: redeemData.message, account: account, analyticsCoordinator: analyticsCoordinator) else { return }
                 let qrCodeInfo = redeemData.qrCode + decimalSignature
                 imageView.image = qrCodeInfo.toQRCode()
             } catch {
-                break
+                //no-op
             }
-        case .watch: break
+        }
+        switch session.account.type {
+        case .real(let account):
+            _generateQr(account: account)
+        case .watch(let account):
+            //TODO should pass in a Config instance instead
+            if Config().development.shouldPretendIsRealWallet {
+                _generateQr(account: account)
+            } else {
+                //no-op
+            }
         }
     }
 

--- a/AlphaWallet/Settings/Types/Config.swift
+++ b/AlphaWallet/Settings/Types/Config.swift
@@ -9,6 +9,8 @@ struct Config {
         let shouldReadClipboardForWalletConnectUrl = false
         ///Useful to reduce network calls
         let isAutoFetchingDisabled = false
+        ///Should only be used to allow users to take paths where the current wallet is real, not watched, e.g sign buttons are enabled. Some of those actions will fail, understandably. Should not display a watch wallet as if it is a real wallet though
+        let shouldPretendIsRealWallet = false
     }
 
     let development = Development()

--- a/AlphaWallet/Tokens/Collectibles/Coordinators/TokensCardCollectionCoordinator.swift
+++ b/AlphaWallet/Tokens/Collectibles/Coordinators/TokensCardCollectionCoordinator.swift
@@ -74,7 +74,7 @@ class TokensCardCollectionCoordinator: NSObject, Coordinator {
         navigationController.pushViewController(rootViewController, animated: true)
         refreshUponAssetDefinitionChanges()
         refreshUponEthereumEventChanges()
-    } 
+    }
 
     private func makeCoordinatorReadOnlyIfNotSupportedByOpenSeaERC1155(type: PaymentFlow, target: IsReadOnlyViewController) {
         switch (type, session.account.type) {
@@ -194,7 +194,7 @@ extension TokensCardCollectionCoordinator: TokensCardCollectionViewControllerDel
     private func showTokenInstanceActionView(forAction action: TokenInstanceAction, tokenHolder: TokenHolder, viewController: UIViewController) {
         delegate?.didTap(for: .send(type: .tokenScript(action: action, tokenObject: token, tokenHolder: tokenHolder)), in: self, viewController: viewController)
     }
-    
+
     func didSelectTokenHolder(in viewController: TokensCardCollectionViewController, didSelectTokenHolder tokenHolder: TokenHolder) {
         switch tokenHolder.type {
         case .collectible:
@@ -232,7 +232,7 @@ extension TokensCardCollectionCoordinator: TokensCardCollectionViewControllerDel
         viewController.navigationItem.leftBarButtonItem = .backBarButton(self, selector: #selector(didCloseTokenInstanceSelected))
         navigationController.pushViewController(viewController, animated: true)
     }
-    
+
     @objc private func didCloseTokenInstanceSelected(_ sender: UIBarButtonItem) {
         navigationController.popViewController(animated: true)
     }

--- a/AlphaWallet/Tokens/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewControllers/TokensCardCollectionViewController.swift
@@ -151,18 +151,27 @@ class TokensCardCollectionViewController: UIViewController {
         buttonsBar.configure(.combined(buttons: viewModel.actions.count))
         buttonsBar.viewController = self
 
+        func _configButton(action: TokenInstanceAction, button: BarButton) {
+            if let selection = action.activeExcludingSelection(selectedTokenHolder: viewModel.tokenHolders[0], tokenId: viewModel.tokenHolders[0].tokenId, forWalletAddress: session.account.address, fungibleBalance: viewModel.fungibleBalance) {
+                if selection.denial == nil {
+                    button.displayButton = false
+                }
+            }
+        }
+
         for (action, button) in zip(actions, buttonsBar.buttons) {
             button.setTitle(action.name, for: .normal)
             button.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
             switch session.account.type {
             case .real:
-                if let selection = action.activeExcludingSelection(selectedTokenHolder: viewModel.tokenHolders[0], tokenId: viewModel.tokenHolders[0].tokenId, forWalletAddress: session.account.address, fungibleBalance: viewModel.fungibleBalance) {
-                    if selection.denial == nil {
-                        button.displayButton = false
-                    }
-                }
+                _configButton(action: action, button: button)
             case .watch:
-                button.isEnabled = false
+                //TODO pass in Config instance instead
+                if Config().development.shouldPretendIsRealWallet {
+                    _configButton(action: action, button: button)
+                } else {
+                    button.isEnabled = false
+                }
             }
         }
     }

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceViewController.swift
@@ -134,19 +134,28 @@ class TokenInstanceViewController: UIViewController, TokenVerifiableStatusViewCo
             buttonsBar.configure(.combined(buttons: viewModel.actions.count))
             buttonsBar.viewController = self
 
+            func _configButton(action: TokenInstanceAction, button: BarButton) {
+                if let selection = action.activeExcludingSelection(selectedTokenHolders: [tokenHolder], forWalletAddress: account.address) {
+                    if selection.denial == nil {
+                        button.displayButton = false
+                    }
+                }
+            }
+
             for (index, button) in buttonsBar.buttons.enumerated() {
                 let action = viewModel.actions[index]
                 button.setTitle(action.name, for: .normal)
                 button.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
                 switch account.type {
                 case .real:
-                    if let selection = action.activeExcludingSelection(selectedTokenHolders: [tokenHolder], forWalletAddress: account.address) {
-                        if selection.denial == nil {
-                            button.displayButton = false
-                        }
-                    }
+                    _configButton(action: action, button: button)
                 case .watch:
-                    button.isEnabled = false 
+                    //TODO pass in a Config instance instead
+                    if Config().development.shouldPretendIsRealWallet {
+                        _configButton(action: action, button: button)
+                    } else {
+                        button.isEnabled = false
+                    }
                 }
             }
         }
@@ -231,7 +240,7 @@ extension TokenInstanceViewController: VerifiableStatusViewController {
     func open(url: URL) {
         delegate?.didPressViewContractWebPage(url, in: self)
     }
-} 
+}
 
 extension TokenInstanceViewController: TokenInstanceAttributeViewDelegate {
     func didSelect(in view: TokenInstanceAttributeView) {

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -137,18 +137,27 @@ class TokenViewController: UIViewController {
         buttonsBar.configure(.combined(buttons: viewModel.actions.count))
         buttonsBar.viewController = self
 
+        func _configButton(action: TokenInstanceAction, viewModel: TokenViewControllerViewModel, button: BarButton) {
+            if let tokenHolder = generateTokenHolder(), let selection = action.activeExcludingSelection(selectedTokenHolders: [tokenHolder], forWalletAddress: session.account.address, fungibleBalance: viewModel.fungibleBalance) {
+                if selection.denial == nil {
+                    button.displayButton = false
+                }
+            }
+        }
+
         for (action, button) in zip(actions, buttonsBar.buttons) {
             button.setTitle(action.name, for: .normal)
             button.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
             switch session.account.type {
             case .real:
-                if let tokenHolder = generateTokenHolder(), let selection = action.activeExcludingSelection(selectedTokenHolders: [tokenHolder], forWalletAddress: session.account.address, fungibleBalance: viewModel.fungibleBalance) {
-                    if selection.denial == nil {
-                        button.displayButton = false
-                    }
-                }
+                _configButton(action: action, viewModel: viewModel, button: button)
             case .watch:
-                button.isEnabled = false
+                //TODO pass in Config instance instead
+                if Config().development.shouldPretendIsRealWallet {
+                    _configButton(action: action, viewModel: viewModel, button: button)
+                } else {
+                    button.isEnabled = false
+                }
             }
         }
     }

--- a/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
+++ b/AlphaWallet/Tokens/Views/TokenInstanceWebView.swift
@@ -444,18 +444,27 @@ extension TokenInstanceWebView: WKScriptMessageHandler {
         let token = TokensDataStore.token(forServer: server)
         let action = DappAction.fromCommand(.eth(command), server: server, transactionType: .dapp(token, requester))
 
-        switch wallet.type {
-        case .real(let account):
+        func _sign(action: DappAction, command: DappCommand, account: AlphaWallet.Address) {
             switch action {
             case .signPersonalMessage(let hexMessage):
                 let msg = convertMessageToHex(msg: hexMessage)
                 let callbackID = command.id
                 signMessage(with: .personalMessage(Data(_hex: msg)), account: account, callbackID: callbackID)
             case .signTransaction, .sendTransaction, .signMessage, .signTypedMessage, .unknown, .sendRawTransaction, .signTypedMessageV3, .ethCall, .walletAddEthereumChain, .walletSwitchEthereumChain:
-                return
+                break
             }
-        case .watch:
-            break
+        }
+
+        switch wallet.type {
+        case .real(let account):
+            _sign(action: action, command: command, account: account)
+        case .watch(let account):
+            //TODO pass in Config instance instead
+            if Config().development.shouldPretendIsRealWallet {
+                _sign(action: action, command: command, account: account)
+            } else {
+                //no-op
+            }
         }
     }
 }

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -62,7 +62,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
         self.eventsDataStore = eventsDataStore
         self.analyticsCoordinator = analyticsCoordinator
         navigationController.navigationBar.isTranslucent = false
-    } 
+    }
 
     func start() {
         rootViewController.configure()
@@ -431,7 +431,7 @@ class TokensCardCoordinator: NSObject, Coordinator {
 }
 
 extension TokensCardCoordinator: TokensCardViewControllerDelegate {
-    
+
     func didTap(transaction: TransactionInstance, in viewController: TokensCardViewController) {
         delegate?.didTap(transaction: transaction, in: self)
     }

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -202,7 +202,12 @@ private extension WalletType {
         case .real:
             return .value(())
         case .watch:
-            return .init(error: WalletConnectCoordinator.RequestCanceledDueToWatchWalletError())
+            //TODO pass in Config instance instead
+            if Config().development.shouldPretendIsRealWallet {
+                return .value(())
+            } else {
+                return .init(error: WalletConnectCoordinator.RequestCanceledDueToWatchWalletError())
+            }
         }
     }
 }


### PR DESCRIPTION
Useful especially when we want to force the send buttons, signing actionsheets to appear for watched wallets