### PR TITLE
Attach domain name and chain ID to RPC node rate limited error analytics logging

### DIFF
--- a/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
+++ b/AlphaWallet/Analytics/Models/AnalyticsTypes.swift
@@ -117,6 +117,7 @@ enum Analytics {
         case addCustomChainType
         case isAccepted
         case reason
+        case domainName
     }
 
     enum UserProperties: String, AnalyticsUserProperty {

--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -180,7 +180,7 @@ final class DappBrowserCoordinator: NSObject, Coordinator {
     private func ethCall(callbackID: Int, from: AlphaWallet.Address?, to: AlphaWallet.Address?, value: String?, data: String, server: RPCServer) {
         let request = EthCallRequest(from: from, to: to, value: value, data: data)
         firstly {
-            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), analyticsCoordinator: analyticsCoordinator)
+            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), server: server, analyticsCoordinator: analyticsCoordinator)
         }.done { result in
             let callback = DappCallback(id: callbackID, value: .ethCall(result))
             self.browserViewController.notifyFinish(callbackID: callbackID, value: .success(callback))

--- a/AlphaWallet/Core/Ethereum/EthereumTransaction.swift
+++ b/AlphaWallet/Core/Ethereum/EthereumTransaction.swift
@@ -14,7 +14,7 @@ enum EthereumTransaction {
     static func isCompleted(transactionId: Id, server: RPCServer, analyticsCoordinator: AnalyticsCoordinator) -> Promise<Bool> {
         let request = GetTransactionRequest(hash: transactionId)
         return firstly {
-            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), analyticsCoordinator: analyticsCoordinator)
+            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), server: server, analyticsCoordinator: analyticsCoordinator)
         }.map { pendingTransaction in
             if let blockNumber = Int(pendingTransaction.blockNumber), blockNumber > 0 {
                 return true

--- a/AlphaWallet/Covalent/TransactionProviders/PendingTransaction/PendingTransactionFetcher.swift
+++ b/AlphaWallet/Covalent/TransactionProviders/PendingTransaction/PendingTransactionFetcher.swift
@@ -19,7 +19,7 @@ final class PendingTransactionFetcher {
         let request = GetTransactionRequest(hash: id)
 
         return Session
-            .sendPublisher(EtherServiceRequest(server: server, batch: BatchFactory().create(request)))
+            .sendPublisher(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), server: server)
             .eraseToAnyPublisher()
     }
 }

