### PR TITLE
Replace the "..." used when truncating addresses in the middle with the real thing: "…"

### DIFF
--- a/modules/AlphaWalletAddress/AlphaWalletAddress/AlphaWallet.swift
+++ b/modules/AlphaWalletAddress/AlphaWalletAddress/AlphaWallet.swift
@@ -121,11 +121,11 @@ extension AlphaWallet.Address {
 }
 
 extension AlphaWallet.Address {
-    //Produces this format: 0x1234...5678
+    //Produces this format: 0x1234…5678
     public var truncateMiddle: String {
         let address = eip55String
         let front = address.prefix(6)
         let back = address.suffix(4)
-        return "\(front)...\(back)"
+        return "\(front)…\(back)"
     }
 }


### PR DESCRIPTION
But maybe due to the font used, it looks unchanged. But changing it otherwise it sticks out in the codebase all the time.

Referring to this:

<img width="200" alt="Screenshot 2022-03-09 at 11 25 31 AM" src="https://user-images.githubusercontent.com/56189/157367214-e793f311-904c-4143-a03a-16b0c7d6110e.png">


