### PR TITLE
Added dark mode to initial wallet creation screen

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		025F5D1F2760C76A00B2A3BC /* ExportJsonKeystoreFileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025F5D1D2760C76A00B2A3BC /* ExportJsonKeystoreFileView.swift */; };
 		025F5D202760C76A00B2A3BC /* ExportJsonKeystorePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025F5D1E2760C76A00B2A3BC /* ExportJsonKeystorePasswordView.swift */; };
 		025F5D2F2760CDE600B2A3BC /* StringValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025F5D2E2760CDE600B2A3BC /* StringValidator.swift */; };
+		026340912850C7D50033E51B /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026340902850C7D50033E51B /* Configuration.swift */; };
 		02645122277206C0009260DC /* TableViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645121277206C0009260DC /* TableViewSection.swift */; };
 		02645124277217D9009260DC /* CustomRpcTableViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02645123277217D9009260DC /* CustomRpcTableViewSection.swift */; };
 		0277D92B282A494600510ECE /* InitialNetworkSelectionCollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0277D92A282A494600510ECE /* InitialNetworkSelectionCollectionModel.swift */; };
@@ -1300,6 +1301,7 @@
 		025F5D1D2760C76A00B2A3BC /* ExportJsonKeystoreFileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportJsonKeystoreFileView.swift; sourceTree = "<group>"; };
 		025F5D1E2760C76A00B2A3BC /* ExportJsonKeystorePasswordView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportJsonKeystorePasswordView.swift; sourceTree = "<group>"; };
 		025F5D2E2760CDE600B2A3BC /* StringValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringValidator.swift; sourceTree = "<group>"; };
+		026340902850C7D50033E51B /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		02645121277206C0009260DC /* TableViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewSection.swift; sourceTree = "<group>"; };
 		02645123277217D9009260DC /* CustomRpcTableViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRpcTableViewSection.swift; sourceTree = "<group>"; };
 		0277D92A282A494600510ECE /* InitialNetworkSelectionCollectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialNetworkSelectionCollectionModel.swift; sourceTree = "<group>"; };
@@ -2756,6 +2758,7 @@
 				5E7C76487E444E00B78BAA14 /* BlockscanChat */,
 				5E7C72AB43EC4939E6C7D46B /* Lists */,
 				5E7C72F803CD9A3A6A8D0839 /* Swaps */,
+				026340902850C7D50033E51B /* Configuration.swift */,
 			);
 			path = AlphaWallet;
 			sourceTree = "<group>";
@@ -7422,6 +7425,7 @@
 				5E7C70DDE7C3BD32FA525753 /* PromptBackupWalletAfterIntervalViewViewModel.swift in Sources */,
 				5E7C76A585ED45EDAD8825CF /* BackupState.swift in Sources */,
 				87BBF98B2563DD7600FF4846 /* WalletConnectServer.swift in Sources */,
+				026340912850C7D50033E51B /* Configuration.swift in Sources */,
 				87C10A6525ED1105008E9B1B /* SignatureConfirmationDetailsViewController.swift in Sources */,
 				5E7C76738DDAAD623C6FB4DC /* PromptBackupWalletAfterExceedingThresholdViewViewModel.swift in Sources */,
 				87A3022724C02212000DF32E /* TransactionConfirmationViewController.swift in Sources */,

--- a/AlphaWallet/Assets.xcassets/cod.colorset/Contents.json
+++ b/AlphaWallet/Assets.xcassets/cod.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.078",
-          "green" : "0.078",
-          "red" : "0.078"
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x14"
         }
       },
       "idiom" : "universal"

