### PR TITLE
Add Makefile target to build and run app in booted simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,9 @@ test14:
 	@xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5' test | $(beautify_cmd)
 
 test: test15
+
+build_and_run_booted:
+	#The simulator "name" specified doesn't matter
+	@xcrun xcodebuild -scheme AlphaWallet -workspace AlphaWallet.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=15.2' -derivedDataPath ./build
+	@xcrun simctl install booted ./build/Build/Products/Debug-iphonesimulator/AlphaWallet.app
+	@xcrun simctl launch booted com.stormbird.alphawallet


### PR DESCRIPTION
make `build_and_run_booted`

Useful for quick testing of PR — especially after cloning the repo separately — without launching Xcode/AppCode and waiting for project to refresh.