### PR TITLE
Added -disableAutomaticPackageResolution to test14, test15, build_and_run_booted targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,16 +88,16 @@ install_bundle:
 	@$(gem_cmd) install --install-dir=$(vendor_path) $(bundle_gem)
 
 test15:
-	@xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.4' test | $(beautify_cmd)
+	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.4' test | $(beautify_cmd)
 
 test14:
-	@xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5' test | $(beautify_cmd)
+	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5' test | $(beautify_cmd)
 
 test: test15
 
 build_and_run_booted:
-	#The simulator "name" specified doesn't matter
-	@xcrun xcodebuild -scheme AlphaWallet -workspace AlphaWallet.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=15.4' -derivedDataPath ./build
+#The simulator "name" specified doesn't matter
+	@xcrun xcodebuild -disableAutomaticPackageResolution -scheme AlphaWallet -workspace AlphaWallet.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=15.4' -derivedDataPath ./build 
 	@xcrun simctl install booted ./build/Build/Products/Debug-iphonesimulator/AlphaWallet.app
 	@xcrun simctl launch booted com.stormbird.alphawallet
 


### PR DESCRIPTION
I added this to the makefile so that when building via the command line, we won't have to automatically resolve the Package dependency. The dependency should be resolved and updated when you add a new dependency (via Xcode or the command line). Once it's checked in to the git repository, we shouldn't resolve the dependencies again.

https://developer.apple.com/documentation/swift_packages/building_swift_packages_or_apps_that_use_them_in_continuous_integration_workflows

```
Use the Expected Version of a Package Dependency
To ensure the CI workflow’s reliability, make sure it uses the appropriate version of package dependencies. Xcode stores the exact version of each package dependency in a file called Package.resolved. The file automatically updates when package requirements in your Xcode project or in the Package.swift manifest file change. Commit this file to your Git repository to ensure it’s always up-to-date on the CI environment to prevent the CI from building your project with unexpected versions of package dependencies.
Tip
You can find the Package.resolved file inside your .xcodeproj directory at [appName].xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved.
If your CI pipeline uses the xcodebuild command directly, also pass the -disableAutomaticPackageResolution flag. This flag ensures that the CI pipeline always uses the package dependencies as defined in the Package.resolved file.
```