### PR TITLE
Trap and print some PromiseKit cauterized errors

### DIFF
--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -517,7 +517,9 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
 
         importToken.importToken(for: contract, server: server, onlyIfThereIsABalance: false)
             .done { _ in }
-            .cauterize()
+            .catch { error in
+                verboseLog("Error while adding imported token contract: \(contract.eip55String) server: \(server) wallet: \(self.wallet.address.eip55String) error: \(error)")
+            }
     }
 
     func show(error: Error) {

--- a/AlphaWallet/Core/TokensAutodetector/AutoDetectTransactedTokensOperation.swift
+++ b/AlphaWallet/Core/TokensAutodetector/AutoDetectTransactedTokensOperation.swift
@@ -15,7 +15,7 @@ protocol AutoDetectTransactedTokensOperationDelegate: class {
 }
 
 final class AutoDetectTransactedTokensOperation: Operation {
-    
+
     weak private var delegate: AutoDetectTransactedTokensOperationDelegate?
     override var isExecuting: Bool {
         return delegate?.isAutoDetectingTransactedTokens ?? false
@@ -36,7 +36,7 @@ final class AutoDetectTransactedTokensOperation: Operation {
         self.tokensDataStore = tokensDataStore
         super.init()
         self.queuePriority = session.server.networkRequestsQueuePriority
-    } 
+    }
 
     override func main() {
         guard let delegate = delegate else { return }
@@ -52,6 +52,8 @@ final class AutoDetectTransactedTokensOperation: Operation {
 
             guard !strongSelf.isCancelled else { return }
             strongSelf.tokensDataStore.addOrUpdate(tokensOrContracts: values)
-        }.cauterize()
+        }.catch { error in
+            verboseLog("Error while detecting tokens wallet: \(self.session.account.address.eip55String) error: \(error)")
+        }
     }
 }

--- a/AlphaWallet/Core/TokensAutodetector/TokenFetcher.swift
+++ b/AlphaWallet/Core/TokensAutodetector/TokenFetcher.swift
@@ -37,7 +37,10 @@ class SingleChainTokenFetcher: NSObject, TokenFetcher {
                     case .name, .symbol, .balance, .decimals:
                         break
                     case .nonFungibleTokenComplete(let name, let symbol, let balance, let tokenType):
-                        guard !onlyIfThereIsABalance || (onlyIfThereIsABalance && !balance.isEmpty) else { break }
+                        guard !onlyIfThereIsABalance || (onlyIfThereIsABalance && !balance.isEmpty) else {
+                            seal.fulfill(.none)
+                            break
+                        }
                         let token = ERCToken(
                                 contract: contract,
                                 server: server,

--- a/AlphaWallet/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
+++ b/AlphaWallet/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
@@ -39,6 +39,8 @@ class TokenScriptSignatureVerifier {
         guard Features.default.isAvailable(.isTokenScriptSignatureStatusEnabled) else {
             //It is safe to return without calling `completion` here since we aren't supposed to be using the results with the feature flag above
             infoLog("[TokenScript] Signature verification disabled")
+            //We call the completion handler so that if the caller is a `Promise`, it will resolve, in order to avoid the warning: "PromiseKit: warning: pending promise deallocated"
+            completion(.success(domain: ""))
             return
         }
 

--- a/AlphaWallet/Tokens/Logic/ContractDataDetector.swift
+++ b/AlphaWallet/Tokens/Logic/ContractDataDetector.swift
@@ -73,19 +73,23 @@ class ContractDataDetector {
                     self.completionOfPartialData(.balance(balance: .erc875(balance), tokenType: .erc875))
                 }.catch { error in
                     self.nonFungibleBalanceSeal.reject(error)
+                    self.decimalsSeal.fulfill(0)
                     self.callCompletionFailed()
                 }
             case .erc721:
                 self.tokenProvider.getERC721Balance(for: self.address).done { balance in
                     self.nonFungibleBalanceSeal.fulfill(.balance(balance))
+                    self.decimalsSeal.fulfill(0)
                     self.completionOfPartialData(.balance(balance: .balance(balance), tokenType: .erc721))
                 }.catch { error in
                     self.nonFungibleBalanceSeal.reject(error)
+                    self.decimalsSeal.fulfill(0)
                     self.callCompletionFailed()
                 }
             case .erc721ForTickets:
                 self.tokenProvider.getERC721ForTicketsBalance(for: self.address).done { balance in
                     self.nonFungibleBalanceSeal.fulfill(.erc721ForTickets(balance))
+                    self.decimalsSeal.fulfill(0)
                     self.completionOfPartialData(.balance(balance: .erc721ForTickets(balance), tokenType: .erc721ForTickets))
                 }.catch { error in
                     self.nonFungibleBalanceSeal.reject(error)
@@ -94,6 +98,7 @@ class ContractDataDetector {
             case .erc1155:
                 let balance: [String] = .init()
                 self.nonFungibleBalanceSeal.fulfill(.balance(balance))
+                self.decimalsSeal.fulfill(0)
                 self.completionOfPartialData(.balance(balance: .balance(balance), tokenType: .erc1155))
             case .erc20:
                 self.tokenProvider.getDecimals(for: self.address).done { decimal in


### PR DESCRIPTION
Part of #4952

Eventually there should be no `.cauterize()` calls to PromiseKit and all the errors should be caught and printed out:

* programmatic errors are fixed
* rate limited calls are logged
* those we can't handle are hardcoded to be ignored