### PR TITLE
Corrected enabledTokens function call parameters in SendViewControllerTests.

### DIFF
--- a/AlphaWalletTests/Transfer/ViewControllers/SendViewControllerTests.swift
+++ b/AlphaWalletTests/Transfer/ViewControllers/SendViewControllerTests.swift
@@ -355,7 +355,7 @@ class SendViewControllerTests: XCTestCase {
         let token = TokenObject(contract: AlphaWallet.Address.make(), server: .main, decimals: 18, value: "2020224719101120", type: .erc20)
         tokenBalanceService.addOrUpdateTokenTestsOnly(token: Token(tokenObject: token))
 
-        let tokens = tokenBalanceService.tokensDataStore.enabledTokens(forServers: [.main])
+        let tokens = tokenBalanceService.tokensDataStore.enabledTokens(for: [.main])
 
         XCTAssertTrue(tokens.contains(Token(tokenObject: token)))
 


### PR DESCRIPTION
There is a compile bug in the `SendViewControllerTests`. This pull request fixes it.