### PR TITLE
Update DAS DApp info

### DIFF
--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -78,7 +78,7 @@ enum OriginalDapps {
         Dapp(name: "Eth Gas Station", description: "Consumer oriented metrics for Eth Gas Market", url: "https://ethgasstation.info", cat: "Tool")
         Dapp(name: "Gas Now", description: "Eth Gas Price forecast system", url: "https://www.gasnow.org/", cat: "Tool")
         Dapp(name: "DASLA", description: "A DAS(Decentralized Account System) account registration tool", url: "https://das.la/", cat: "Tool")
-        Dapp(name: "DAS", description: "A cross-chain decentralized account system.", url: "https://da.systems/", cat: "Tool")
+        Dapp(name: ".bit (Previously DAS)", description: "Your decentralized identity for Web3.0 life", url: "https://did.id/", cat: "Tool")
     ]
 
     struct Category {


### PR DESCRIPTION
DAS has branded as .bit. And the new website is https://did.id
