### PR TITLE
Remove unnecessary `import Trustkeystore`

### DIFF
--- a/AlphaWallet/Core/DecodedFunctionCall.swift
+++ b/AlphaWallet/Core/DecodedFunctionCall.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 import BigInt
-import TrustKeystore
 import web3swift
 
 struct DecodedFunctionCall {

--- a/AlphaWallet/Core/SwapToken/HoneySwap/HoneySwapERC20Token.swift
+++ b/AlphaWallet/Core/SwapToken/HoneySwap/HoneySwapERC20Token.swift
@@ -6,10 +6,9 @@
 //
 
 import Foundation
-import TrustKeystore
 
 extension HoneySwap {
-    
+
     struct TokensResponse: Decodable {
         let tokens: [ERC20Token]
     }

--- a/AlphaWallet/Core/SwapToken/Oneinch/ERC20Token.swift
+++ b/AlphaWallet/Core/SwapToken/Oneinch/ERC20Token.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import TrustKeystore
 
 extension Oneinch {
     struct ApiResponsePayload: Decodable {

--- a/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ClaimPaidOrderCoordinator.swift
@@ -6,7 +6,6 @@
 import Foundation
 import BigInt
 import Result
-import TrustKeystore
 
 protocol ClaimOrderCoordinatorDelegate: class, CanOpenURL {
     func coordinator(_ coordinator: ClaimPaidOrderCoordinator, didFailTransaction error: AnyError)
@@ -147,7 +146,7 @@ class ClaimPaidOrderCoordinator: Coordinator {
                                       completion: @escaping (Swift.Result<Data, AnyError>) -> Void) {
 
         do {
-            let parameters: [Any] = [expiry, tokenIds, BigUInt(v), Data(_hex: r), Data(_hex: s), TrustKeystore.Address(address: recipient)]
+            let parameters: [Any] = [expiry, tokenIds, BigUInt(v), Data(_hex: r), Data(_hex: s), recipient]
             let functionEncoder = Function(name: "spawnPassTo", parameters: [
                 .uint(bits: 256),
                 .dynamicArray(.uint(bits: 256)),
@@ -180,7 +179,7 @@ class ClaimPaidOrderCoordinator: Coordinator {
                 BigUInt(v),
                 Data(_hex: r),
                 Data(_hex: s),
-                Address(address: recipient)
+                recipient
             ]
             let functionEncoder = Function(name: "dropCurrency", parameters: [
                 .uint(bits: 256),

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -5,7 +5,6 @@ import APIKit
 import BigInt
 import JSONRPCKit
 import PromiseKit
-import TrustKeystore
 
 protocol TransactionConfiguratorDelegate: AnyObject {
     func configurationChanged(in configurator: TransactionConfigurator)
@@ -346,10 +345,10 @@ class TransactionConfigurator {
                 let function = Function(name: "transfer", parameters: [ABIType.address, ABIType.uint(bits: 256)])
                 //Note: be careful here with the BigUInt and BigInt, the type needs to be exact
                 let encoder = ABIEncoder()
-                try encoder.encode(function: function, arguments: [Address(address: transaction.recipient!), BigUInt(transaction.value)])
+                try encoder.encode(function: function, arguments: [transaction.recipient!, BigUInt(transaction.value)])
                 return createConfiguration(server: server, transaction: transaction, gasLimit: transaction.gasLimit ?? GasLimitConfiguration.maxGasLimit, data: encoder.data)
             case .erc875Token(let token, _):
-                let parameters: [Any] = [TrustKeystore.Address(address: transaction.recipient!), transaction.indices!.map({ BigUInt($0) })]
+                let parameters: [Any] = [transaction.recipient!, transaction.indices!.map({ BigUInt($0) })]
                 let arrayType: ABIType
                 if token.contractAddress.isLegacy875Contract {
                     arrayType = ABIType.uint(bits: 16)
@@ -393,13 +392,13 @@ class TransactionConfigurator {
                 if token.contractAddress.isLegacy721Contract {
                     function = Function(name: "transfer", parameters: [.address, .uint(bits: 256)])
                     parameters = [
-                        TrustKeystore.Address(address: transaction.recipient!), transaction.tokenId!
+                        transaction.recipient!, transaction.tokenId!
                     ]
                 } else {
                     function = Function(name: "safeTransferFrom", parameters: [.address, .address, .uint(bits: 256)])
                     parameters = [
-                        TrustKeystore.Address(address: account),
-                        TrustKeystore.Address(address: transaction.recipient!),
+                        account,
+                        transaction.recipient!,
                         transaction.tokenId!
                     ]
                 }
@@ -411,8 +410,8 @@ class TransactionConfigurator {
                 case .singleTransfer:
                     let function = Function(name: "safeTransferFrom", parameters: [.address, .address, .uint(bits: 256), .uint(bits: 256), .dynamicBytes])
                     let parameters: [Any] = [
-                        TrustKeystore.Address(address: account),
-                        TrustKeystore.Address(address: transaction.recipient!),
+                        account,
+                        transaction.recipient!,
                         transaction.tokenIdsAndValues![0].tokenId,
                         transaction.tokenIdsAndValues![0].value,
                         Data()
@@ -432,8 +431,8 @@ class TransactionConfigurator {
                     ])
 
                     let parameters: [Any] = [
-                        TrustKeystore.Address(address: account),
-                        TrustKeystore.Address(address: transaction.recipient!),
+                        account,
+                        transaction.recipient!,
                         tokenIds,
                         values,
                         Data()

--- a/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
+++ b/AlphaWalletTests/Coordinators/SendCoordinatorTests.swift
@@ -2,7 +2,6 @@
 
 import XCTest
 @testable import AlphaWallet
-import TrustKeystore
 
 class SendCoordinatorTests: XCTestCase {
 

--- a/AlphaWalletTests/EtherClient/EtherKeystoreTests.swift
+++ b/AlphaWalletTests/EtherClient/EtherKeystoreTests.swift
@@ -5,7 +5,6 @@ import LocalAuthentication
 @testable import AlphaWallet
 import BigInt
 import KeychainSwift
-import TrustKeystore
 import WalletCore
 
 class EtherKeystoreTests: XCTestCase {

--- a/AlphaWalletTests/EtherClient/TransactionSigningTests.swift
+++ b/AlphaWalletTests/EtherClient/TransactionSigningTests.swift
@@ -2,7 +2,6 @@
 
 import BigInt
 @testable import AlphaWallet
-import TrustKeystore
 import XCTest
 
 class TransactionSigningTests: XCTestCase {

--- a/AlphaWalletTests/Factories/FakeKeystore.swift
+++ b/AlphaWalletTests/Factories/FakeKeystore.swift
@@ -3,7 +3,6 @@
 import Foundation
 import LocalAuthentication
 @testable import AlphaWallet
-import TrustKeystore
 import Result
 
 struct FakeKeystore: Keystore {

--- a/AlphaWalletTests/Factories/Wallet.swift
+++ b/AlphaWalletTests/Factories/Wallet.swift
@@ -1,7 +1,6 @@
 // Copyright SIX DAY LLC. All rights reserved.
 
 import Foundation
-import TrustKeystore
 @testable import AlphaWallet
 
 extension Wallet {


### PR DESCRIPTION
Includes using `AlphaWallet.Address` instead of `TrustKeystore.Address` for encoding function calls because it has been supported for a long time