### PR TITLE
Fix: transaction ABI function parsing. Previous code is dependent on order of enumerating a dictionary key-value pairs of function arguments

### DIFF
--- a/AlphaWallet/Core/Ethereum/ABI/DecodedFunctionCall+Decode.swift
+++ b/AlphaWallet/Core/Ethereum/ABI/DecodedFunctionCall+Decode.swift
@@ -34,14 +34,16 @@ extension DecodedFunctionCall {
                 guard let functionName = function.name else { return nil }
 
                 if functionToResearch == function.methodEncoding.hex(), let inputs = element.decodeInputData(data) {
-                    //NOTE: perform filter for response input data to remove duplicated values from dictionary
-                    let arguments = inputs.compactMap { value -> (type: ABIType, value: AnyObject)? in
-                        if let inputParam = function.inputs.first(where: { $0.name == value.key }), let type = ABIType(abiParam: inputParam.type) {
-                            return (type, value.value as AnyObject)
+                    let arguments: [(type: ABIType, value: AnyObject)] = function.inputs.compactMap { inputParam in
+                        let value = inputs[inputParam.name]
+                        if let type = ABIType(abiParam: inputParam.type) {
+                            return (type: type, value: value as AnyObject)
+                        } else {
+                            return nil
                         }
-                        return nil
                     }
-
+                    //TODO check isArgCountMatches too:
+                    _ = inputs.count * 2 == function.inputs.count
                     let functionType = DecodedFunctionCall.FunctionType(name: functionName, arguments: arguments)
                     return DecodedFunctionCall(name: functionName, arguments: arguments, type: functionType)
                 }

--- a/AlphaWalletTests/Core/Ethereum/ABI/DecodedFunctionCall+DecodeTests.swift
+++ b/AlphaWalletTests/Core/Ethereum/ABI/DecodedFunctionCall+DecodeTests.swift
@@ -10,6 +10,12 @@ class DecodedFunctionCallTest: XCTestCase {
         XCTAssertEqual(decoded?.name, "transfer")
     }
 
+    func testDecode2() {
+        let data = Data(hex: "0x095ea7b30000000000000000000000000c6d898ac945e493d25751ea43be2c8beb881d8c000000000000000000000000000000000000000000000000048ae94435bf1640")
+        let function = DecodedFunctionCall(data: data)
+        XCTAssertEqual(function?.name, "approve")
+    }
+
     func testDecodeDoesNotCrash() {
         ////https://ropsten.etherscan.io/tx/0xf406723cc8e0165ded6e8e268e6576ab1a4f12736f6b90eff1adbca87f79a608
         let data = Data(hex: "000000000000000000000000007bee82bdd9e866b2bd114780a47f2261c684e3000000000000000000000000fe6d4bc2de2d0b0e6fe47f08a28ed52f9d052a020000000000000000000000000000000000000000000000000000000000000001")


### PR DESCRIPTION
eg. decoding an ERC20 `approve()` function might not work.

Added a unit test, but unfortunately the tests doesn't reliably show the original code will fail. But it helps proves the new version works.