### PR TITLE
Remove WithReusableIdentifier from UICollectionViewCell as conformance is set somewhere else.

### DIFF
--- a/AlphaWallet/Extensions/UITableView.swift
+++ b/AlphaWallet/Extensions/UITableView.swift
@@ -23,9 +23,6 @@ extension UITableViewCell: WithReusableIdentifier {
 extension UITableViewHeaderFooterView: WithReusableIdentifier {
 }
 
-extension UICollectionViewCell: WithReusableIdentifier {
-}
-
 extension UICollectionReusableView: WithReusableIdentifier {
 }
 


### PR DESCRIPTION
```
/alpha-wallet-ios/AlphaWallet/Extensions/UITableView.swift:26:33: conformance of 'UICollectionViewCell' to protocol 'WithReusableIdentifier' was already stated in the type's module 'UIKit'
extension UICollectionViewCell: WithReusableIdentifier {
```
Pull request to silence the above warning.