### PR TITLE
[Log] Capture in debug log that OpenSea API key has expired #4812

### DIFF
--- a/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSea.swift
+++ b/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSea.swift
@@ -150,6 +150,7 @@ public class OpenSea {
         enum OpenSeaApiError: Error {
             case rateLimited
             case invalidApiKey
+            case expiredApiKey
         }
 
         func privatePerformRequest(url: URL) -> Promise<(HTTPURLResponse, JSON)> {
@@ -163,7 +164,11 @@ public class OpenSea {
                         if let response: HTTPURLResponse = response.response {
                             let statusCode = response.statusCode
                             if statusCode == 401 {
-                                throw OpenSeaApiError.invalidApiKey
+                                if let body = String(data: data, encoding: .utf8), body.contains("Expired API key") {
+                                    throw OpenSeaApiError.expiredApiKey
+                                } else {
+                                    throw OpenSeaApiError.invalidApiKey
+                                }
                             } else if statusCode == 429 {
                                 throw OpenSeaApiError.rateLimited
                             }


### PR DESCRIPTION
Closes #4812 

Interestingly, a key that has expired might still return `429` (rate limited) sometimes.