### PR TITLE
Re-order groups in Wallet tab

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -306,10 +306,10 @@ fileprivate extension WalletFilter {
     static var orderedTabs: [WalletFilter] {
         return [
             .all,
-            .defi,
-            .governance,
             .assets,
             .collectiblesOnly,
+            .defi,
+            .governance,
         ]
     }
 


### PR DESCRIPTION
(Disregard margin differences in screenshot below:)

Before PR|After PR
-|-
<img width="487" alt="Screenshot 2022-05-31 at 4 05 47 PM" src="https://user-images.githubusercontent.com/56189/171125304-a20809e2-009c-47f2-bec0-c85b0128d4fa.png">|<img width="487" alt="Screenshot 2022-05-31 at 4 10 39 PM" src="https://user-images.githubusercontent.com/56189/171125268-4e4d9b3b-ccd7-4c99-a2ad-71ca573c098c.png">
