### PR TITLE
Renamed protocols in SaveCustomRpcManualEntryView and WhatsNewListingViewController-Coordinator from DelegateProtocols to Delegate etc

### DIFF
--- a/AlphaWallet/Settings/Views/SaveCustomRpcManualEntryView.swift
+++ b/AlphaWallet/Settings/Views/SaveCustomRpcManualEntryView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-@objc protocol KeyboardNavigationDelegateProtocol {
+@objc protocol KeyboardNavigationDelegate {
     func gotoNextResponder()
     func gotoPrevResponder()
     func addHttpsText()
@@ -199,7 +199,7 @@ class SaveCustomRpcManualEntryView: UIView {
 
 }
 
-extension SaveCustomRpcManualEntryView: KeyboardNavigationDelegateProtocol {
+extension SaveCustomRpcManualEntryView: KeyboardNavigationDelegate {
 
     func gotoNextResponder() {
         nextTextField()?.becomeFirstResponder()
@@ -232,7 +232,7 @@ fileprivate func defaultTextField(_ type: UIKeyboardType, placeHolder: String, l
     return textField
 }
 
-fileprivate func navToolbar(for delegate: KeyboardNavigationDelegateProtocol) -> UIToolbar {
+fileprivate func navToolbar(for delegate: KeyboardNavigationDelegate) -> UIToolbar {
     let toolbar = UIToolbar(frame: .zero)
     let prev = UIBarButtonItem(title: "<", style: .plain, target: delegate, action: #selector(delegate.gotoPrevResponder))
     let next = UIBarButtonItem(title: ">", style: .plain, target: delegate, action: #selector(delegate.gotoNextResponder))
@@ -242,7 +242,7 @@ fileprivate func navToolbar(for delegate: KeyboardNavigationDelegateProtocol) ->
     return toolbar
 }
 
-fileprivate func urlToolbar(for delegate: KeyboardNavigationDelegateProtocol) -> UIToolbar {
+fileprivate func urlToolbar(for delegate: KeyboardNavigationDelegate) -> UIToolbar {
     let toolbar = UIToolbar(frame: .zero)
     let prev = UIBarButtonItem(title: "<", style: .plain, target: delegate, action: #selector(delegate.gotoPrevResponder))
     let next = UIBarButtonItem(title: ">", style: .plain, target: delegate, action: #selector(delegate.gotoNextResponder))

--- a/AlphaWallet/WhatsNew/Coordinators/WhatsNewExperimentCoordinator.swift
+++ b/AlphaWallet/WhatsNew/Coordinators/WhatsNewExperimentCoordinator.swift
@@ -64,7 +64,7 @@ class WhatsNewExperimentCoordinator: Coordinator {
     }
 }
 
-extension WhatsNewExperimentCoordinator: WhatsNewListingCoordinatorProtocol {
+extension WhatsNewExperimentCoordinator: WhatsNewListingCoordinatorDelegate {
     func didDismiss(controller: WhatsNewListingViewController) {
         delegate?.didEnd(in: self)
     }

--- a/AlphaWallet/WhatsNew/Coordinators/WhatsNewListingCoordinator.swift
+++ b/AlphaWallet/WhatsNew/Coordinators/WhatsNewListingCoordinator.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-@objc protocol WhatsNewListingCoordinatorProtocol {
+@objc protocol WhatsNewListingCoordinatorDelegate {
     func didDismiss(controller: WhatsNewListingViewController)
 }
 
@@ -20,7 +20,7 @@ class WhatsNewListingCoordinator: NSObject, Coordinator {
         super.init()
     }
 
-    func display(viewModel: WhatsNewListingViewModel, delegate: WhatsNewListingCoordinatorProtocol) {
+    func display(viewModel: WhatsNewListingViewModel, delegate: WhatsNewListingCoordinatorDelegate) {
         let viewController = WhatsNewListingViewController(viewModel: viewModel)
         viewController.whatsNewListingDelegate = delegate
         navigationController.present(viewController, animated: true)

--- a/AlphaWallet/WhatsNew/ViewControllers/WhatsNewListingViewController.swift
+++ b/AlphaWallet/WhatsNew/ViewControllers/WhatsNewListingViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class WhatsNewListingViewController: ModalViewController {
     let viewModel: WhatsNewListingViewModel
-    weak var whatsNewListingDelegate: WhatsNewListingCoordinatorProtocol?
+    weak var whatsNewListingDelegate: WhatsNewListingCoordinatorDelegate?
 
     init(viewModel: WhatsNewListingViewModel) {
         self.viewModel = viewModel


### PR DESCRIPTION
Code renamed to remove Protocol from DelegateProtocols and CoordinatorProtocols.