### PR TITLE
Fix: Deep-link Wallet API's output URL for signpersonalmessage's signature value should have the key "signature" instead of "message" #4938

### DIFF
--- a/AlphaWallet/Core/Helpers/WalletApiService.swift
+++ b/AlphaWallet/Core/Helpers/WalletApiService.swift
@@ -176,7 +176,7 @@ extension WalletApiService {
             case .success(let data):
                 components?.queryItems = queryItems + [
                     .init(name: "call", value: "signpersonalmessage"),
-                    .init(name: "message", value: data.hexEncoded)
+                    .init(name: "signature", value: data.hexEncoded)
                 ]
             case .failure:
                 components?.queryItems = queryItems + [


### PR DESCRIPTION
Fixes #4938

cc @justindg 