### PR TITLE
Cache ENS forward and reverse resolution by name and address respectively, instead of their hashes

### DIFF
--- a/AlphaWallet/Core/Helpers/BlockieGenerator.swift
+++ b/AlphaWallet/Core/Helpers/BlockieGenerator.swift
@@ -95,10 +95,10 @@ class BlockiesGenerator {
 
         if let ens = ens {
             promise = GetENSTextRecordsCoordinator(server: .forResolvingEns)
-                .getENSRecord(for: ens, record: .avatar)
+                .getENSRecord(forName: ens, record: .avatar)
         } else {
             promise = GetENSTextRecordsCoordinator(server: .forResolvingEns)
-                .getENSRecord(for: address, record: .avatar)
+                .getENSRecord(forAddress: address, record: .avatar)
         }
 
         return firstly {

--- a/AlphaWallet/Core/UnstoppableDomains/AddressOrEnsResolution.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/AddressOrEnsResolution.swift
@@ -38,6 +38,12 @@ protocol CachedEnsResolutionServiceType {
 }
 
 struct ENSLookupKey: Hashable {
-    let name: String
+    let nameOrAddress: String
     let server: RPCServer
+
+    init(nameOrAddress: String, server: RPCServer) {
+        //Lowercase for case-insensitive lookups
+        self.nameOrAddress = nameOrAddress.lowercased()
+        self.server = server
+    }
 }

--- a/AlphaWallet/Core/UnstoppableDomains/AddressOrEnsResolution.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/AddressOrEnsResolution.swift
@@ -30,11 +30,11 @@ protocol DomainResolutionServiceType {
 }
 
 protocol CachebleAddressResolutionServiceType {
-    func cachedAddressValue(for input: String) -> AlphaWallet.Address?
+    func cachedAddressValue(forName name: String) -> AlphaWallet.Address?
 }
 
 protocol CachedEnsResolutionServiceType {
-    func cachedEnsValue(for input: AlphaWallet.Address) -> String?
+    func cachedEnsValue(forAddress address: AlphaWallet.Address) -> String?
 }
 
 struct ENSLookupKey: Hashable {

--- a/AlphaWallet/Core/UnstoppableDomains/DomainResolutionService.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/DomainResolutionService.swift
@@ -8,9 +8,11 @@
 import Foundation
 import PromiseKit
 
-class DomainResolutionService: DomainResolutionServiceType {
+class DomainResolutionService {
     let server: RPCServer = .forResolvingEns
+}
 
+extension DomainResolutionService: DomainResolutionServiceType {
     func resolveAddress(string value: String) -> Promise<BlockieAndAddressOrEnsResolution> {
 
         func resolveBlockieImage(addr: AlphaWallet.Address) -> Promise<BlockieAndAddressOrEnsResolution> {

--- a/AlphaWallet/Core/UnstoppableDomains/DomainResolutionService.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/DomainResolutionService.swift
@@ -33,15 +33,14 @@ extension DomainResolutionService: DomainResolutionServiceType {
             unstoppableDomainsV2Resolver
         ]
 
-        if let cached = services.compactMap({ $0.cachedAddressValue(for: value) }).first {
+        if let cached = services.compactMap({ $0.cachedAddressValue(forName: value) }).first {
             return resolveBlockieImage(addr: cached)
         }
 
         return getEnsAddressCoordinator
-            .getENSAddressFromResolver(for: value)
+            .getENSAddressFromResolver(forName: value)
             .recover { _ -> Promise<AlphaWallet.Address> in
-                unstoppableDomainsV2Resolver
-                    .resolveAddress(for: value)
+                unstoppableDomainsV2Resolver.resolveAddress(forName: value)
             }.then { addr -> Promise<BlockieAndAddressOrEnsResolution> in
                 resolveBlockieImage(addr: addr)
             }
@@ -67,7 +66,7 @@ extension DomainResolutionService: DomainResolutionServiceType {
             unstoppableDomainsV2Resolver
         ]
 
-        if let cached = services.compactMap({ $0.cachedEnsValue(for: address) }).first {
+        if let cached = services.compactMap({ $0.cachedEnsValue(forAddress: address) }).first {
             return resolveBlockieImage(ens: cached)
         }
 

--- a/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
@@ -39,19 +39,19 @@ class UnstoppableDomainsV2Resolver {
         UnstoppableDomainsV2Resolver.domainsCache[ENSLookupKey(name: node, server: server)] = domain
     }
 
-    func resolveAddress(for input: String) -> Promise<AlphaWallet.Address> {
-        if let value = AlphaWallet.Address(string: input) {
+    func resolveAddress(forName name: String) -> Promise<AlphaWallet.Address> {
+        if let value = AlphaWallet.Address(string: name) {
             return .value(value)
         }
 
         let server = server
-        let node = input.lowercased().nameHash
+        let node = name.lowercased().nameHash
         if let value = UnstoppableDomainsV2Resolver.cachedAddress(forNode: node, server: server) {
             return .value(value)
         }
 
         let baseURL = Constants.unstoppableDomainsV2API
-        guard let url = URL(string: "\(baseURL)/domains/\(input)") else {
+        guard let url = URL(string: "\(baseURL)/domains/\(name)") else {
             return .init(error: UnstoppableDomainsV2ApiError(localizedDescription: "Error calling \(baseURL) API isMainThread: \(Thread.isMainThread)"))
         }
 
@@ -106,14 +106,14 @@ class UnstoppableDomainsV2Resolver {
 
 extension UnstoppableDomainsV2Resolver: CachebleAddressResolutionServiceType {
 
-    func cachedAddressValue(for input: String) -> AlphaWallet.Address? {
-        return UnstoppableDomainsV2Resolver.cachedAddress(forNode: input.lowercased().nameHash, server: server)
+    func cachedAddressValue(forName name: String) -> AlphaWallet.Address? {
+        return UnstoppableDomainsV2Resolver.cachedAddress(forNode: name.lowercased().nameHash, server: server)
     }
 }
 
 extension UnstoppableDomainsV2Resolver: CachedEnsResolutionServiceType {
 
-    func cachedEnsValue(for address: AlphaWallet.Address) -> String? {
+    func cachedEnsValue(forAddress address: AlphaWallet.Address) -> String? {
         return UnstoppableDomainsV2Resolver.cachedDomain(forNode: address.eip55String, server: server)
     }
 

--- a/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
@@ -23,20 +23,20 @@ class UnstoppableDomainsV2Resolver {
         self.server = server
     }
 
-    private static func cachedAddress(forNode node: String, server: RPCServer) -> AlphaWallet.Address? {
-        return UnstoppableDomainsV2Resolver.addressesCache[ENSLookupKey(name: node, server: server)]
+    private static func cachedAddress(forName name: String, server: RPCServer) -> AlphaWallet.Address? {
+        return UnstoppableDomainsV2Resolver.addressesCache[ENSLookupKey(nameOrAddress: name, server: server)]
     }
 
-    private static func cache(forNode node: String, address: AlphaWallet.Address, server: RPCServer) {
-        UnstoppableDomainsV2Resolver.addressesCache[ENSLookupKey(name: node, server: server)] = address
+    private static func cache(forName name: String, address: AlphaWallet.Address, server: RPCServer) {
+        UnstoppableDomainsV2Resolver.addressesCache[ENSLookupKey(nameOrAddress: name, server: server)] = address
     }
 
-    private static func cachedDomain(forNode node: String, server: RPCServer) -> String? {
-        return UnstoppableDomainsV2Resolver.domainsCache[ENSLookupKey(name: node, server: server)]
+    private static func cachedDomain(forAddress address: AlphaWallet.Address, server: RPCServer) -> String? {
+        return UnstoppableDomainsV2Resolver.domainsCache[ENSLookupKey(nameOrAddress: address.eip55String, server: server)]
     }
 
-    private static func cache(forNode node: String, domain: String, server: RPCServer) {
-        UnstoppableDomainsV2Resolver.domainsCache[ENSLookupKey(name: node, server: server)] = domain
+    private static func cache(forAddress address: AlphaWallet.Address, domain: String, server: RPCServer) {
+        UnstoppableDomainsV2Resolver.domainsCache[ENSLookupKey(nameOrAddress: address.eip55String, server: server)] = domain
     }
 
     func resolveAddress(forName name: String) -> Promise<AlphaWallet.Address> {
@@ -45,8 +45,7 @@ class UnstoppableDomainsV2Resolver {
         }
 
         let server = server
-        let node = name.lowercased().nameHash
-        if let value = UnstoppableDomainsV2Resolver.cachedAddress(forNode: node, server: server) {
+        if let value = UnstoppableDomainsV2Resolver.cachedAddress(forName: name, server: server) {
             return .value(value)
         }
 
@@ -69,14 +68,13 @@ class UnstoppableDomainsV2Resolver {
                     throw UnstoppableDomainsV2ApiError(localizedDescription: "Error calling \(baseURL) API isMainThread: \(Thread.isMainThread)")
                 }
             }.get { address in
-                UnstoppableDomainsV2Resolver.cache(forNode: node, address: address, server: server)
+                UnstoppableDomainsV2Resolver.cache(forName: name, address: address, server: server)
             }
     }
 
     func resolveDomain(address: AlphaWallet.Address) -> Promise<String> {
         let server = server
-        let node = address.eip55String
-        if let value = UnstoppableDomainsV2Resolver.cachedDomain(forNode: node, server: server) {
+        if let value = UnstoppableDomainsV2Resolver.cachedDomain(forAddress: address, server: server) {
             return .value(value)
         }
 
@@ -99,7 +97,7 @@ class UnstoppableDomainsV2Resolver {
                     throw UnstoppableDomainsV2ApiError(localizedDescription: "Error calling \(baseURL) API isMainThread: \(Thread.isMainThread)")
                 }
             }.get { domain in
-                UnstoppableDomainsV2Resolver.cache(forNode: node, domain: domain, server: server)
+                UnstoppableDomainsV2Resolver.cache(forAddress: address, domain: domain, server: server)
             }
     }
 }
@@ -107,14 +105,14 @@ class UnstoppableDomainsV2Resolver {
 extension UnstoppableDomainsV2Resolver: CachebleAddressResolutionServiceType {
 
     func cachedAddressValue(forName name: String) -> AlphaWallet.Address? {
-        return UnstoppableDomainsV2Resolver.cachedAddress(forNode: name.lowercased().nameHash, server: server)
+        return UnstoppableDomainsV2Resolver.cachedAddress(forName: name, server: server)
     }
 }
 
 extension UnstoppableDomainsV2Resolver: CachedEnsResolutionServiceType {
 
     func cachedEnsValue(forAddress address: AlphaWallet.Address) -> String? {
-        return UnstoppableDomainsV2Resolver.cachedDomain(forNode: address.eip55String, server: server)
+        return UnstoppableDomainsV2Resolver.cachedDomain(forAddress: address, server: server)
     }
 
 }

--- a/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
@@ -23,23 +23,21 @@ class ENSReverseLookupCoordinator: ENSDelegateImpl {
         return firstly {
             ENS(delegate: self, chainId: server.chainID).getName(fromAddress: address)
         }.get { name in
-            let node = address.nameHash
-            Self.cache(forNode: node, result: name, server: self.server)
+            Self.cache(forAddress: address, result: name, server: self.server)
         }
     }
 
-    private func cachedResult(forNode node: String) -> String? {
-        return ENSReverseLookupCoordinator.resultsCache[ENSLookupKey(name: node, server: server)]
+    private func cachedResult(forAddress address: AlphaWallet.Address) -> String? {
+        return ENSReverseLookupCoordinator.resultsCache[ENSLookupKey(nameOrAddress: address.eip55String, server: server)]
     }
 
-    private static func cache(forNode node: String, result: String, server: RPCServer) {
-        ENSReverseLookupCoordinator.resultsCache[ENSLookupKey(name: node, server: server)] = result
+    private static func cache(forAddress address: AlphaWallet.Address, result: String, server: RPCServer) {
+        ENSReverseLookupCoordinator.resultsCache[ENSLookupKey(nameOrAddress: address.eip55String, server: server)] = result
     }
 }
 
 extension ENSReverseLookupCoordinator: CachedEnsResolutionServiceType {
     func cachedEnsValue(forAddress address: AlphaWallet.Address) -> String? {
-        let node = address.nameHash
-        return cachedResult(forNode: node)
+        return cachedResult(forAddress: address)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
@@ -4,18 +4,13 @@ import Foundation
 import AlphaWalletENS
 import PromiseKit
 
-class ENSReverseLookupCoordinator: CachedEnsResolutionServiceType, ENSDelegateImpl {
+class ENSReverseLookupCoordinator: ENSDelegateImpl {
     private static var resultsCache = [ENSLookupKey: String]()
 
     private let server: RPCServer
 
     init(server: RPCServer) {
         self.server = server
-    }
-
-    func cachedEnsValue(for input: AlphaWallet.Address) -> String? {
-        let node = input.nameHash
-        return cachedResult(forNode: node)
     }
 
     //TODO make calls from multiple callers at the same time for the same address more efficient
@@ -39,5 +34,12 @@ class ENSReverseLookupCoordinator: CachedEnsResolutionServiceType, ENSDelegateIm
 
     private static func cache(forNode node: String, result: String, server: RPCServer) {
         ENSReverseLookupCoordinator.resultsCache[ENSLookupKey(name: node, server: server)] = result
+    }
+}
+
+extension ENSReverseLookupCoordinator: CachedEnsResolutionServiceType {
+    func cachedEnsValue(for input: AlphaWallet.Address) -> String? {
+        let node = input.nameHash
+        return cachedResult(forNode: node)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/ENSReverseLookupCoordinator.swift
@@ -14,16 +14,16 @@ class ENSReverseLookupCoordinator: ENSDelegateImpl {
     }
 
     //TODO make calls from multiple callers at the same time for the same address more efficient
-    func getENSNameFromResolver(forAddress input: AlphaWallet.Address) -> Promise<String> {
-        //TODO caching should be based on input instead
-        if let cachedResult = cachedEnsValue(for: input) {
+    func getENSNameFromResolver(forAddress address: AlphaWallet.Address) -> Promise<String> {
+        //TODO caching should be based on address instead of node
+        if let cachedResult = cachedEnsValue(forAddress: address) {
             return .value(cachedResult)
         }
 
         return firstly {
-            ENS(delegate: self, chainId: server.chainID).getName(fromAddress: input)
+            ENS(delegate: self, chainId: server.chainID).getName(fromAddress: address)
         }.get { name in
-            let node = input.nameHash
+            let node = address.nameHash
             Self.cache(forNode: node, result: name, server: self.server)
         }
     }
@@ -38,8 +38,8 @@ class ENSReverseLookupCoordinator: ENSDelegateImpl {
 }
 
 extension ENSReverseLookupCoordinator: CachedEnsResolutionServiceType {
-    func cachedEnsValue(for input: AlphaWallet.Address) -> String? {
-        let node = input.nameHash
+    func cachedEnsValue(forAddress address: AlphaWallet.Address) -> String? {
+        let node = address.nameHash
         return cachedResult(forNode: node)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
@@ -5,18 +5,13 @@ import Foundation
 import AlphaWalletENS
 import PromiseKit
 
-class GetENSAddressCoordinator: CachebleAddressResolutionServiceType, ENSDelegateImpl {
+class GetENSAddressCoordinator: ENSDelegateImpl {
 
     private static var resultsCache: [ENSLookupKey: AlphaWallet.Address] = [:]
     private (set) var server: RPCServer
 
     init(server: RPCServer) {
         self.server = server
-    }
-
-    func cachedAddressValue(for input: String) -> AlphaWallet.Address? {
-        let node = input.lowercased().nameHash
-        return cachedResult(forNode: node)
     }
 
     func getENSAddressFromResolver(for input: String) -> Promise<AlphaWallet.Address> {
@@ -39,5 +34,12 @@ class GetENSAddressCoordinator: CachebleAddressResolutionServiceType, ENSDelegat
 
     private static func cache(forNode node: String, result: AlphaWallet.Address, server: RPCServer) {
         GetENSAddressCoordinator.resultsCache[ENSLookupKey(name: node, server: server)] = result
+    }
+}
+
+extension GetENSAddressCoordinator: CachebleAddressResolutionServiceType {
+    func cachedAddressValue(for input: String) -> AlphaWallet.Address? {
+        let node = input.lowercased().nameHash
+        return cachedResult(forNode: node)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
@@ -14,16 +14,16 @@ class GetENSAddressCoordinator: ENSDelegateImpl {
         self.server = server
     }
 
-    func getENSAddressFromResolver(for input: String) -> Promise<AlphaWallet.Address> {
-        //TODO caching should be based on input instead
-        if let cachedResult = cachedAddressValue(for: input) {
+    func getENSAddressFromResolver(forName name: String) -> Promise<AlphaWallet.Address> {
+        //TODO caching should be based on name instead
+        if let cachedResult = cachedAddressValue(forName: name) {
             return .value(cachedResult)
         }
 
         return firstly {
-            ENS(delegate: self, chainId: server.chainID).getENSAddress(fromName: input)
+            ENS(delegate: self, chainId: server.chainID).getENSAddress(fromName: name)
         }.get { address in
-            let node = input.lowercased().nameHash
+            let node = name.lowercased().nameHash
             Self.cache(forNode: node, result: address, server: self.server)
         }
     }
@@ -38,8 +38,8 @@ class GetENSAddressCoordinator: ENSDelegateImpl {
 }
 
 extension GetENSAddressCoordinator: CachebleAddressResolutionServiceType {
-    func cachedAddressValue(for input: String) -> AlphaWallet.Address? {
-        let node = input.lowercased().nameHash
+    func cachedAddressValue(forName name: String) -> AlphaWallet.Address? {
+        let node = name.lowercased().nameHash
         return cachedResult(forNode: node)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSOwnerCoordinator.swift
@@ -23,23 +23,21 @@ class GetENSAddressCoordinator: ENSDelegateImpl {
         return firstly {
             ENS(delegate: self, chainId: server.chainID).getENSAddress(fromName: name)
         }.get { address in
-            let node = name.lowercased().nameHash
-            Self.cache(forNode: node, result: address, server: self.server)
+            Self.cache(forName: name, result: address, server: self.server)
         }
     }
 
-    private func cachedResult(forNode node: String) -> AlphaWallet.Address? {
-        return GetENSAddressCoordinator.resultsCache[ENSLookupKey(name: node, server: server)]
+    private func cachedResult(forName name: String) -> AlphaWallet.Address? {
+        return GetENSAddressCoordinator.resultsCache[ENSLookupKey(nameOrAddress: name, server: server)]
     }
 
-    private static func cache(forNode node: String, result: AlphaWallet.Address, server: RPCServer) {
-        GetENSAddressCoordinator.resultsCache[ENSLookupKey(name: node, server: server)] = result
+    private static func cache(forName name: String, result: AlphaWallet.Address, server: RPCServer) {
+        GetENSAddressCoordinator.resultsCache[ENSLookupKey(nameOrAddress: name, server: server)] = result
     }
 }
 
 extension GetENSAddressCoordinator: CachebleAddressResolutionServiceType {
     func cachedAddressValue(forName name: String) -> AlphaWallet.Address? {
-        let node = name.lowercased().nameHash
-        return cachedResult(forNode: node)
+        return cachedResult(forName: name)
     }
 }

--- a/AlphaWallet/Tokens/Coordinators/GetENSTextRecordsCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/GetENSTextRecordsCoordinator.swift
@@ -27,23 +27,23 @@ final class GetENSTextRecordsCoordinator: ENSDelegateImpl {
         ensReverseLookup = ENSReverseLookupCoordinator(server: server)
     }
 
-    func getENSRecord(for address: AlphaWallet.Address, record: ENSTextRecordKey) -> Promise<String> {
+    func getENSRecord(forAddress address: AlphaWallet.Address, record: ENSTextRecordKey) -> Promise<String> {
         firstly {
             ensReverseLookup.getENSNameFromResolver(forAddress: address)
         }.then { ens -> Promise<String> in
-            self.getENSRecord(for: ens, record: record)
+            self.getENSRecord(forName: ens, record: record)
         }
     }
 
-    func getENSRecord(for input: String, record: ENSTextRecordKey) -> Promise<String> {
-        //TODO caching should be based on input instead
-        let addr = input.lowercased().nameHash
+    func getENSRecord(forName name: String, record: ENSTextRecordKey) -> Promise<String> {
+        //TODO caching should be based on name instead
+        let addr = name.lowercased().nameHash
         if let cachedResult = cachedResult(forNode: addr, record: record) {
             return .value(cachedResult)
         }
 
         return firstly {
-            ENS(delegate: self, chainId: server.chainID).getTextRecord(forName: input, recordKey: record)
+            ENS(delegate: self, chainId: server.chainID).getTextRecord(forName: name, recordKey: record)
         }.get { value in
             self.cache(forNode: addr, record: record, result: value)
         }

--- a/AlphaWalletTests/Tokens/Coordinators/GetENSOwnerCoordinatorTests.swift
+++ b/AlphaWalletTests/Tokens/Coordinators/GetENSOwnerCoordinatorTests.swift
@@ -19,7 +19,7 @@ class GetENSOwnerCoordinatorTests: XCTestCase {
         let ensName = "b00n.thisisme.eth"
         let server = makeServerForMainnet()
         firstly {
-            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(for: ensName)
+            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(forName: ensName)
         }.done { address in
             if address.sameContract(as: "0xbbce83173d5c1D122AE64856b4Af0D5AE07Fa362") {
                 expectation.fulfill()
@@ -39,7 +39,7 @@ class GetENSOwnerCoordinatorTests: XCTestCase {
         let ensName = "ethereum.eth"
         let server = makeServerForMainnet()
         firstly {
-            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(for: ensName)
+            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(forName: ensName)
         }.done { address in
             if address.sameContract(as: "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe") {
                 expectation.fulfill()
@@ -59,7 +59,7 @@ class GetENSOwnerCoordinatorTests: XCTestCase {
         let ensName = "1.offchainexample.eth"
         let server = makeServerForMainnet()
         firstly {
-            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(for: ensName)
+            GetENSAddressCoordinator(server: server).getENSAddressFromResolver(forName: ensName)
         }.done { address in
             if address.sameContract(as: "0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5") {
                 expectation.fulfill()

--- a/modules/AlphaWalletENS/AlphaWalletENS/Extensions/Address+Extensions.swift
+++ b/modules/AlphaWalletENS/AlphaWalletENS/Extensions/Address+Extensions.swift
@@ -8,8 +8,8 @@ import Foundation
 import AlphaWalletAddress
 
 extension AlphaWallet.Address {
-    //Hash based on the EIP655 address. So not really https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md
-    public var nameHash: String {
+    //https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md
+    var nameHash: String {
         "\(eip55String.drop0x).addr.reverse".lowercased().nameHash
     }
 }


### PR DESCRIPTION
Less computation and easier to debug

Depends on and includes: #4272