### PR TITLE
CallForAssetAttributeCoordinator doesn't use assetDefinitionStore value, and self.server is the same as server value in functionCall: AssetFunctionCall so we can remove them #4173

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -24,11 +24,6 @@ class InCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate {
     private let appTracker: AppTracker
     private let analyticsCoordinator: AnalyticsCoordinator
     private let restartQueue: RestartTaskQueue
-    private var callForAssetAttributeCoordinators = ServerDictionary<CallForAssetAttributeCoordinator>() {
-        didSet {
-            XMLHandler.callForAssetAttributeCoordinators = callForAssetAttributeCoordinators
-        }
-    }
     private let queue: DispatchQueue = DispatchQueue(label: "com.Background.updateQueue", qos: .userInitiated)
     lazy private var eventsDataStore: NonActivityEventsDataStore = NonActivityMultiChainEventsDataStore(realm: realm)
     lazy private var eventsActivityDataStore: EventsActivityDataStoreProtocol = EventsActivityDataStore(realm: realm)
@@ -169,7 +164,6 @@ class InCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate {
     }
 
     deinit {
-        XMLHandler.callForAssetAttributeCoordinators = nil
         //NOTE: Clear all smart contract calls
         clearSmartContractCallsCache()
     }
@@ -241,13 +235,6 @@ class InCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate {
         migration.oneTimeCreationOfOneDatabaseToHoldAllChains(assetDefinitionStore: assetDefinitionStore)
     }
 
-    private func setupCallForAssetAttributeCoordinators() {
-        callForAssetAttributeCoordinators = .init()
-        for each in config.enabledServers {
-            callForAssetAttributeCoordinators[each] = CallForAssetAttributeCoordinator(server: each, assetDefinitionStore: self.assetDefinitionStore)
-        }
-    }
-
     private func removeFailedOrPendingTransactions() {
         //TODO why do we remove such transactions? especially `.failed` and `.unknown`?
         transactionDataStore.removeTransactions(for: [.failed, .pending, .unknown], servers: config.enabledServers)
@@ -270,7 +257,6 @@ class InCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate {
         oneTimeCreationOfOneDatabaseToHoldAllChains()
         setupWalletSessions()
         removeFailedOrPendingTransactions()
-        setupCallForAssetAttributeCoordinators()
     }
 
     //Internal for test purposes

--- a/AlphaWallet/TokenScriptClient/Models/AssetAttribute.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetAttribute.swift
@@ -165,9 +165,7 @@ extension Dictionary where Key == AttributeId, Value == AssetAttribute {
     func resolve(withTokenIdOrEvent tokenIdOrEvent: TokenIdOrEvent, userEntryValues: [AttributeId: String], server: RPCServer, account: Wallet, additionalValues: [AttributeId: AssetAttributeSyntaxValue], localRefs: [AttributeId: AssetInternalValue]) -> [AttributeId: AssetAttributeSyntaxValue] {
         var attributeNameValues = [AttributeId: AssetAttributeSyntaxValue]()
         let (tokenIdBased, userEntryBased, functionBased, eventBased) = splitAttributesByOrigin
-        guard let callForAssetAttributeCoordinator = XMLHandler.callForAssetAttributeCoordinators?[server] else {
-            return [:]
-        }
+        let callForAssetAttributeCoordinator = XMLHandler.callForAssetAttributeCoordinator
         for (attributeId, attribute) in tokenIdBased {
             let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: .init(), localRefs: localRefs)
             attributeNameValues[attributeId] = value

--- a/AlphaWallet/TokenScriptClient/Models/CallForAssetAttributeCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Models/CallForAssetAttributeCoordinator.swift
@@ -8,14 +8,7 @@ import web3swift
 
 ///This class temporarily stores the promises used to make function calls. This is so we don't make the same function calls (over network) + arguments combination multiple times concurrently. Once the call completes, we remove it from the cache.
 class CallForAssetAttributeCoordinator {
-    private let server: RPCServer
-    private let assetDefinitionStore: AssetDefinitionStore
     private var promiseCache = [AssetFunctionCall: Promise<AssetInternalValue>]()
-
-    init(server: RPCServer, assetDefinitionStore: AssetDefinitionStore) {
-        self.server = server 
-        self.assetDefinitionStore = assetDefinitionStore
-    }
 
     func getValue(
             forAttributeId attributeId: AttributeId,
@@ -58,7 +51,7 @@ class CallForAssetAttributeCoordinator {
             let contract = functionCall.contract
 
             //Fine to store a strong reference to self here because it's still useful to cache the function call result
-            callSmartContract(withServer: server, contract: contract, functionName: functionCall.functionName, abiString: "[\(function.abi)]", parameters: functionCall.arguments).done { dictionary in
+            callSmartContract(withServer: functionCall.server, contract: contract, functionName: functionCall.functionName, abiString: "[\(function.abi)]", parameters: functionCall.arguments).done { dictionary in
                 if let value = dictionary["0"] {
                     switch functionCall.output.type {
                     case .address:

--- a/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
+++ b/AlphaWallet/TokenScriptClient/Models/XMLHandler.swift
@@ -677,7 +677,7 @@ private class PrivateXMLHandler {
 /// This class delegates all the functionality to a singleton of the actual XML parser. 1 for each contract. So we just parse the XML file 1 time only for each contract
 public class XMLHandler {
     //TODO not the best thing to have, especially because it's an optional
-    static var callForAssetAttributeCoordinators: ServerDictionary<CallForAssetAttributeCoordinator>?
+    static var callForAssetAttributeCoordinator = CallForAssetAttributeCoordinator()
     fileprivate static var xmlHandlers = [AlphaWallet.Address: PrivateXMLHandler]()
     fileprivate static var baseXmlHandlers = [String: PrivateXMLHandler]()
     private let privateXMLHandler: PrivateXMLHandler

--- a/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
+++ b/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
@@ -903,8 +903,7 @@ class XMLHandlerTest: XCTestCase {
         let contractAddress = AlphaWallet.Address(string: "0xA66A3F08068174e8F005112A8b2c7A507a822335")!
         let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
 
-        XMLHandler.callForAssetAttributeCoordinators = .init()
-        XMLHandler.callForAssetAttributeCoordinators![.main] = CallForAssetAttributeCoordinator(server: .main, assetDefinitionStore: store)
+        XMLHandler.callForAssetAttributeCoordinator = CallForAssetAttributeCoordinator()
 
         store[contractAddress] = xml
         let xmlHandler = XMLHandler(contract: contractAddress, tokenType: .erc20, assetDefinitionStore: store)
@@ -912,7 +911,7 @@ class XMLHandlerTest: XCTestCase {
         let server: RPCServer = .main
         let token = xmlHandler.getToken(name: "Some name", symbol: "Some symbol", fromTokenIdOrEvent: .tokenId(tokenId: tokenId), index: 1, inWallet: .make(), server: server, tokenType: TokenType.erc875)
         let values = token.values
-        XMLHandler.callForAssetAttributeCoordinators = nil
+
         XCTAssertEqual(values["locality"]?.stringValue, "Saint Petersburg")
     }
 // swiftlint:enable function_body_length


### PR DESCRIPTION
Closes #4173