### PR TITLE
Fix: Should show an error instead of crash when importing an invalid "raw" private key #4921

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		5E7C73AB79C2C5FC6C76CDFF /* ERC20-TokenScript.tsml in Resources */ = {isa = PBXBuildFile; fileRef = 5E7C78795F6336DDBE2EB4C5 /* ERC20-TokenScript.tsml */; };
 		5E7C73CE76679D1E1D6714F7 /* SolidityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C43F1B371836552CC18 /* SolidityType.swift */; };
 		5E7C73E7A68C56162FA2E845 /* EtherscanSingleChainTransactionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74259A3F3B0277B0E8C5 /* EtherscanSingleChainTransactionProvider.swift */; };
+		5E7C73EAE1DE07CF7B6C1B70 /* KeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79A125DB5FBD258F9F95 /* KeysTests.swift */; };
 		5E7C73F6762376F5B2B4214D /* EtherKeystore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BA8A301CEEDE36D76A3 /* EtherKeystore.swift */; };
 		5E7C73F723684B295A8DEEB3 /* GetTokenUri.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7870764B15D5E213604B /* GetTokenUri.swift */; };
 		5E7C73FB906BF267F28B0205 /* ActivityRowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C762AA80515C4E0A87C44 /* ActivityRowType.swift */; };
@@ -1778,6 +1779,7 @@
 		5E7C799836611BEE66000EE1 /* DappsHomeHeaderViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsHomeHeaderViewViewModel.swift; sourceTree = "<group>"; };
 		5E7C799D2B7D91072FC0050B /* DappsHomeViewControllerHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsHomeViewControllerHeaderView.swift; sourceTree = "<group>"; };
 		5E7C799E4784815CB0202820 /* Core.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Core.swift; sourceTree = "<group>"; };
+		5E7C79A125DB5FBD258F9F95 /* KeysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeysTests.swift; sourceTree = "<group>"; };
 		5E7C79C0C9631E4DFC4A40DF /* TokenScriptCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScriptCard.swift; sourceTree = "<group>"; };
 		5E7C79D674D45A07E694CE31 /* LockView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockView.swift; sourceTree = "<group>"; };
 		5E7C79E3BC4CACB123840A42 /* LocaleViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocaleViewCell.swift; sourceTree = "<group>"; };
@@ -2843,6 +2845,7 @@
 				2923D9B61FDA5E51000CF3F8 /* PasswordGeneratorTests.swift */,
 				61DCE17C2001A7A20053939F /* RLPTests.swift */,
 				61C359E12002AC9D0097B04D /* TransactionSigningTests.swift */,
+				5E7C79A125DB5FBD258F9F95 /* KeysTests.swift */,
 			);
 			path = EtherClient;
 			sourceTree = "<group>";
@@ -7767,6 +7770,7 @@
 				5E7C7965C9BF539ABAD1D01C /* FakeDomainResolutionService.swift in Sources */,
 				5E7C7F8271F730462D4E3D93 /* FakeBlockiesGenerator.swift in Sources */,
 				5E7C7D198781B7C98A12ABBC /* WalletFilterTest.swift in Sources */,
+				5E7C73EAE1DE07CF7B6C1B70 /* KeysTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/KeyManagement/EtherKeystore.swift
+++ b/AlphaWallet/KeyManagement/EtherKeystore.swift
@@ -167,7 +167,7 @@ open class EtherKeystore: NSObject, Keystore {
                 return .failure(error)
             }
         case .privateKey(let privateKey):
-            let address = AlphaWallet.Address(fromPrivateKey: privateKey)
+            guard let address = AlphaWallet.Address(fromPrivateKey: privateKey) else { return .failure(.failedToImportPrivateKey) }
             guard !isAddressAlreadyInWalletsList(address: address) else {
                 return .failure(.duplicateAccount)
             }
@@ -187,7 +187,7 @@ open class EtherKeystore: NSObject, Keystore {
             guard mnemonicIsGood else { return .failure(.failedToCreateWallet) }
             guard let wallet = HDWallet(mnemonic: mnemonicString, passphrase: emptyPassphrase) else { return .failure(.failedToCreateWallet) }
             let privateKey = derivePrivateKeyOfAccount0(fromHdWallet: wallet)
-            let address = AlphaWallet.Address(fromPrivateKey: privateKey)
+            guard let address = AlphaWallet.Address(fromPrivateKey: privateKey) else { return .failure(.failedToCreateWallet) }
             guard !isAddressAlreadyInWalletsList(address: address) else {
                 return .failure(.duplicateAccount)
             }
@@ -249,7 +249,7 @@ open class EtherKeystore: NSObject, Keystore {
 
         guard walletWhenImported.mnemonic == mnemonic else { return false }
         let privateKey = derivePrivateKeyOfAccount0(fromHdWallet: walletWhenImported)
-        let address = AlphaWallet.Address(fromPrivateKey: privateKey)
+        guard let address = AlphaWallet.Address(fromPrivateKey: privateKey) else { return false }
         let testData = "any data will do here"
         let hash = testData.data(using: .utf8)!.sha3(.keccak256)
         //Do not use EthereumSigner.vitaliklizeConstant because the ECRecover implementation doesn't include it

--- a/AlphaWalletTests/EtherClient/KeysTests.swift
+++ b/AlphaWalletTests/EtherClient/KeysTests.swift
@@ -1,0 +1,33 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import XCTest
+@testable import AlphaWallet
+
+class KeysTests: XCTestCase {
+    //Keys *must* be 64 characters (i.e. 32 bytes) for this test
+    //Order of curve n = fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140, private keys must be smaller than n
+    func testImportInvalidPrivateKeys() {
+        XCTAssertNil(deriveAddressFromPrivateKey("00"))
+        XCTAssertNil(deriveAddressFromPrivateKey("0xff"))
+        XCTAssertNil(deriveAddressFromPrivateKey("ff"))
+        XCTAssertNil(deriveAddressFromPrivateKey("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n"))
+        XCTAssertNil(deriveAddressFromPrivateKey("ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccd"))
+        XCTAssertNotNil(deriveAddressFromPrivateKey("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+        XCTAssertNil(deriveAddressFromPrivateKey("ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+        XCTAssertNotNil(deriveAddressFromPrivateKey("fffffffccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+        XCTAssertNil(deriveAddressFromPrivateKey("fffffffcccccccccccccccccccccccccccccccccccccccccccccccccccccccck"))
+        XCTAssertNil(deriveAddressFromPrivateKey("0000000000000000000000000000000000000000000000000000000000000000"))
+        //key == order of curve n - 1, OK
+        XCTAssertNotNil(deriveAddressFromPrivateKey("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"))
+        //key == order of curve n, invalid key
+        XCTAssertNil(deriveAddressFromPrivateKey("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"))
+        //key == order of curve n+1, invalid key
+        XCTAssertNil(deriveAddressFromPrivateKey("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142"))
+    }
+
+    private func deriveAddressFromPrivateKey(_ privateKeyInput : String) -> AlphaWallet.Address? {
+        let privateKey = Data(hexString: privateKeyInput)
+        guard let privateKey = privateKey else { return nil }
+        return AlphaWallet.Address(fromPrivateKey: privateKey)
+    }
+}


### PR DESCRIPTION
Fixes: #4921

Reproduce by importing this as key: `fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141`
