### PR TITLE
RemoteLogger.swift:97:20: 'DDASLLogger' was deprecated in iOS 10.0: Use DDOSLogger instead #4199

### DIFF
--- a/AlphaWallet/Core/Helpers/RemoteLogger.swift
+++ b/AlphaWallet/Core/Helpers/RemoteLogger.swift
@@ -94,7 +94,7 @@ final class DDLogger: Logger {
         fileLogger.rollingFrequency = 60 * 60 * 24
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
 
-        logger.add(DDASLLogger.sharedInstance, with: .debug)
+        logger.add(DDOSLogger.sharedInstance, with: .debug)
         logger.add(fileLogger, with: .info)
     }
 


### PR DESCRIPTION
replace DDASLLogger with DDOSLogger in logger because of DDASLLogger deprecation in iOS 10
