### PR TITLE
Changed timeout in GetIsERC1155ContractCoordinatorTestCase to 20 seconds instead of 10 minutes, fixed up some style issues.

### DIFF
--- a/AlphaWalletTests/Tokens/Coordinators/GetIsERC1155ContractCoordinatorTestCase.swift
+++ b/AlphaWalletTests/Tokens/Coordinators/GetIsERC1155ContractCoordinatorTestCase.swift
@@ -30,20 +30,23 @@ class GetIsERC1155ContractCoordinatorTestCase: XCTestCase {
     func testgetIsERC1155Contract() throws {
         let coordinator = GetIsERC1155ContractCoordinator(forServer: .main, cacheName: fileName)
         let expectation = expectation(description: "Waiting for server response")
-        coordinator.getIsERC1155Contract(for: address1)
-            .done { returnValue in
-                self.result = returnValue
-                expectation.fulfill()
-            }
-            .cauterize()
-        wait(for: [expectation], timeout: 10 * 60)
+        firstly {
+            coordinator.getIsERC1155Contract(for: address1)
+        }.done { returnValue in
+            self.result = returnValue
+        }.ensure {
+            expectation.fulfill()
+        }.catch {error in
+            XCTFail("Unknown error: \(error)")
+        }
+        wait(for: [expectation], timeout: 20)
         let cache = CachedERC1155ContractDictionary(fileName: fileName)
         XCTAssertNotNil(cache)
         XCTAssertNotNil(result)
-        let cachedResult = cache!.isERC1155Contract(for: address1)
+        let cachedResult = cache?.isERC1155Contract(for: address1)
         XCTAssertNotNil(cachedResult)
-        XCTAssertEqual(cachedResult!, result!)
-        cache!.remove()
+        XCTAssertEqual(cachedResult, result)
+        cache?.remove()
     }
 
 }


### PR DESCRIPTION
Changed time out for GetIsERC1155ContractCoordinatorTestCase from 10 minutes to 20 seconds. Fixed up some style issues with PromiseKit calls. 
