### PR TITLE
Make enable network screen fill bottom safe area

### DIFF
--- a/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
@@ -25,7 +25,7 @@ class EnabledServersViewController: UIViewController {
         tableView.register(RPCDisplaySelectableTableViewCell.self)
         tableView.dataSource = self
         tableView.isEditing = false
-        
+
         return tableView
     }()
     private let restartQueue: RestartTaskQueue
@@ -54,7 +54,7 @@ class EnabledServersViewController: UIViewController {
             tableView.leadingAnchor.constraint(equalTo: roundedBackground.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: roundedBackground.trailingAnchor),
             tableView.topAnchor.constraint(equalTo: roundedBackground.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ] + roundedBackground.createConstraintsWithContainer(view: view))
     }
 
@@ -115,7 +115,7 @@ class EnabledServersViewController: UIViewController {
         guard let customRpc = server.customRpc else { return }
         delegate?.didEditSelectedServer(customRpc: customRpc, in: self)
     }
-    
+
     private func markForDeletion(server: RPCServer) {
         guard let customRpc = server.customRpc else { return }
         pushReloadServersIfNeeded()


### PR DESCRIPTION
When not at the bottom:

Before PR|After PR
-|-
<img width="200" alt="Screenshot 2022-08-01 at 3 41 39 PM" src="https://user-images.githubusercontent.com/56189/182099681-3d943472-f9b0-417e-bc45-3c34abe8ca13.png">|<img width="200" alt="Screenshot 2022-08-01 at 3 41 02 PM" src="https://user-images.githubusercontent.com/56189/182099711-44fcc407-21c2-448d-bdb4-ca6acb73e374.png">

Unchanged, at the bottom:

<img width="200" alt="Screenshot 2022-08-01 at 3 40 53 PM" src="https://user-images.githubusercontent.com/56189/182099715-1701f95a-bc95-46c4-8504-1f4a94221818.png">