--- a/AlphaWallet/Configuration.swift
+++ b/AlphaWallet/Configuration.swift
@@ -1,0 +1,100 @@
+//
+//  Configuration.swift
+//  AlphaWallet
+//
+//  Created by Jerome Chan on 30/5/22.
+//
+
+import UIKit
+
+fileprivate func colorFrom(trait: UITraitCollection, lightColor: UIColor, darkColor: UIColor) -> UIColor {
+    switch trait.userInterfaceStyle {
+    case .unspecified, .light:
+        return lightColor
+    case .dark:
+        return darkColor
+    }
+}
+
+struct Configuration {
+    struct Color {
+        struct Semantic {
+            static let defaultViewBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
+            }
+            static let defaultForegroundText = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
+            }
+
+            static let primaryButtonBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.cod()!, darkColor: R.color.alabaster()!)
+            }
+            static let primaryButtonHighlightedBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.concrete()!)
+            }
+            static let primaryButtonBackgroundInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.mike()!, darkColor: R.color.mine()!)
+            }
+            static let primaryButtonBorderInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.mike()!, darkColor: R.color.mine()!)
+            }
+            static let primaryButtonTextActive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.black()!)
+            }
+            static let primaryButtonTextInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.black()!)
+            }
+            static let primaryButtonBorderActive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.cod()!, darkColor: R.color.alabaster()!)
+            }
+
+            static let secondaryButtonBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.dusty()!)
+            }
+            static let secondaryButtonHighlightedBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.concrete()!, darkColor: R.color.dusty()!)
+            }
+            static let secondaryButtonBackgroundInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.mike()!, darkColor: R.color.dusty()!)
+            }
+            static let secondaryButtonBorderInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.mike()!, darkColor: R.color.dusty()!)
+            }
+            static let secondaryButtonTextActive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
+            }
+            static let secondaryButtonTextInactive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
+            }
+            static let secondaryButtonBorderActive = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.dusty()!)
+            }
+        }
+    }
+}
+
+class UIKitFactory {
+
+    static func defaultView(autoResizingMarkIntoConstraints: Bool = false) -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = autoResizingMarkIntoConstraints
+        return decorateAsDefaultView(view)
+    }
+
+    @discardableResult static func decorateAsDefaultView(_ view: UIView) -> UIView {
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
+        return view
+    }
+
+    static func defaultLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        return decorateAsDefaultLabel(label)
+    }
+
+    @discardableResult static func decorateAsDefaultLabel(_ label: UILabel) -> UILabel {
+        label.textColor = Configuration.Color.Semantic.defaultForegroundText
+        return label
+    }
+
+}

