### PR TITLE
Added function to update AmountTextField’s InputAccessoryView based on button type. SendViewController modified to use the "next" InputAccessoryView.

### DIFF
--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -37,7 +37,7 @@ class SendViewController: UIViewController {
     }()
 
     lazy var amountTextField: AmountTextField = {
-        let amountTextField = AmountTextField(tokenObject: transactionType.tokenObject)
+        let amountTextField = AmountTextField(tokenObject: transactionType.tokenObject, buttonType: .next)
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
         amountTextField.accessoryButtonTitle = .next

--- a/AlphaWallet/UI/Views/AmountTextField.swift
+++ b/AlphaWallet/UI/Views/AmountTextField.swift
@@ -389,7 +389,7 @@ class AmountTextField: UIControl {
 
     weak var delegate: AmountTextFieldDelegate?
 
-    init(tokenObject: TokenObject) {
+    init(tokenObject: TokenObject, buttonType: AmountTextField.AccessoryButtonTitle = .done) {
         cryptoCurrency = .cryptoCurrency(tokenObject)
         currentPair = Pair(left: cryptoCurrency, right: .usd)
 
@@ -407,6 +407,8 @@ class AmountTextField: UIControl {
         NSLayoutConstraint.activate([
             stackView.anchorsConstraint(to: self),
         ])
+
+        updateTextFieldInputAccessoryView(buttonType: buttonType)
 
         inputAccessoryButton.addTarget(self, action: #selector(closeKeyboard), for: .touchUpInside)
     }
@@ -448,6 +450,15 @@ class AmountTextField: UIControl {
         }
     }
 
+    private func updateTextFieldInputAccessoryView(buttonType: AmountTextField.AccessoryButtonTitle) {
+        switch buttonType {
+        case .done:
+            textField.inputAccessoryView = UIToolbar.doneToolbarButton(#selector(closeKeyboard), self)
+        case .next:
+            textField.inputAccessoryView = UIToolbar.nextToolbarButton(#selector(closeKeyboard), self)
+        }
+    }
+    
     @discardableResult override func becomeFirstResponder() -> Bool {
         super.becomeFirstResponder()
         return textField.becomeFirstResponder()


### PR DESCRIPTION
closes: #3948

![Simulator Screen Shot - iPhone 11 - 2022-03-31 at 23 42 28](https://user-images.githubusercontent.com/1050309/161097832-4c39bb45-cb7c-4d7d-be35-6f7ffa29d9e9.png)
