### PR TITLE
[Performance] Speed up cached smart contract calls that are not invoked from TokenScript

### DIFF
--- a/AlphaWallet/Core/ENS/ENSDelegateImpl.swift
+++ b/AlphaWallet/Core/ENS/ENSDelegateImpl.swift
@@ -18,7 +18,7 @@ protocol ENSDelegateImpl: ENSDelegate {
 extension ENSDelegateImpl {
     func callSmartContract(withChainId chainId: ChainId, contract: AlphaWallet.Address, functionName: String, abiString: String, parameters: [AnyObject], timeout: TimeInterval?) -> Promise<[String: Any]> {
         let server = RPCServer(chainID: chainId)
-        return globalCallSmartContract(server, contract, functionName, abiString, parameters, timeout)
+        return globalCallSmartContract(server, contract, functionName, abiString, parameters, timeout, false)
     }
 
     func getSmartContractCallData(withChainId chainId: ChainId, contract: AlphaWallet.Address, functionName: String, abiString: String, parameters: [AnyObject], timeout: TimeInterval?) -> Data? {

--- a/AlphaWallet/TokenScriptClient/Models/CallForAssetAttributeCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Models/CallForAssetAttributeCoordinator.swift
@@ -51,7 +51,7 @@ class CallForAssetAttributeCoordinator {
             let contract = functionCall.contract
 
             //Fine to store a strong reference to self here because it's still useful to cache the function call result
-            callSmartContract(withServer: functionCall.server, contract: contract, functionName: functionCall.functionName, abiString: "[\(function.abi)]", parameters: functionCall.arguments).done { dictionary in
+            callSmartContract(withServer: functionCall.server, contract: contract, functionName: functionCall.functionName, abiString: "[\(function.abi)]", parameters: functionCall.arguments, shouldDelayIfCached: true).done { dictionary in
                 if let value = dictionary["0"] {
                     switch functionCall.output.type {
                     case .address:


### PR DESCRIPTION
Removes the delay of 0.7sec that is only needed as hack for TokenScript views