### PR TITLE
Fix: crash when mainnet is not enabled #4791

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -89,7 +89,7 @@ class TokensCoordinator: Coordinator {
     private var cancelable = Set<AnyCancellable>()
     private let generator = BlockiesGenerator()
     private let importToken: ImportToken
-    
+
     init(
             navigationController: UINavigationController = .withOverridenBarAppearence(),
             sessions: ServerDictionary<WalletSession>,
@@ -166,7 +166,7 @@ class TokensCoordinator: Coordinator {
         addUefaTokenIfAny()
         alertService.start()
     }
-    
+
     deinit {
         autoDetectTransactedTokensQueue.cancelAllOperations()
         autoDetectTokensQueue.cancelAllOperations()
@@ -190,7 +190,10 @@ class TokensCoordinator: Coordinator {
     }
 
     private func addUefaTokenIfAny() {
-        importToken.importToken(for: Constants.uefaMainnet, server: Constants.uefaRpcServer, onlyIfThereIsABalance: true)
+        let server = Constants.uefaRpcServer
+        //TODO maybe should make `importToken` fail gracefully when requested for a server that isn't active instead, but it'd involve introducing optionals to other call-sites which seem to make things more complicated and worse
+        guard sessions.hasKey(server) else { return }
+        importToken.importToken(for: Constants.uefaMainnet, server: server, onlyIfThereIsABalance: true)
             .done { _ in }
             .cauterize()
     }
@@ -298,7 +301,7 @@ extension TokensCoordinator: TokensViewControllerDelegate {
 
             alertController.addAction(swapAction)
         }
-        
+
         let renameThisWalletAction = UIAlertAction(title: R.string.localizable.tokensWalletRenameThisWallet(), style: .default) { [weak self] _ in
             guard let strongSelf = self else { return }
             strongSelf.didPressRenameThisWallet()
@@ -465,7 +468,7 @@ extension TokensCoordinator: QRCodeResolutionCoordinatorDelegate {
             navigationController: navigationController,
             filter: .filter(NativeCryptoOrErc20TokenFilter()),
             eventsDataStore: eventsDataStore
-        ) 
+        )
         coordinator.delegate = self
         addCoordinator(coordinator)
 


### PR DESCRIPTION
Fixes #4791

Not the best fix, but comment in code explains why:

```
        //TODO maybe should make `importToken` fail gracefully when requested for a server that isn't active instead, but it'd involve introducing optionals to other call-sites which seem to make things more complicated and worse
        guard sessions.hasKey(server) else { return }
```