### PR TITLE
Hide TokenScript signature verifier result because it's always invalid now

### DIFF
--- a/AlphaWallet/Core/Features.swift
+++ b/AlphaWallet/Core/Features.swift
@@ -30,4 +30,5 @@ enum Features {
     static let isAnalyticsUIEnabled = true
     static let isJsonFileBasedStorageForWalletAddressesEnabled = true
     static let isBlockscanChatEnabled = true
+    static let isTokenScriptSignatureStatusEnabled = false
 }

--- a/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenViewController.swift
@@ -3,7 +3,7 @@
 import Foundation
 import UIKit
 import BigInt
-import PromiseKit 
+import PromiseKit
 
 protocol TokenViewControllerDelegate: class, CanOpenURL {
     func didTapSwap(forTransactionType transactionType: TransactionType, service: SwapTokenURLProviderType, inViewController viewController: TokenViewController)
@@ -187,16 +187,20 @@ class TokenViewController: UIViewController {
             }.cauterize()
         }
 
-        if let server = xmlHandler.server, let status = tokenScriptStatusPromise.value, server.matches(server: session.server) {
-            switch status {
-            case .type0NoTokenScript:
+        if Features.isTokenScriptSignatureStatusEnabled {
+            if let server = xmlHandler.server, let status = tokenScriptStatusPromise.value, server.matches(server: session.server) {
+                switch status {
+                case .type0NoTokenScript:
+                    navigationItem.rightBarButtonItem = nil
+                case .type1GoodTokenScriptSignatureGoodOrOptional, .type2BadTokenScript:
+                    let button = createTokenScriptFileStatusButton(withStatus: status, urlOpener: self)
+                    navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
+                }
+            } else {
                 navigationItem.rightBarButtonItem = nil
-            case .type1GoodTokenScriptSignatureGoodOrOptional, .type2BadTokenScript:
-                let button = createTokenScriptFileStatusButton(withStatus: status, urlOpener: self)
-                navigationItem.rightBarButtonItem = UIBarButtonItem(customView: button)
             }
         } else {
-            navigationItem.rightBarButtonItem = nil
+            //no-op
         }
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -201,16 +201,20 @@ class TokensCardViewController: UIViewController {
             }.cauterize()
         }
 
-        if let server = xmlHandler.server, let status = tokenScriptStatusPromise.value, server.matches(server: session.server) {
-            switch status {
-            case .type0NoTokenScript:
+        if Features.isTokenScriptSignatureStatusEnabled {
+            if let server = xmlHandler.server, let status = tokenScriptStatusPromise.value, server.matches(server: session.server) {
+                switch status {
+                case .type0NoTokenScript:
+                    collectionInfoPageView.rightBarButtonItem = nil
+                case .type1GoodTokenScriptSignatureGoodOrOptional, .type2BadTokenScript:
+                    let button = createTokenScriptFileStatusButton(withStatus: status, urlOpener: self)
+                    collectionInfoPageView.rightBarButtonItem = UIBarButtonItem(customView: button)
+                }
+            } else {
                 collectionInfoPageView.rightBarButtonItem = nil
-            case .type1GoodTokenScriptSignatureGoodOrOptional, .type2BadTokenScript:
-                let button = createTokenScriptFileStatusButton(withStatus: status, urlOpener: self)
-                collectionInfoPageView.rightBarButtonItem = UIBarButtonItem(customView: button)
             }
         } else {
-            collectionInfoPageView.rightBarButtonItem = nil
+            //no-op
         }
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
@@ -10,6 +10,8 @@ import PromiseKit
 
 extension VerifiableStatusViewController where Self: UIViewController {
     func updateNavigationRightBarButtons(withTokenScriptFileStatus statusPromise: Promise<TokenLevelTokenScriptDisplayStatus>?, hasShowInfoButton: Bool = true) {
+        guard Features.isTokenScriptSignatureStatusEnabled else { return }
+
         guard let status = statusPromise?.value else {
             let label: UIBarButtonItem = .init(title: R.string.localizable.tokenScriptVerifying(), style: .plain, target: nil, action: nil)
             var showInfoButton = hasShowInfoButton


### PR DESCRIPTION
Closes #4018 

Before PR|After PR
-|-
<img width="200" alt="Screenshot 2022-03-04 at 4 52 08 PM" src="https://user-images.githubusercontent.com/56189/156731169-603deee1-a78c-49a9-a7e4-27fc1052aa60.png">|<img width="200" alt="Screenshot 2022-03-04 at 4 50 45 PM" src="https://user-images.githubusercontent.com/56189/156731134-a36a2036-7efc-459b-b90c-6eab784c0bd6.png">
