### PR TITLE
Move utility functions to AlphaWalletCore pod

### DIFF
--- a/AlphaWallet/Core/Coordinators/WalletBalance/PrivateBalanceFetcher.swift
+++ b/AlphaWallet/Core/Coordinators/WalletBalance/PrivateBalanceFetcher.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
+import AlphaWalletCore
 import BigInt
 import PromiseKit
 import Result
 import SwiftyJSON
-import Combine
 
 protocol PrivateTokensDataStoreDelegate: AnyObject {
     func didUpdate(in tokensDataStore: PrivateBalanceFetcher)

--- a/AlphaWallet/Core/NFT/Enjin/EnjinNetworkProvider.swift
+++ b/AlphaWallet/Core/NFT/Enjin/EnjinNetworkProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AlphaWalletCore
 import Apollo
 import PromiseKit
 

--- a/AlphaWallet/Core/NFT/OpenSea/OpenSeaNetworkProvider.swift
+++ b/AlphaWallet/Core/NFT/OpenSea/OpenSeaNetworkProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import Alamofire
+import AlphaWalletCore
 import BigInt
 import PromiseKit
 import Result

--- a/AlphaWallet/Core/TokensAutodetector/TokensAutodetector.swift
+++ b/AlphaWallet/Core/TokensAutodetector/TokensAutodetector.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AlphaWalletCore
 import PromiseKit
 
 extension SingleChainTokensAutodetector {
@@ -77,7 +78,7 @@ class SingleChainTokensAutodetector: NSObject, TokensAutodetector {
             self?.autoDetectTransactedTokens()
             self?.autoDetectPartnerTokens()
         }
-    } 
+    }
 
     ///Implementation: We refresh once only, after all the auto detected tokens' data have been pulled because each refresh pulls every tokens' (including those that already exist before the this auto detection) price as well as balance, placing heavy and redundant load on the device. After a timeout, we refresh once just in case it took too long, so user at least gets the chance to see some auto detected tokens
     private func autoDetectTransactedTokens() {
@@ -237,7 +238,7 @@ extension SingleChainTokensAutodetector: AutoDetectTransactedTokensOperationDele
         return when(resolved: [fetchErc20Tokens, fetchNonErc20Tokens])
             .map(on: queue, { results in
                 return results.compactMap { $0.optionalValue }.flatMap { $0 }
-            }) 
+            })
     }
 }
 

--- a/AlphaWallet/Core/Types/TokenProviderType.swift
+++ b/AlphaWallet/Core/Types/TokenProviderType.swift
@@ -5,12 +5,13 @@
 //  Created by Vladyslav Shepitko on 27.08.2021.
 //
 
+import AlphaWalletCore
 import PromiseKit
 import Result
 import BigInt
 
 // NOTE: Think about the name, more fittable name is needed
-protocol TokenProviderType: class { 
+protocol TokenProviderType: class {
     func getContractName(for address: AlphaWallet.Address) -> Promise<String>
     func getContractSymbol(for address: AlphaWallet.Address) -> Promise<String>
     func getDecimals(for address: AlphaWallet.Address) -> Promise<UInt8>
@@ -246,6 +247,6 @@ class TokenProvider: TokenProviderType {
         }.catch({ e in
             error(value: e, pref: "isErc20Promise", address: address)
         })
-    } 
+    }
 }
 

--- a/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinator.swift
@@ -6,17 +6,6 @@ import PromiseKit
 import web3swift
 import Combine
 
