### PR TITLE
Syncronize access to `func performSync(_ block: @escaping (Realm) -> Void) {`, to make sure there is no two or more call at same time #4883

### DIFF
--- a/AlphaWallet/Core/Types/RunLoopThread.swift
+++ b/AlphaWallet/Core/Types/RunLoopThread.swift
@@ -43,14 +43,14 @@ class RunLoopThread: Thread {
         }
     }
 
-    func performSync(_ block: @escaping () -> Swift.Void) {
+    func _perform(_ block: @escaping () -> Swift.Void) {
         guard self.isExecuting else {
             if !self.isCancelled {
                 if isRunLoopThreadLoggingEnabled {
                     debugLog("[Thread] \(name ?? String(describing: self)) hasn't started up yet. Starting soon...")
                 }
                 Thread.sleep(forTimeInterval: 0.002)
-                self.performSync(block)
+                self._perform(block)
             } else {
                 if isRunLoopThreadLoggingEnabled {
                     debugLog("[Thread] \(name ?? String(describing: self)) has already been cancelled!")
@@ -69,7 +69,7 @@ class RunLoopThread: Thread {
     }
 
     func stop() {
-        self.performSync() {
+        self._perform() {
             self.cancel()
         }
     }


### PR DESCRIPTION
Fixes #4883