--- a/AlphaWallet/EtherClient/ChainState.swift
+++ b/AlphaWallet/EtherClient/ChainState.swift
@@ -56,7 +56,7 @@ class ChainState {
     @objc func fetch() {
         let request = EtherServiceRequest(server: server, batch: BatchFactory().create(BlockNumberRequest()))
         firstly {
-            Session.send(request, analyticsCoordinator: analyticsCoordinator)
+            Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator)
         }.done { [weak self] in
             self?.latestBlock = $0
         }.catch { error in

--- a/AlphaWallet/EtherClient/Models/GetNextNonce.swift
+++ b/AlphaWallet/EtherClient/Models/GetNextNonce.swift
@@ -6,24 +6,28 @@ import JSONRPCKit
 import PromiseKit
 
 class GetNextNonce {
+    //Important to store the RPC URL and not read `RPCServer.server` because it might be overridden by a RPC node that supports private transactions
     private let rpcURL: URL
+    private let server: RPCServer
     private let wallet: AlphaWallet.Address
     private let analyticsCoordinator: AnalyticsCoordinator
 
     init(server: RPCServer, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
         self.rpcURL = server.rpcURL
+        self.server = server
         self.wallet = wallet
         self.analyticsCoordinator = analyticsCoordinator
     }
 
-    init(rpcURL: URL, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
+    init(rpcURL: URL, server: RPCServer, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
         self.rpcURL = rpcURL
+        self.server = server
         self.wallet = wallet
         self.analyticsCoordinator = analyticsCoordinator
     }
 
     func promise() -> Promise<Int> {
         let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(GetTransactionCountRequest(address: wallet, state: "pending")))
-        return Session.send(request, analyticsCoordinator: analyticsCoordinator)
+        return Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator)
     }
 }

--- a/AlphaWallet/Extensions/Publishers/Session+Publishers.swift
+++ b/AlphaWallet/Extensions/Publishers/Session+Publishers.swift
@@ -12,8 +12,8 @@ import Combine
 
 extension Session {
 
-    class func sendPublisher<Request: APIKit.Request>(_ request: Request, callbackQueue: CallbackQueue? = nil) -> AnyPublisher<Request.Response, SessionTaskError> {
-        sendImplPublisher(request, callbackQueue: callbackQueue)
+    class func sendPublisher<Request: APIKit.Request>(_ request: Request, server: RPCServer, callbackQueue: CallbackQueue? = nil) -> AnyPublisher<Request.Response, SessionTaskError> {
+        sendImplPublisher(request, server: server, callbackQueue: callbackQueue)
             .retry(times: 2, when: {
                 guard case SessionTaskError.requestError(let e) = $0 else { return false }
                 return e is SendTransactionRetryableError
@@ -21,7 +21,7 @@ extension Session {
             .eraseToAnyPublisher()
     }
 
-    private class func sendImplPublisher<Request: APIKit.Request>(_ request: Request, callbackQueue: CallbackQueue? = nil) -> AnyPublisher<Request.Response, SessionTaskError> {
+    private class func sendImplPublisher<Request: APIKit.Request>(_ request: Request, server: RPCServer, callbackQueue: CallbackQueue? = nil) -> AnyPublisher<Request.Response, SessionTaskError> {
         var sessionTask: SessionTask?
         let publisher = Deferred {
             Future<Request.Response, SessionTaskError> { seal in
@@ -30,7 +30,7 @@ extension Session {
                     case .success(let result):
                         seal(.success(result))
                     case .failure(let error):
-                        if let e = convertToUserFriendlyError(error: error, baseUrl: request.baseURL) {
+                        if let e = convertToUserFriendlyError(error: error, server: server, baseUrl: request.baseURL) {
                             seal(.failure(.requestError(e)))
                         } else {
                             seal(.failure(error))

--- a/AlphaWallet/Extensions/Session+PromiseKit.swift
+++ b/AlphaWallet/Extensions/Session+PromiseKit.swift
@@ -31,8 +31,8 @@ extension Session {
 
     private static func logRpcNodeError(_ rpcNodeError: SendTransactionRetryableError, analyticsCoordinator: AnalyticsCoordinator) {
         switch rpcNodeError {
-        case .rateLimited:
-            analyticsCoordinator.log(error: Analytics.WebApiErrors.rpcNodeRateLimited)
+        case .rateLimited(let server, let domainName):
+            analyticsCoordinator.log(error: Analytics.WebApiErrors.rpcNodeRateLimited, properties: [Analytics.Properties.chain.rawValue: server.chainID, Analytics.Properties.domainName.rawValue: domainName])
         case .possibleBinanceTestnetTimeout, .networkConnectionWasLost, .invalidCertificate, .requestTimedOut:
             return
         }
@@ -121,7 +121,7 @@ extension Session {
                 case .unacceptableStatusCode(let statusCode):
                     if statusCode == 429 {
                         warnLog("[API] Rate limited by baseURL: \(baseUrl.absoluteString)")
-                        return SendTransactionRetryableError.rateLimited
+                        return SendTransactionRetryableError.rateLimited(server: server, domainName: baseUrl.host ?? "")
                     } else {
                         RemoteLogger.instance.logRpcOrOtherWebError("APIKit.ResponseError.unacceptableStatusCode | status: \(statusCode)", url: baseUrl.absoluteString)
                     }

--- a/AlphaWallet/Extensions/Session+PromiseKit.swift
+++ b/AlphaWallet/Extensions/Session+PromiseKit.swift
@@ -7,14 +7,14 @@ import PromiseKit
 
 extension Session {
 
-    private class func sendImpl<Request: APIKit.Request>(_ request: Request, analyticsCoordinator: AnalyticsCoordinator, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
+    private class func sendImpl<Request: APIKit.Request>(_ request: Request, server: RPCServer, analyticsCoordinator: AnalyticsCoordinator, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
         let (promise, seal) = Promise<Request.Response>.pending()
         Session.send(request, callbackQueue: callbackQueue) { result in
             switch result {
             case .success(let result):
                 seal.fulfill(result)
             case .failure(let error):
-                if let e = convertToUserFriendlyError(error: error, baseUrl: request.baseURL) {
+                if let e = convertToUserFriendlyError(error: error, server: server, baseUrl: request.baseURL) {
                     if let e = e as? SendTransactionRetryableError {
                         logRpcNodeError(e, analyticsCoordinator: analyticsCoordinator)
                     }
@@ -38,20 +38,20 @@ extension Session {
         }
     }
 
-    class func send<Request: APIKit.Request>(_ request: Request, analyticsCoordinator: AnalyticsCoordinator, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
-        let promise = sendImpl(request, analyticsCoordinator: analyticsCoordinator, callbackQueue: callbackQueue)
+    class func send<Request: APIKit.Request>(_ request: Request, server: RPCServer, analyticsCoordinator: AnalyticsCoordinator, callbackQueue: CallbackQueue? = nil) -> Promise<Request.Response> {
+        let promise = sendImpl(request, server: server, analyticsCoordinator: analyticsCoordinator, callbackQueue: callbackQueue)
         return firstly {
             promise
         }.recover { error -> Promise<Request.Response> in
             if error is SendTransactionRetryableError {
-                return sendImpl(request, analyticsCoordinator: analyticsCoordinator, callbackQueue: callbackQueue)
+                return sendImpl(request, server: server, analyticsCoordinator: analyticsCoordinator, callbackQueue: callbackQueue)
             } else {
                 return promise
             }
         }
     }
 
-    static func convertToUserFriendlyError(error: SessionTaskError, baseUrl: URL) -> Error? {
+    static func convertToUserFriendlyError(error: SessionTaskError, server: RPCServer, baseUrl: URL) -> Error? {
         infoLog("convertToUserFriendlyError URL: \(baseUrl.absoluteString) error: \(error)")
         switch error {
         case .connectionError(let e):

--- a/AlphaWallet/Settings/Coordinators/PingInfuraCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/PingInfuraCoordinator.swift
@@ -40,9 +40,10 @@ class PingInfuraCoordinator: Coordinator {
     }
 
     private func pingInfura() {
-        let request = EtherServiceRequest(server: .main, batch: BatchFactory().create(BlockNumberRequest()))
+        let server = RPCServer.main
+        let request = EtherServiceRequest(server: server, batch: BatchFactory().create(BlockNumberRequest()))
         firstly {
-            Session.send(request, analyticsCoordinator: analyticsCoordinator)
+            Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator)
         }.done { _ in
             UIAlertController.alert(
                     title: R.string.localizable.settingsPingInfuraSuccessful(),

--- a/AlphaWallet/Settings/Models/AddCustomChain.swift
+++ b/AlphaWallet/Settings/Models/AddCustomChain.swift
@@ -172,7 +172,7 @@ extension AddCustomChain.functional {
         let server = RPCServer.custom(customRpc)
         let request = EthChainIdRequest()
         return firstly {
-            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), analyticsCoordinator: analyticsCoordinator)
+            Session.send(EtherServiceRequest(server: server, batch: BatchFactory().create(request)), server: server, analyticsCoordinator: analyticsCoordinator)
         }.map { result in
             if let retrievedChainId = Int(chainId0xString: result), retrievedChainId == chainId {
                 return (chainId: chainId, rpcUrl: rpcUrl)

--- a/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
+++ b/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
@@ -17,9 +17,11 @@ public final class GetDASNameLookup {
 
     private static let ethAddressKey = "address.eth"
 
+    private let server: RPCServer
     private let analyticsCoordinator: AnalyticsCoordinator
 
-    init(analyticsCoordinator: AnalyticsCoordinator) {
+    init(server: RPCServer, analyticsCoordinator: AnalyticsCoordinator) {
+        self.server = server
         self.analyticsCoordinator = analyticsCoordinator
     }
 
@@ -35,7 +37,7 @@ public final class GetDASNameLookup {
 
         let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(DASLookupRequest(value: value)))
         debugLog("[DAS] Looking up value \(value)")
-        return Session.send(request, analyticsCoordinator: analyticsCoordinator).map { response -> AlphaWallet.Address in
+        return Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator).map { response -> AlphaWallet.Address in
             debugLog("[DAS] response for value: \(value) response : \(response)")
             if let record = response.records.first(where: { $0.key == GetDASNameLookup.ethAddressKey }), let address = AlphaWallet.Address(string: record.value) {
                 infoLog("[DAS] resolve value: \(value) to address: \(address)")

--- a/AlphaWallet/Tokens/Logic/GetNativeCryptoCurrencyBalance.swift
+++ b/AlphaWallet/Tokens/Logic/GetNativeCryptoCurrencyBalance.swift
@@ -18,6 +18,6 @@ class GetNativeCryptoCurrencyBalance {
 
     func getBalance(for address: AlphaWallet.Address) -> Promise<Balance> {
         let request = EtherServiceRequest(server: server, batch: BatchFactory().create(BalanceRequest(address: address)))
-        return Session.send(request, analyticsCoordinator: analyticsCoordinator, callbackQueue: queue.flatMap { .dispatchQueue($0) })
+        return Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator, callbackQueue: queue.flatMap { .dispatchQueue($0) })
     }
 }

--- a/AlphaWallet/Transactions/EtherscanSingleChainTransactionProvider.swift
+++ b/AlphaWallet/Transactions/EtherscanSingleChainTransactionProvider.swift
@@ -162,7 +162,7 @@ class EtherscanSingleChainTransactionProvider: SingleChainTransactionProvider {
         let request = GetTransactionRequest(hash: transaction.id)
 
         firstly {
-            Session.send(EtherServiceRequest(server: session.server, batch: BatchFactory().create(request)), analyticsCoordinator: analyticsCoordinator)
+            Session.send(EtherServiceRequest(server: session.server, batch: BatchFactory().create(request)), server: session.server, analyticsCoordinator: analyticsCoordinator)
         }.done(on: queue, { [weak self] pendingTransaction in
             guard let strongSelf = self else { return }
 

--- a/AlphaWallet/Transfer/Controllers/GasPriceEstimator.swift
+++ b/AlphaWallet/Transfer/Controllers/GasPriceEstimator.swift
@@ -83,7 +83,7 @@ final class GasPriceEstimator {
         let defaultPrice: BigInt = GasPriceConfiguration.defaultPrice(forServer: server)
 
         return firstly {
-            Session.send(request, analyticsCoordinator: analyticsCoordinator)
+            Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator)
         }.map {
             if let gasPrice = BigInt($0.drop0x, radix: 16) {
                 if (gasPrice + GasPriceConfiguration.oneGwei) > maxPrice {

--- a/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
+++ b/AlphaWallet/Transfer/Controllers/TransactionConfigurator.swift
@@ -112,7 +112,7 @@ class TransactionConfigurator {
         )
 
         firstly {
-            Session.send(EtherServiceRequest(server: session.server, batch: BatchFactory().create(request)), analyticsCoordinator: analyticsCoordinator)
+            Session.send(EtherServiceRequest(server: session.server, batch: BatchFactory().create(request)), server: session.server, analyticsCoordinator: analyticsCoordinator)
         }.done { gasLimit in
             infoLog("Estimated gas limit with eth_estimateGas: \(gasLimit)")
             let gasLimit: BigInt = {

--- a/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/SendTransactionCoordinator.swift
@@ -33,7 +33,7 @@ class SendTransactionCoordinator {
         let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(rawRequest))
 
         return firstly {
-            Session.send(request, analyticsCoordinator: analyticsCoordinator)
+            Session.send(request, server: session.server, analyticsCoordinator: analyticsCoordinator)
         }.recover { error -> Promise<SendRawTransactionRequest.Response> in
             self.logSelectSendError(error)
             throw error
@@ -72,7 +72,7 @@ class SendTransactionCoordinator {
 
     private func resolveNextNonce(for transaction: UnsignedTransaction) -> Promise<UnsignedTransaction> {
         firstly {
-            GetNextNonce(rpcURL: rpcURL, wallet: session.account.address, analyticsCoordinator: analyticsCoordinator).promise()
+            GetNextNonce(rpcURL: rpcURL, server: session.server, wallet: session.account.address, analyticsCoordinator: analyticsCoordinator).promise()
         }.map { nonce -> UnsignedTransaction in
             let transaction = self.appendNonce(to: transaction, currentNonce: nonce)
             return transaction
@@ -97,7 +97,7 @@ class SendTransactionCoordinator {
         let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(rawTransaction))
 
         return firstly {
-            Session.send(request, analyticsCoordinator: analyticsCoordinator)
+            Session.send(request, server: session.server, analyticsCoordinator: analyticsCoordinator)
         }.recover { error -> Promise<SendRawTransactionRequest.Response> in
             self.logSelectSendError(error)
             throw error

--- a/AlphaWallet/Transfer/Types/SendTransactionError.swift
+++ b/AlphaWallet/Transfer/Types/SendTransactionError.swift
@@ -15,7 +15,7 @@ enum SendTransactionNotRetryableError: Error {
 //TODO name is not right. It's not "SendTransaction" since `eth_getBalance` etc uses it too. Maybe RpcNodeRetryableRequestError?
 enum SendTransactionRetryableError: LocalizedError {
     case possibleBinanceTestnetTimeout
-    case rateLimited
+    case rateLimited(server: RPCServer, domainName: String)
     case networkConnectionWasLost
     case invalidCertificate
     case requestTimedOut

--- a/AlphaWalletTests/Core/Types/SessionTests.swift
+++ b/AlphaWalletTests/Core/Types/SessionTests.swift
@@ -14,7 +14,7 @@ import PromiseKit
 
 extension Session {
     typealias SendPublisherExampleClosure = (_ callback: @escaping(SessionTaskError?) -> Void) -> Void
-    
+
     class func sendPublisherTestsOnly(closure: @escaping SendPublisherExampleClosure) -> AnyPublisher<Void, SessionTaskError> {
         var isCanceled: Bool = false
         let publisher = Deferred {
@@ -22,7 +22,8 @@ extension Session {
                 closure { error in
                     guard !isCanceled else { return }
                     if let error = error {
-                        if let e = convertToUserFriendlyError(error: error, baseUrl: URL(string: "http:/google.com")!) {
+                        let server = RPCServer.main
+                        if let e = convertToUserFriendlyError(error: error, server: server, baseUrl: URL(string: "http:/google.com")!) {
                             seal(.failure(.requestError(e)))
                         } else {
                             seal(.failure(error))


### PR DESCRIPTION
2 commits:

- Pass around RPCServer more so it can be used for logging in a future commit
- Attach domain name of RPC node and chain ID when logging RPC node rate limited errors to analytics

Helps identify problematic RPC nodes where we get rate limited and affect users