### PR TITLE
Rename fastlane lane to `upload` to avoid name collison: "Name of the lane 'testflight' is already taken by the action named 'testflight' #4964

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,8 +65,8 @@ platform :ios do
 
   # You can define as many lanes as you want
 
-  desc "Upload a build for TestFlight"
-  lane :testflight do
+  desc "Upload a build for TestFlight and submission"
+  lane :upload do
     cocoapods(use_bundle_exec: true)
 
     build_app(workspace: "AlphaWallet.xcworkspace", scheme: "AlphaWallet",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,13 +47,13 @@ Screenshots
 
 
 
-### ios testflight
+### ios upload
 
 ```sh
-[bundle exec] fastlane ios testflight
+[bundle exec] fastlane ios upload
 ```
 
-Upload a build for TestFlight
+Upload a build for TestFlight and submission
 
 ----
 


### PR DESCRIPTION
Closes #4964