### PR TITLE
Fix: crash after posting transaction

### DIFF
--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -413,7 +413,7 @@ extension TransactionsStorage.functional {
     }
 
     static func noncePredicate(nonce: String) -> NSPredicate {
-        return NSPredicate(format: "nonce == \(nonce)")
+        return NSPredicate(format: "nonce == '\(nonce)'")
     }
 
     static func nonEmptyIdTransactionPredicate(server: RPCServer) -> NSPredicate {


### PR DESCRIPTION
Closes #3995

`NSPredicate(format:)` isn't type safe. Is there a better way? Does Realm provide some type-safe magic to form the predicate from the `Transaction` perhaps?

@oa-s would you help check the other `NSPredicate(format:)` calls for these? :)