### PR TITLE
Fix: Gnosis RPC URL is outdated and doesn't work anymore #4875

### DIFF
--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -605,7 +605,7 @@ enum RPCServer: Hashable, CaseIterable {
             case .poa: return "https://core.poa.network"
             case .sokol: return "https://sokol.poa.network"
             case .goerli: return "https://goerli.infura.io/v3/\(Constants.Credentials.infuraKey)"
-            case .xDai: return "https://rpc.xdaichain.com"
+            case .xDai: return "https://rpc.ankr.com/gnosis"
             case .artis_sigma1: return "https://rpc.sigma1.artis.network"
             case .artis_tau1: return "https://rpc.tau1.artis.network"
             case .binance_smart_chain: return "https://bsc-dataseed.binance.org"


### PR DESCRIPTION
Fixes #4875

According to https://developers.gnosischain.com/for-developers/developer-resources/update-rpc-url

Test data
---
Wallet with wQOIN: https://blockscout.com/xdai/mainnet/address/0x4873678E53484e7Bbf1242a5fD6D608FDF24D48F/transactions
wQOIN: https://blockscout.com/xdai/mainnet/token/0x5A6086794668d7D94f2CA2616DB3C6BB0528d3a2