### PR TITLE
Fix crash because dictionary property in `AssetAttributesCache` is accessed in both main and non-main threads concurrently #4810

### DIFF
--- a/AlphaWallet/TokenScriptClient/Models/AssetAttributesCache.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetAttributesCache.swift
@@ -9,11 +9,10 @@ class AssetAttributesCache {
     private var resolvedAttributesData: AssetAttributesCacheData
     private var functionOriginAttributes: [AlphaWallet.Address: [AttributeId: AssetAttribute]] = .init()
     private var functionOriginSubscribables: [AlphaWallet.Address: [TokenId: [AttributeId: Subscribable<AssetInternalValue>]]] = .init()
-    
+
     init() {
         let decoder = JSONDecoder()
-        //TODO read from JSON file/database (if it exists)
-        self.resolvedAttributesData = (try? decoder.decode(AssetAttributesCacheData.self, from: Data())) ?? .init()
+        self.resolvedAttributesData = .init()
     }
 
     func clearCacheWhenTokenScriptChanges(forContract contract: AlphaWallet.Address) {
@@ -94,8 +93,8 @@ class AssetAttributesCache {
     }
 }
 
-struct AssetAttributesCacheData: Codable {
-    private var contracts = [AlphaWallet.Address: ContractTokenIdsAttributeValues]()
+struct AssetAttributesCacheData {
+    private var contracts = AtomicDictionary<AlphaWallet.Address, ContractTokenIdsAttributeValues>()
 
     fileprivate subscript(contract: AlphaWallet.Address) -> ContractTokenIdsAttributeValues? {
         get {


### PR DESCRIPTION
Fixes #4810

`AssetAttributesCacheData` no longer implements `Codable`. It's harmless since we haven't implemented persistance to disk.

I look at switching to `AtomicDictionary ` as a short-term solution though. Refer to: https://github.com/AlphaWallet/alpha-wallet-ios/issues/4810#issuecomment-1148208721