### PR TITLE
[Refactor] Access fonts via Fonts.regular(size:) etc instead of explicitly referring to the font family/name

### DIFF
--- a/AlphaWallet/AddMultipleCustomRpc/AddMultipleCustomRpcView.swift
+++ b/AlphaWallet/AddMultipleCustomRpc/AddMultipleCustomRpcView.swift
@@ -20,7 +20,7 @@ class AddMultipleCustomRpcView: UIView {
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProBold(size: 17.0)
+        label.font = Fonts.bold(size: 17)
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -36,7 +36,7 @@ class AddMultipleCustomRpcView: UIView {
 
     private lazy var networkNameLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProRegular(size: 15.0)
+        label.font = Fonts.regular(size: 15)
         label.text = "…"
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -51,7 +51,7 @@ class AddMultipleCustomRpcView: UIView {
 
     private lazy var progressLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProRegular(size: 15.0)
+        label.font = Fonts.regular(size: 15)
         label.text = "-"
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -144,7 +144,7 @@ class AddMultipleCustomRpcView: UIView {
     func stopActivityIndicator() {
         activityIndicatorView.stopAnimating()
     }
-    
+
     func update() {
         networkNameLabel.text = chainNameString
         progressLabel.text = progressString

--- a/AlphaWallet/Features/FeaturesTableViewController.swift
+++ b/AlphaWallet/Features/FeaturesTableViewController.swift
@@ -59,7 +59,7 @@ class FeaturesTableViewController: UITableViewController {
     private func configure(cell: UITableViewCell, at indexPath: IndexPath) -> UITableViewCell {
         let key = keys[indexPath.row]
         let value = features.isAvailable(key)
-        cell.textLabel?.font = R.font.sourceSansProRegular(size: 12.0)
+        cell.textLabel?.font = Fonts.regular(size: 12)
         cell.textLabel?.text = key.rawValue.insertSpaceBeforeCapitals()
         cell.accessoryType = value ? .checkmark : .none
         return cell

--- a/AlphaWallet/Settings/ViewModels/ServerViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/ServerViewModel.swift
@@ -82,7 +82,7 @@ struct ServerImageViewModel: ServerImageTableViewCellViewModelType {
     var primaryText: String {
         return server.displayName
     }
-    var primaryFont: UIFont = R.font.sourceSansProRegular(size: 20.0)!
+    var primaryFont: UIFont = Fonts.regular(size: 20)
     var primaryFontColor: UIColor = R.color.black()!
 
     var secondaryText: String {
@@ -94,7 +94,7 @@ struct ServerImageViewModel: ServerImageTableViewCellViewModelType {
         }
 
     }
-    var secondaryFont: UIFont = R.font.sourceSansProRegular(size: 15.0)!
+    var secondaryFont: UIFont = Fonts.regular(size: 15)
     var secondaryFontColor: UIColor = R.color.dove()!
 }
 

--- a/AlphaWallet/Style/AppStyle.swift
+++ b/AlphaWallet/Style/AppStyle.swift
@@ -9,7 +9,7 @@ func applyStyle() {
     UITabBar.appearance().tintColor = Colors.appTint
     UITabBar.appearance().shadowImage = UIImage(color: Style.TabBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
     UITabBar.appearance().backgroundImage = UIImage(color: Style.TabBar.Background.color)
-    
+
     UINavigationBar.appearance().shadowImage = UIImage(color: Style.NavigationBar.Separator.color, size: CGSize(width: 0.25, height: 0.25))
     UINavigationBar.appearance().compactAppearance = UINavigationBarAppearance.defaultAppearence
     UINavigationBar.appearance().standardAppearance = UINavigationBarAppearance.defaultAppearence
@@ -376,7 +376,7 @@ enum Style {
             static let height = 60.0
             static let backgroundColor = R.color.alabaster()
             static let textColor = R.color.dove()
-            static let font = R.font.sourceSansProSemibold(size: 15.0)
+            static let font = Fonts.semibold(size: 15)
         }
         enum Row {
             static let height = 80.0
@@ -417,8 +417,8 @@ enum Style {
             static let color: UIColor = R.color.mercury()!
         }
         enum Font {
-            static let normal: UIFont = R.font.sourceSansProRegular(size: 13.0)!
-            static let selected: UIFont = R.font.sourceSansProSemibold(size: 13.0)!
+            static let normal: UIFont = Fonts.regular(size: 13)
+            static let selected: UIFont = Fonts.semibold(size: 13)
             enum Color {
                 static let selected: UIColor = R.color.azure()!
                 static let normal: UIColor = R.color.dove()!
@@ -430,7 +430,7 @@ enum Style {
             static let color: UIColor = R.color.mercury()!
         }
     }
-    
+
     enum NavigationBar {
         enum Separator {
             static let color: UIColor = R.color.mercury()!
@@ -453,7 +453,7 @@ enum Style {
     enum Search {
         enum Network {
             enum Empty {
-                static let font = R.font.sourceSansProRegular(size: 17.0)
+                static let font = Fonts.regular(size: 17)
                 static let color: UIColor = R.color.mine()!
                 static let text: String = R.string.localizable.searchNetworkResultEmpty()
             }
@@ -463,7 +463,7 @@ enum Style {
         static let configuration = ScrollableSegmentedControlConfiguration(lineConfiguration: ScrollableSegmentedControlHighlightableLineViewConfiguration(lineHeight: 1.0, highlightHeight: 3.0, lineColor: R.color.mercury()!, highLightColor: R.color.azure()!), isProportionalWidth: true, cellSpacing: 10.0, alignmentWhenNotScrollable: .filled, animationDuration: 0.25, animationCurve: .easeInOut)
     }
     enum ScrollableSegmentedControlCell {
-        static let configuration = ScrollableSegmentedControlCellConfiguration(backgroundColor: .white, highlightedTextColor: R.color.azure()!, nonHighlightedTextColor: R.color.dove()!, highlightedFont: R.font.sourceSansProSemibold(size: 15.0)!, nonHighlightedFont: R.font.sourceSansProRegular(size: 15.0)!, cellPadding: 8.0, textBottomPadding: 12.0)
+        static let configuration = ScrollableSegmentedControlCellConfiguration(backgroundColor: .white, highlightedTextColor: R.color.azure()!, nonHighlightedTextColor: R.color.dove()!, highlightedFont: Fonts.semibold(size: 15), nonHighlightedFont: Fonts.regular(size: 15), cellPadding: 8.0, textBottomPadding: 12.0)
     }
     enum value {
         static let appreciated: UIColor = R.color.green()!

--- a/AlphaWallet/WhatsNew/Views/WhatsNewViews.swift
+++ b/AlphaWallet/WhatsNew/Views/WhatsNewViews.swift
@@ -10,7 +10,7 @@ import UIKit
 class WhatsNewHeaderView: UIView {
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProBold(size: 24.0)
+        label.font = Fonts.bold(size: 24)
         label.textAlignment = .center
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -54,7 +54,7 @@ class WhatsNewSubHeaderView: UIView {
     }()
     lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProSemibold(size: 20.0)
+        label.font = Fonts.semibold(size: 20)
         label.textAlignment = .center
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -99,7 +99,7 @@ class WhatsNewEntryView: UIView {
     }()
     lazy var entryLabel: UILabel = {
         let label = UILabel()
-        label.font = R.font.sourceSansProRegular(size: 20.0)
+        label.font = Fonts.regular(size: 20)
         label.textAlignment = .natural
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Closes #4746