### PR TITLE
Use Klaytn production RPC node for Cypress mainnet and Baobab testnet

### DIFF
--- a/AlphaWallet/EtherClient/EtherServiceRequest.swift
+++ b/AlphaWallet/EtherClient/EtherServiceRequest.swift
@@ -6,15 +6,18 @@ import JSONRPCKit
 
 struct EtherServiceRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
     private let rpcURL: URL
+    private let rpcHeaders: [String: String]
     private let batch: Batch
 
     init(server: RPCServer, batch: Batch) {
         self.batch = batch
         self.rpcURL = server.rpcURL
+        self.rpcHeaders = server.rpcHeaders
     }
 
-    init(rpcURL: URL, batch: Batch) {
+    init(rpcURL: URL, rpcHeaders: [String: String], batch: Batch) {
         self.batch = batch
+        self.rpcHeaders = rpcHeaders
         self.rpcURL = rpcURL
     }
 
@@ -34,6 +37,10 @@ struct EtherServiceRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
 
     var parameters: Any? {
         return batch.requestObject
+    }
+
+    var headerFields: [String: String] {
+        return rpcHeaders
     }
 
     func response(from object: Any, urlResponse: HTTPURLResponse) throws -> Response {

--- a/AlphaWallet/EtherClient/Models/GetNextNonce.swift
+++ b/AlphaWallet/EtherClient/Models/GetNextNonce.swift
@@ -6,25 +6,27 @@ import JSONRPCKit
 import PromiseKit
 
 class GetNextNonce {
-    //Important to store the RPC URL and not read `RPCServer.server` because it might be overridden by a RPC node that supports private transactions
+    //Important to store the RPC URL and headers, and not read from `server` because it might be overridden by a RPC node that supports private transactions
     private let rpcURL: URL
+    private let rpcHeaders: [String: String]
     private let server: RPCServer
     private let wallet: AlphaWallet.Address
     private let analyticsCoordinator: AnalyticsCoordinator
 
     convenience init(server: RPCServer, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
-        self.init(rpcURL: server.rpcURL, server: server, wallet: wallet, analyticsCoordinator: analyticsCoordinator)
+        self.init(rpcURL: server.rpcURL, rpcHeaders: server.rpcHeaders, server: server, wallet: wallet, analyticsCoordinator: analyticsCoordinator)
     }
 
-    init(rpcURL: URL, server: RPCServer, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
+    init(rpcURL: URL, rpcHeaders: [String: String], server: RPCServer, wallet: AlphaWallet.Address, analyticsCoordinator: AnalyticsCoordinator) {
         self.rpcURL = rpcURL
+        self.rpcHeaders = rpcHeaders
         self.server = server
         self.wallet = wallet
         self.analyticsCoordinator = analyticsCoordinator
     }
 
     func promise() -> Promise<Int> {
-        let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(GetTransactionCountRequest(address: wallet, state: "pending")))
+        let request = EtherServiceRequest(rpcURL: rpcURL, rpcHeaders: rpcHeaders, batch: BatchFactory().create(GetTransactionCountRequest(address: wallet, state: "pending")))
         return Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator)
     }
 }

--- a/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
@@ -389,7 +389,7 @@ class ImportMagicLinkCoordinator: Coordinator {
         let vString = "0" + String(vInt)
         let signature = "0x" + signedOrder.signature.drop0x.substring(to: 128) + vString
         let nodeURL = server.rpcURL
-        let provider = Web3HttpProvider(nodeURL, network: server.web3Network)!
+        let provider = Web3HttpProvider(nodeURL, headers: server.rpcHeaders, network: server.web3Network)!
         let web3Instance = web3swift.web3(provider: provider)
 
         return web3swift.web3.Personal(provider: web3Instance.provider, web3: web3Instance).ecrecover(

--- a/AlphaWallet/Settings/Types/Constants+Credentials.swift
+++ b/AlphaWallet/Settings/Types/Constants+Credentials.swift
@@ -19,5 +19,7 @@ extension Constants {
         static let unstoppableDomainsV2ApiKey = "Bearer rLuujk_dLBN-JDE6Xl8QSCg-FeIouRKM"
         static let blockscanChatProxyKey = ""
         static let covalentApiKey = "ckey_7ee61be7f8364ba784f697510bd"
+        //Without the "Basic " prefix
+        static let klaytnRpcNodeKeyBasicAuth = ""
     }
 }

--- a/AlphaWallet/Settings/Types/RPCServers.swift
+++ b/AlphaWallet/Settings/Types/RPCServers.swift
@@ -605,13 +605,42 @@ enum RPCServer: Hashable, CaseIterable {
             case .arbitrumRinkeby: return "https://arbitrum-rinkeby.infura.io/v3/\(Constants.Credentials.infuraKey)"
             case .palm: return "https://palm-mainnet.infura.io/v3/\(Constants.Credentials.infuraKey)"
             case .palmTestnet: return "https://palm-testnet.infura.io/v3/\(Constants.Credentials.infuraKey)"
-            case .klaytnCypress: return "https://public-node-api.klaytnapi.com/v1/cypress"
-            case .klaytnBaobabTestnet: return "https://api.baobab.klaytn.net:8651"
+            case .klaytnCypress:
+                let basicAuth = Constants.Credentials.klaytnRpcNodeKeyBasicAuth
+                if basicAuth.isEmpty {
+                    return "https://public-node-api.klaytnapi.com/v1/cypress"
+                } else {
+                    return "https://node-api.klaytnapi.com/v1/klaytn"
+                }
+            case .klaytnBaobabTestnet:
+                let basicAuth = Constants.Credentials.klaytnRpcNodeKeyBasicAuth
+                if basicAuth.isEmpty {
+                    return "https://api.baobab.klaytn.net:8651"
+                } else {
+                    return "https://node-api.klaytnapi.com/v1/klaytn"
+                }
             case .ioTeX: return "https://babel-api.mainnet.iotex.io"
             case .ioTeXTestnet: return "https://babel-api.testnet.iotex.io"
             }
         }()
         return URL(string: urlString)!
+    }
+
+    var rpcHeaders: RPCNodeHTTPHeaders {
+        switch self {
+        case .klaytnCypress, .klaytnBaobabTestnet:
+            let basicAuth = Constants.Credentials.klaytnRpcNodeKeyBasicAuth
+            if basicAuth.isEmpty {
+                return .init()
+            } else {
+                return [
+                    "Authorization": "Basic \(basicAuth)",
+                    "x-chain-id": "\(chainID)",
+                ]
+            }
+        case .main, .classic, .callisto, .kovan, .ropsten, .rinkeby, .poa, .sokol, .goerli, .xDai, .phi, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .ioTeX, .ioTeXTestnet:
+            return .init()
+        }
     }
 
     var transactionInfoEndpoints: URL? {

--- a/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
@@ -39,7 +39,8 @@ func getCachedWeb3(forServer server: RPCServer, timeout: TimeInterval) throws ->
     if let result = web3s[server]?[timeout] {
         return result
     } else {
-        guard let webProvider = Web3HttpProvider(server.rpcURL, network: server.web3Network) else {
+        let rpcHeaders = server.rpcHeaders
+        guard let webProvider = Web3HttpProvider(server.rpcURL, headers: rpcHeaders, network: server.web3Network) else {
             throw Web3Error(description: "Error creating web provider for: \(server.rpcURL) + \(server.web3Network)")
         }
         let configuration = webProvider.session.configuration

--- a/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
+++ b/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
@@ -29,13 +29,13 @@ public final class GetDASNameLookup {
         return value.trimmed.hasSuffix(".bit")
     }
 
-    func resolve(rpcURL: URL, value: String) -> Promise<AlphaWallet.Address> {
+    func resolve(rpcURL: URL, rpcHeaders: [String: String], value: String) -> Promise<AlphaWallet.Address> {
         guard GetDASNameLookup.isValid(value: value) else {
             debugLog("[DAS] Invalid lookup: \(value)")
             return .init(error: DASNameLookupError.invalidInput)
         }
 
-        let request = EtherServiceRequest(rpcURL: rpcURL, batch: BatchFactory().create(DASLookupRequest(value: value)))
+        let request = EtherServiceRequest(rpcURL: rpcURL, rpcHeaders: rpcHeaders, batch: BatchFactory().create(DASLookupRequest(value: value)))
         debugLog("[DAS] Looking up value \(value)")
         return Session.send(request, server: server, analyticsCoordinator: analyticsCoordinator).map { response -> AlphaWallet.Address in
             debugLog("[DAS] response for value: \(value) response : \(response)")

--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ target 'AlphaWallet' do
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/AlphaWallet/latest-keystore-snapshot', :commit => 'c0bdc4f6ffc117b103e19d17b83109d4f5a0e764'
   pod 'SwiftyJSON', '5.0.0'
-  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> '11b13daa2fbfced4fbe2ec94415b972b2c42d647'
+  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> 'a84b1ca9ce76ea862356dcec5740305fcd7255cf'
   pod 'SAMKeychain'
   pod 'PromiseKit/CorePromise'
   pod 'PromiseKit/Alamofire'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES:
   - TrustKeystore (from `https://github.com/AlphaWallet/latest-keystore-snapshot`, commit `c0bdc4f6ffc117b103e19d17b83109d4f5a0e764`)
   - TrustWalletCore (= 2.6.34)
   - WalletConnectSwift (from `https://github.com/AlphaWallet/WalletConnectSwift.git`, commit `b6556058331f619e15482b82d7c6ab57d9711399`)
-  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `11b13daa2fbfced4fbe2ec94415b972b2c42d647`)
+  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `a84b1ca9ce76ea862356dcec5740305fcd7255cf`)
   - xcbeautify
 
 SPEC REPOS:
@@ -255,7 +255,7 @@ EXTERNAL SOURCES:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: 11b13daa2fbfced4fbe2ec94415b972b2c42d647
+    :commit: a84b1ca9ce76ea862356dcec5740305fcd7255cf
     :git: https://github.com/AlphaWallet/web3swift.git
 
 CHECKOUT OPTIONS:
@@ -284,7 +284,7 @@ CHECKOUT OPTIONS:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: 11b13daa2fbfced4fbe2ec94415b972b2c42d647
+    :commit: a84b1ca9ce76ea862356dcec5740305fcd7255cf
     :git: https://github.com/AlphaWallet/web3swift.git
 
 SPEC CHECKSUMS:
@@ -343,6 +343,6 @@ SPEC CHECKSUMS:
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: b5b4a34d65d6cecd431f895cb18324b3b99e4f27
+PODFILE CHECKSUM: a9ec18fa47385a933ccc020724e3f205990d324c
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Closes #5050

```
if API basic auth credentials provided in credentials file
    Use it with Klaytn API Service (KAS)
else
    use public/free node
end
```

---

Actually not sure what is the rate limit with KAS, but the public node that we used is from a shared pool with every user/app, so let's go with KAS and if necessary we can get a better plan later