### PR TITLE
Improve OpenSea API call error logging

### DIFF
--- a/AlphaWallet/Core/OpenSea/OpenSeaNetworkProvider.swift
+++ b/AlphaWallet/Core/OpenSea/OpenSeaNetworkProvider.swift
@@ -165,6 +165,9 @@ final class OpenSeaNetworkProvider {
                 privatePerformRequest(url: url).map { _, json -> JSON in
                     json
                 }
+            }.recover { error -> Promise<JSON> in
+                infoLog("[OpenSea] API error: \(error)")
+                throw error
             }
         }
     }


### PR DESCRIPTION
Closes #4163

We seem to have lost the debug log for `429`s. This PR restores it too.