### PR TITLE
Fix: eth_call might have `value` specified. Include if it does. Otherwise tapping Buy in OpenSea with non-zero eth will fail because an eth_call with `value` is made to estimate gas #4299

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -165,8 +165,8 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
         coordinator.start(fromSource: .browser)
     }
 
-    private func ethCall(callbackID: Int, from: AlphaWallet.Address?, to: AlphaWallet.Address?, data: String, server: RPCServer) {
-        let request = EthCallRequest(from: from, to: to, data: data)
+    private func ethCall(callbackID: Int, from: AlphaWallet.Address?, to: AlphaWallet.Address?, value: String?, data: String, server: RPCServer) {
+        let request = EthCallRequest(from: from, to: to, value: value, data: data)
         firstly {
             Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)))
         }.done { result in
@@ -490,11 +490,11 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
                 signMessage(with: .typedMessage(typedData), account: account, callbackID: callbackID)
             case .signTypedMessageV3(let typedData):
                 signMessage(with: .eip712v3And4(typedData), account: account, callbackID: callbackID)
-            case .ethCall(from: let from, to: let to, data: let data):
+            case .ethCall(from: let from, to: let to, value: let value, data: let data):
                 //Must use unchecked form for `Address `because `from` and `to` might be 0x0..0. We assume the dapp author knows what they are doing
                 let from = AlphaWallet.Address(uncheckedAgainstNullAddress: from)
                 let to = AlphaWallet.Address(uncheckedAgainstNullAddress: to)
-                ethCall(callbackID: callbackID, from: from, to: to, data: data, server: server)
+                ethCall(callbackID: callbackID, from: from, to: to, value: value, data: data, server: server)
             case .walletAddEthereumChain(let customChain):
                 addCustomChain(callbackID: callbackID, customChain: customChain, inViewController: viewController)
             case .walletSwitchEthereumChain(let targetChain):

--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -12,7 +12,7 @@ enum DappAction {
     case signTransaction(UnconfirmedTransaction)
     case sendTransaction(UnconfirmedTransaction)
     case sendRawTransaction(String)
-    case ethCall(from: String, to: String, data: String)
+    case ethCall(from: String, to: String, value: String?, data: String)
     case walletAddEthereumChain(WalletAddEthereumChainObject)
     case walletSwitchEthereumChain(WalletSwitchEthereumChainObject)
     case unknown
@@ -47,7 +47,8 @@ extension DappAction {
                 let from = command.object["from"]?.value ?? ""
                 let to = command.object["to"]?.value ?? ""
                 let data = command.object["data"]?.value ?? ""
-                return .ethCall(from: from, to: to, data: data)
+                let value: String? = command.object["value"]?.value
+                return .ethCall(from: from, to: to, value: value, data: data)
             case .unknown:
                 return .unknown
             }

--- a/AlphaWallet/EtherClient/Requests/EthCalllRequest.swift
+++ b/AlphaWallet/EtherClient/Requests/EthCalllRequest.swift
@@ -8,6 +8,7 @@ struct EthCallRequest: JSONRPCKit.Request {
 
     let from: AlphaWallet.Address?
     let to: AlphaWallet.Address?
+    let value: String?
     let data: String
 
     var method: String {
@@ -24,6 +25,9 @@ struct EthCallRequest: JSONRPCKit.Request {
         }
         if let from = from {
             payload["from"] = from.eip55String
+        }
+        if let value = value {
+            payload["value"] = value
         }
         let results: [Any] = [
             payload,


### PR DESCRIPTION
Fix #4299

Before the PR, this fails because when purchasing an NFT, OpenSea invokes `atomicMatch_()` as a call to estimate gas before the actual `atomicMatch_()` transaction. The `eth_call` contains a `value` which we had ignored.

To reproduce (needs enough ETH on mainnet/testnet, but doesn't require spending them):

1. Go to https://opensea.io or https://testnets.opensea.io in browser tab
2. Make sure browser is set to Ethereum mainnet or Rinkeby accordingly
3. Pick an NFT which has a Buy Now button (see screenshot)
4. Tap Buy Now
5. Agree to signature request (for "Welcome to Open…")
6. Agree to terms
7. Tap Confirm checkout

Expect
---
8. Actionsheet to confirm transaction to appear

Observed
---
9. Actionsheet to confirm transaction to appear

Example of NFT if it hasn't been sold: https://opensea.io/assets/0x495f947276749ce646f68ac8c248420045cb7b5e/31862423316013544672112958943537902323768601419378833813327842235360034684929 [^1]

[^1]: Search for one like this: https://opensea.io/assets?search[chains][0]=ETHEREUM&search[priceFilter][symbol]=ETH&search[priceFilter][min]=0.001&search[resultModel]=ASSETS&search[sortAscending]=true&search[sortBy]=PRICE&search[toggles][0]=BUY_NOW