-extension PromiseKit.Result {
-    var optionalValue: T? {
-        switch self {
-        case .fulfilled(let value):
-            return value
-        case .rejected:
-            return nil
-        }
-    }
-}
-
 final class EventSourceCoordinator: NSObject {
     private var wallet: Wallet
     private let tokensDataStore: TokensDataStore
@@ -28,7 +17,7 @@ final class EventSourceCoordinator: NSObject {
     private let queue = DispatchQueue(label: "com.eventSourceCoordinator.updateQueue")
     private let enabledServers: [RPCServer]
     private var cancellable = Set<AnyCancellable>()
-    
+
     init(wallet: Wallet, tokensDataStore: TokensDataStore, assetDefinitionStore: AssetDefinitionStore, eventsDataStore: NonActivityEventsDataStore, config: Config) {
         self.wallet = wallet
         self.tokensDataStore = tokensDataStore
@@ -43,7 +32,7 @@ final class EventSourceCoordinator: NSObject {
     func start() {
         setupWatchingTokenChangesToFetchEvents()
         setupWatchingTokenScriptFileChangesToFetchEvents()
-    } 
+    }
 
     private func setupWatchingTokenChangesToFetchEvents() {
         tokensDataStore

--- a/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinatorForActivities.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/EventSourceCoordinatorForActivities.swift
@@ -1,6 +1,7 @@
 // Copyright © 2020 Stormbird PTE. LTD.
 
 import Foundation
+import AlphaWalletCore
 import BigInt
 import PromiseKit
 import web3swift
@@ -30,7 +31,7 @@ final class EventSourceCoordinatorForActivities {
     func start() {
         setupWatchingTokenChangesToFetchEvents()
         setupWatchingTokenScriptFileChangesToFetchEvents()
-    } 
+    }
 
     private func setupWatchingTokenChangesToFetchEvents() {
         tokensDataStore
@@ -128,7 +129,7 @@ extension EventSourceCoordinatorForActivities.functional {
 
             let oldEvent = eventsDataStore
             .getLastMatchingEventSortedByBlockNumber(forContract: eventOrigin.contract, tokenContract: tokenContract, server: server, eventName: eventOrigin.eventName)
-            
+
             let fromBlock: (EventFilter.Block, UInt64)
             if let newestEvent = oldEvent {
                 let value = UInt64(newestEvent.blockNumber + 1)

--- a/AlphaWallet/Transactions/Coordinators/AlphaWalletProviderFactory.swift
+++ b/AlphaWallet/Transactions/Coordinators/AlphaWalletProviderFactory.swift
@@ -8,7 +8,7 @@ import Combine
 
 struct AlphaWalletProviderFactory {
     static let policies: [String: ServerTrustPolicy] = [:]
-    
+
     static func makeProvider() -> MoyaProvider<AlphaWalletService> {
         let manager = Manager(
             configuration: URLSessionConfiguration.default,
@@ -35,45 +35,6 @@ extension MoyaProvider {
                     seal.reject(error)
                 }
             }
-        }
-    }
-}
-
-func attempt<T>(maximumRetryCount: Int = 3, delayBeforeRetry: DispatchTimeInterval = .seconds(1), delayUpperRangeValueFrom0To: Int = 5, _ body: @escaping () -> Promise<T>) -> Promise<T> {
-    var attempts = 0
-    func attempt() -> Promise<T> {
-        attempts += 1
-        return body().recover { error -> Promise<T> in
-            guard attempts < maximumRetryCount else {
-                throw error
-            }
-
-            if case PMKError.cancelled = error {
-                throw error
-            }
-            return after(delayBeforeRetry.nextRandomInterval(upTo: delayUpperRangeValueFrom0To)).then(on: nil, attempt)
-        }
-    }
-
-    return attempt()
-}
-
-private extension DispatchTimeInterval {
-
-    func nextRandomInterval(upTo value: Int = 5) -> DispatchTimeInterval {
-        let jitter = Int.random(in: 0 ..< value)
-
-        switch self {
-        case .microseconds(let value):
-            return .microseconds(value + jitter)
-        case .milliseconds(let value):
-            return .milliseconds(value + jitter)
-        case .nanoseconds(let value):
-            return .nanoseconds(value + jitter)
-        case .never:
-            return .never
-        case .seconds(let value):
-            return .seconds(value + jitter)
         }
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,8 @@ PODS:
     - EthereumAddress
     - TrustKeystore
     - web3swift
-  - AlphaWalletCore (1.0.1)
+  - AlphaWalletCore (1.0.1):
+    - PromiseKit
   - AlphaWalletENS (1.0.0):
     - AlphaWalletAddress
     - PromiseKit
@@ -267,7 +268,7 @@ SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   Alamofire-Synchronous: eedf1e6e961c3795a63c74990b3f7d9fbfac7e50
   AlphaWalletAddress: d742c9b77d0a798c6711de5c32b573e474b64d8e
-  AlphaWalletCore: f0dc8f3f6c6600b9419596b944deb4145f00f7e1
+  AlphaWalletCore: 0424dd8e215a8aa57c9828543a960071a95663e8
   AlphaWalletENS: df3cb79a2def496f78b06a838d0a111528e473db
   AlphaWalletWeb3Provider: 7ca1e1c1dc841dc1915f970daace48bf34931655
   APIKit: 9e1a4069608bf0ae5238811e6cfc26928ad4d01e

--- a/modules/AlphaWalletCore/AlphaWalletCore.podspec
+++ b/modules/AlphaWalletCore/AlphaWalletCore.podspec
@@ -25,4 +25,5 @@ Pod::Spec.new do |s|
 
   s.frameworks       = 'Foundation'
 
+  s.dependency 'PromiseKit'
 end

--- a/modules/AlphaWalletCore/AlphaWalletCore/Extensions/PromiseKit+Extensions.swift
+++ b/modules/AlphaWalletCore/AlphaWalletCore/Extensions/PromiseKit+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  PromiseKit+Extensions.swift
+//  AlphaWalletOpenSea
+//
+//  Created by Hwee-Boon Yar on Apr/30/22.
+//
+
+import Foundation
+import PromiseKit
+
+extension PromiseKit.Result {
+    public var optionalValue: T? {
+        switch self {
+        case .fulfilled(let value):
+            return value
+        case .rejected:
+            return nil
+        }
+    }
+}

--- a/modules/AlphaWalletCore/AlphaWalletCore/attempt.swift
+++ b/modules/AlphaWalletCore/AlphaWalletCore/attempt.swift
@@ -1,0 +1,47 @@
+//
+//  attempt.swift
+//  AlphaWalletCore
+//
+//  Created by Hwee-Boon Yar on Apr/30/22.
+//
+
+import Foundation
+import PromiseKit
+
+public func attempt<T>(maximumRetryCount: Int = 3, delayBeforeRetry: DispatchTimeInterval = .seconds(1), delayUpperRangeValueFrom0To: Int = 5, _ body: @escaping () -> Promise<T>) -> Promise<T> {
+    var attempts = 0
+    func attempt() -> Promise<T> {
+        attempts += 1
+        return body().recover { error -> Promise<T> in
+            guard attempts < maximumRetryCount else {
+                throw error
+            }
+
+            if case PMKError.cancelled = error {
+                throw error
+            }
+            return after(delayBeforeRetry.nextRandomInterval(upTo: delayUpperRangeValueFrom0To)).then(on: nil, attempt)
+        }
+    }
+
+    return attempt()
+}
+
+fileprivate extension DispatchTimeInterval {
+    func nextRandomInterval(upTo value: Int = 5) -> DispatchTimeInterval {
+        let jitter = Int.random(in: 0 ..< value)
+
+        switch self {
+        case .microseconds(let value):
+            return .microseconds(value + jitter)
+        case .milliseconds(let value):
+            return .milliseconds(value + jitter)
+        case .nanoseconds(let value):
+            return .nanoseconds(value + jitter)
+        case .never:
+            return .never
+        case .seconds(let value):
+            return .seconds(value + jitter)
+        }
+    }
+}


### PR DESCRIPTION
Towards #4472 as these code are used across modules/apps. 

Probably have to be careful with moving stuff into `AlphaWalletCore` like this. This PR for example adds `PromiseKit` as a dependency to `AlphaWalletCore` which had zero third party dependencies. But did it anyway to avoid add yet another new pod (for now, since I'm building one for OpenSea).