--- a/AlphaWallet/Core/Views/ButtonsBar/ButtonsBar.swift
+++ b/AlphaWallet/Core/Views/ButtonsBar/ButtonsBar.swift
@@ -339,23 +339,23 @@ class HorizontalButtonsBar: UIView, ButtonsBarViewType {
 struct ButtonsBarViewModel {
 
     static let primaryButton = ButtonsBarViewModel(
-        buttonBackgroundColor: ButtonsBarStyle.Colors.primaryBackgroundActive,
-        highlightedButtonBackgroundColor: ButtonsBarStyle.Colors.primaryHighlightedBackground,
-        disabledButtonBackgroundColor: ButtonsBarStyle.Colors.primaryBackgroundInactive,
-        disabledButtonBorderColor: ButtonsBarStyle.Colors.primaryBorderInactive,
-        buttonTitleColor: ButtonsBarStyle.Colors.primaryTextActive,
-        disabledButtonTitleColor: ButtonsBarStyle.Colors.primaryTextInactive,
-        buttonBorderColor: ButtonsBarStyle.Colors.primaryBorderActive
+        buttonBackgroundColor: Configuration.Color.Semantic.primaryButtonBackground,
+        highlightedButtonBackgroundColor: Configuration.Color.Semantic.primaryButtonHighlightedBackground,
+        disabledButtonBackgroundColor: Configuration.Color.Semantic.primaryButtonBackgroundInactive,
+        disabledButtonBorderColor: Configuration.Color.Semantic.primaryButtonBorderInactive,
+        buttonTitleColor: Configuration.Color.Semantic.primaryButtonTextActive,
+        disabledButtonTitleColor: Configuration.Color.Semantic.primaryButtonTextInactive,
+        buttonBorderColor: Configuration.Color.Semantic.primaryButtonBorderActive
     )
 
     static let secondaryButton = ButtonsBarViewModel(
-        buttonBackgroundColor: ButtonsBarStyle.Colors.secondaryBackgroundActive,
-        highlightedButtonBackgroundColor: ButtonsBarStyle.Colors.secondaryHighlightedBackground,
-        disabledButtonBackgroundColor: ButtonsBarStyle.Colors.secondaryBackgroundInactive,
-        disabledButtonBorderColor: ButtonsBarStyle.Colors.secondaryBorderInactive,
-        buttonTitleColor: ButtonsBarStyle.Colors.secondaryTextActive,
-        disabledButtonTitleColor: ButtonsBarStyle.Colors.secondaryTextInactive,
-        buttonBorderColor: ButtonsBarStyle.Colors.secondaryBorderActive
+        buttonBackgroundColor: Configuration.Color.Semantic.secondaryButtonBackground,
+        highlightedButtonBackgroundColor: Configuration.Color.Semantic.secondaryButtonHighlightedBackground,
+        disabledButtonBackgroundColor: Configuration.Color.Semantic.secondaryButtonBackgroundInactive,
+        disabledButtonBorderColor: Configuration.Color.Semantic.secondaryButtonBorderInactive,
+        buttonTitleColor: Configuration.Color.Semantic.secondaryButtonTextActive,
+        disabledButtonTitleColor: Configuration.Color.Semantic.secondaryButtonTextInactive,
+        buttonBorderColor: Configuration.Color.Semantic.secondaryButtonBorderActive
     )
 
     static let systemButton = ButtonsBarViewModel(
@@ -372,6 +372,7 @@ struct ButtonsBarViewModel {
     static let moreButton = ButtonsBarViewModel(buttonBorderWidth: 0)
 
     var buttonBackgroundColor: UIColor = Colors.appWhite
+
     var highlightedButtonBackgroundColor: UIColor?
     var disabledButtonBackgroundColor: UIColor = Colors.disabledActionButton
     var disabledButtonBorderColor: UIColor = Colors.disabledActionButton

--- a/AlphaWallet/Extensions/UIButton.swift
+++ b/AlphaWallet/Extensions/UIButton.swift
@@ -5,12 +5,16 @@ import UIKit
 
 extension UIButton {
     func setBackgroundColor(_ color: UIColor, forState: UIControl.State) {
-        UIGraphicsBeginImageContext(CGSize(width: 1, height: 1))
-        UIGraphicsGetCurrentContext()!.setFillColor(color.cgColor)
-        UIGraphicsGetCurrentContext()!.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
-        let colorImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
+        let imageAsset = UIImageAsset()
 
-        setBackgroundImage(colorImage, for: forState)
+        let lightImage = UIImage(color: color.lightMode)!
+        let lightMode = UITraitCollection(traitsFrom: [.init(userInterfaceStyle: .light)])
+        imageAsset.register(lightImage, with: lightMode)
+
+        let darkImage = UIImage(color: color.darkMode)!
+        let darkMode = UITraitCollection(traitsFrom: [.init(userInterfaceStyle: .dark)])
+        imageAsset.register(darkImage, with: darkMode)
+
+        setBackgroundImage(imageAsset.image(with: .current), for: state)
     }
 }

--- a/AlphaWallet/Extensions/UIColor.swift
+++ b/AlphaWallet/Extensions/UIColor.swift
@@ -35,4 +35,13 @@ extension UIColor {
             blue: CGFloat(b) / 0xff, alpha: 1
         )
     }
+
+    var lightMode: UIColor {
+        return resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+    }
+
+    var darkMode: UIColor {
+        return resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+    }
+
 }

--- a/AlphaWallet/Wallet/ViewControllers/CreateInitialWalletViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/CreateInitialWalletViewController.swift
@@ -73,8 +73,11 @@ class CreateInitialWalletViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func loadView() {
+        self.view = UIKitFactory.defaultView(autoResizingMarkIntoConstraints: true)
+    }
+
     func configure() {
-        view.backgroundColor = Colors.appBackground
         imageView.image = viewModel.imageViewImage
         titleLabel.attributedText = viewModel.titleAttributedString
 

--- a/AlphaWallet/Wallet/ViewModels/CreateInitialWalletViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/CreateInitialWalletViewModel.swift
@@ -15,13 +15,13 @@ struct CreateInitialViewModel {
 
         return .init(string: R.string.localizable.gettingStartedSubtitle(), attributes: [
             .font: font,
-            .foregroundColor: Colors.appText,
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .paragraphStyle: paragraph
         ])
     }
 
     var imageViewImage: UIImage {
-        return R.image.launch_icon()!
+        return R.image.launchScreen()!
     }
 
     var createWalletButtonTitle: String {

--- a/AlphaWalletTests/Extensions/UIColorExtensionTests.swift
+++ b/AlphaWalletTests/Extensions/UIColorExtensionTests.swift
@@ -40,4 +40,21 @@ class UIColorExtensionTests: XCTestCase {
         XCTAssert(blue*0xff == 0x56, "\(blue)")
     }
 
+    func testLightDarkColorMode() throws {
+        let lightColor = UIColor.yellow
+        let darkColor = UIColor.gray
+        let compositeColor = UIColor { trait in
+            switch trait.userInterfaceStyle {
+            case .unspecified, .light:
+                return lightColor
+            case .dark:
+                return darkColor
+            }
+        }
+
+        XCTAssertEqual(compositeColor.lightMode, lightColor)
+        XCTAssertEqual(compositeColor.darkMode, darkColor)
+
+    }
+
 }


### PR DESCRIPTION
![iwcs](https://user-images.githubusercontent.com/1050309/172624628-d4340951-d040-438c-a7a4-a118d2188797.gif)

Delete current app to remove wallet data. Check to see if this code style is acceptable. Once approved, I will fix the info.plist flag to change `appearance` to `light` before merging. Also are the colours right? I went by the style guide. Also Dusty is defined as RGB 153, 153, 153 in the colour guide but the style guide had 151, 151, 151. I followed the colour guide.

![Simulator Screen Shot - iPhone 11 - 2022-06-08 at 21 12 40 copy](https://user-images.githubusercontent.com/1050309/172625183-5973104e-1e8b-4a3a-a98b-0d1f931c8105.png) ![Simulator Screen Shot - iPhone 11 - 2022-06-08 at 21 13 00 copy](https://user-images.githubusercontent.com/1050309/172625190-80e3faab-d299-4430-815f-a21c714e09bf.png)

@hboon @colourfreak 