### PR TITLE
Support `scriptURI()` smart contract call to retrieve URI for TokenScript files

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		5E7C7A5ACC0CB30368182EA1 /* EnsResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74A233BDB3465C93BAB3 /* EnsResolver.swift */; };
 		5E7C7A67B6143DFB9B1CF02B /* ConfirmSignMessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7DD9C564F2C7DE435894 /* ConfirmSignMessageTableViewCell.swift */; };
 		5E7C7A6CC21C553CD4008F14 /* DappButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C75E7D995ABE0E6B7AD55 /* DappButton.swift */; };
+		5E7C7A709C0BF6C7716A6251 /* ScriptUri.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C71F2CAF30A270E966817 /* ScriptUri.swift */; };
 		5E7C7A7FFA16D3505F94BB9E /* FakeActivitiesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BB70AD8C1E92D37196F /* FakeActivitiesService.swift */; };
 		5E7C7A91D0F6CBDA3C89DEAC /* LocaleViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79E3BC4CACB123840A42 /* LocaleViewCell.swift */; };
 		5E7C7A928412AF3E16CDA038 /* AmountTextField_v2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73D0DCE61EA2DE2DA21D /* AmountTextField_v2.swift */; };
@@ -1582,6 +1583,7 @@
 		5E7C71DB4EDD10EA665101C2 /* ActivityViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityViewCell.swift; sourceTree = "<group>"; };
 		5E7C71E355BD14E975AF7491 /* TokensDataStoreTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensDataStoreTest.swift; sourceTree = "<group>"; };
 		5E7C71E8E2D256BC461E9597 /* TokenScriptSelection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScriptSelection.swift; sourceTree = "<group>"; };
+		5E7C71F2CAF30A270E966817 /* ScriptUri.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptUri.swift; sourceTree = "<group>"; };
 		5E7C71FA42A4828FDC07E72E /* SendPrivateTransactionsProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendPrivateTransactionsProvider.swift; sourceTree = "<group>"; };
 		5E7C720596AD351B21CE7583 /* DatabaseMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseMigration.swift; sourceTree = "<group>"; };
 		5E7C7228C9BEB801D4CD34DE /* EtherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EtherTests.swift; sourceTree = "<group>"; };
@@ -4638,6 +4640,7 @@
 				5E7C73553968E56A08D90D0C /* Erc1155TokenIdsFetcher.swift */,
 				8728FFE22742906A008E5524 /* TokenCardTableViewCellFactory.swift */,
 				87E1A5EC2837884300E98555 /* HistoryHelper.swift */,
+				5E7C71F2CAF30A270E966817 /* ScriptUri.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -7698,6 +7701,7 @@
 				5E7C70F8A7DD8D5EC812A80F /* SwapQuote.swift in Sources */,
 				5E7C76484BE3E1F41ABA4A00 /* SwapEstimate.swift in Sources */,
 				5E7C762FC313F112981FAD35 /* DevelopmentForcedError.swift in Sources */,
+				5E7C7A709C0BF6C7716A6251 /* ScriptUri.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -1114,9 +1114,9 @@ extension ActiveWalletCoordinator: TransactionsServiceDelegate {
         walletBalanceService.refreshBalance(updatePolicy: .all, wallets: [wallet])
     }
 
-    func didExtractNewContracts(in service: TransactionsService, contracts: [AlphaWallet.Address]) {
-        for each in contracts {
-            assetDefinitionStore.fetchXML(forContract: each)
+    func didExtractNewContracts(in service: TransactionsService, contractsAndServers: [AddressAndRPCServer]) {
+        for each in contractsAndServers {
+            assetDefinitionStore.fetchXML(forContract: each.address, server: each.server)
         }
     }
 }

--- a/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
@@ -474,7 +474,7 @@ class ImportMagicLinkCoordinator: Coordinator {
     }()
 
     private func makeTokenHolder(_ bytes32Tokens: [String], _ contractAddress: AlphaWallet.Address) {
-        assetDefinitionStore.fetchXML(forContract: contractAddress, useCacheAndFetch: true) { [weak self] _ in
+        assetDefinitionStore.fetchXML(forContract: contractAddress, server: server, useCacheAndFetch: true) { [weak self] _ in
             guard let strongSelf = self else { return }
 
             func makeTokenHolder(name: String, symbol: String, type: TokenType? = nil) {

--- a/AlphaWallet/TokenScriptClient/Coordinators/FetchTokenScriptFiles.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/FetchTokenScriptFiles.swift
@@ -7,18 +7,15 @@ class FetchTokenScriptFiles {
     private let tokensDataStore: TokensDataStore
     private let config: Config
 
-    private var contractsInDatabase: [AlphaWallet.Address] {
-        var contracts = [AlphaWallet.Address]()
-        contracts.append(contentsOf: tokensDataStore.enabledTokens(for: config.enabledServers).filter {
+    private var contractsInDatabase: [AddressAndOptionalRPCServer] {
+        return tokensDataStore.enabledTokens(for: config.enabledServers).filter {
             switch $0.type {
             case .erc20, .erc721, .erc875, .erc721ForTickets, .erc1155:
                 return true
             case .nativeCryptocurrency:
                 return false
             }
-        }.map { $0.contractAddress })
-
-        return contracts
+        }.map { AddressAndOptionalRPCServer(address: $0.contractAddress, server: $0.server) }
     }
 
     private var contractsWithTokenScriptFileFromOfficialRepo: [AlphaWallet.Address] {
@@ -35,8 +32,8 @@ class FetchTokenScriptFiles {
 
     func start() {
         queue.async {
-            let contracts = Array(Set(self.contractsInDatabase + self.contractsWithTokenScriptFileFromOfficialRepo))
-            self.assetDefinitionStore.fetchXMLs(forContracts: contracts)
+            let contractsAndServers = Array(Set(self.contractsInDatabase + self.contractsWithTokenScriptFileFromOfficialRepo.map { AddressAndOptionalRPCServer(address: $0, server: nil) }))
+            self.assetDefinitionStore.fetchXMLs(forContractsAndServers: contractsAndServers)
         }
     }
 

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionBackingStore.swift
@@ -21,6 +21,6 @@ protocol AssetDefinitionBackingStore {
 }
 
 protocol AssetDefinitionBackingStoreDelegate: AnyObject {
-    func invalidateAssetDefinition(forContract contract: AlphaWallet.Address)
+    func invalidateAssetDefinition(forContractAndServer contractAndServer: AddressAndOptionalRPCServer)
     func badTokenScriptFilesChanged(in: AssetDefinitionBackingStore)
 }

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionDiskBackingStoreWithOverrides.swift
@@ -29,8 +29,8 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
         } else {
             let store = AssetDefinitionDiskBackingStore(directoryName: AssetDefinitionDiskBackingStoreWithOverrides.overridesDirectoryName)
             self.overridesStore = store
-            store.watchDirectoryContents { [weak self] contract in
-                self?.delegate?.invalidateAssetDefinition(forContract: contract)
+            store.watchDirectoryContents { [weak self] contractAndServer in
+                self?.delegate?.invalidateAssetDefinition(forContractAndServer: contractAndServer)
             }
         }
 
@@ -120,7 +120,7 @@ class AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStore 
 }
 
 extension AssetDefinitionDiskBackingStoreWithOverrides: AssetDefinitionBackingStoreDelegate {
-    func invalidateAssetDefinition(forContract contract: AlphaWallet.Address) {
+    func invalidateAssetDefinition(forContractAndServer contractAndServer: AddressAndOptionalRPCServer) {
         //do nothing
     }
 

--- a/AlphaWallet/Tokens/Logic/ContractDataDetector.swift
+++ b/AlphaWallet/Tokens/Logic/ContractDataDetector.swift
@@ -41,7 +41,7 @@ class ContractDataDetector {
     func fetch(completion: @escaping (ContractData) -> Void) {
         self.completion = completion
 
-        assetDefinitionStore.fetchXML(forContract: address)
+        assetDefinitionStore.fetchXML(forContract: address, server: nil)
 
         firstly {
             namePromise

--- a/AlphaWallet/Tokens/Logic/ScriptUri.swift
+++ b/AlphaWallet/Tokens/Logic/ScriptUri.swift
@@ -1,0 +1,51 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+import Result
+import web3swift
+import PromiseKit
+
+class ScriptUri {
+    private let server: RPCServer
+    private let abiString = """
+                            [
+                                {
+                                  "constant" : false,
+                                  "inputs" : [
+                                  ],
+                                  "name" : "scriptURI",
+                                  "outputs" : [
+                                    {
+                                      "name" : "",
+                                      "type" : "string"
+                                    }
+                                  ],
+                                  "payable" : false,
+                                  "stateMutability" : "nonpayable",
+                                  "type" : "function"
+                                }
+                            ]
+                            """
+
+    init(forServer server: RPCServer) {
+        self.server = server
+    }
+
+    func get(forContract contract: AlphaWallet.Address) -> Promise<URL> {
+        let functionName = "scriptURI"
+        return firstly {
+            callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: abiString, timeout: Constants.fetchContractDataTimeout)
+        }.map { urlStringResult in
+            if let urlString = urlStringResult["0"] as? String {
+                if let url = URL(string: urlString) {
+                    let url = url.rewrittenIfIpfs
+                    return url
+                } else {
+                    throw AnyError(Web3Error(description: "Error extracting result from \(contract.eip55String).\(functionName)()"))
+                }
+            } else {
+                throw AnyError(Web3Error(description: "Error extracting result from \(contract.eip55String).\(functionName)()"))
+            }
+        }
+    }
+}

--- a/AlphaWallet/Tokens/Types/AddressAndRPCServer.swift
+++ b/AlphaWallet/Tokens/Types/AddressAndRPCServer.swift
@@ -19,3 +19,20 @@ struct AddressAndRPCServer: Hashable, Codable, CustomStringConvertible {
         hasher.combine(description)
     }
 }
+
+struct AddressAndOptionalRPCServer: Hashable, Codable, CustomStringConvertible {
+    let address: AlphaWallet.Address
+    let server: RPCServer?
+
+    var description: String {
+        if let server = server {
+            return "\(address.eip55String)-\(server)"
+        } else {
+            return address.eip55String
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(description)
+    }
+}

--- a/AlphaWallet/Transactions/TokensFromTransactionsFetcher.swift
+++ b/AlphaWallet/Transactions/TokensFromTransactionsFetcher.swift
@@ -9,19 +9,19 @@ import Foundation
 import PromiseKit
 
 protocol TokensFromTransactionsFetcherDelegate: AnyObject {
-    func didExtractTokens(in fetcher: TokensFromTransactionsFetcher, contracts: [AlphaWallet.Address], tokenUpdates: [TokenUpdate])
+    func didExtractTokens(in fetcher: TokensFromTransactionsFetcher, contractsAndServers: [AddressAndRPCServer], tokenUpdates: [TokenUpdate])
 }
 
 final class TokensFromTransactionsFetcher {
     private let tokensDataStore: TokensDataStore
     private let session: WalletSession
-    
+
     weak var delegate: TokensFromTransactionsFetcherDelegate?
 
     init(tokensDataStore: TokensDataStore, session: WalletSession) {
         self.tokensDataStore = tokensDataStore
         self.session = session
-    } 
+    }
 
     func extractNewTokens(from transactions: [TransactionInstance]) {
         guard !transactions.isEmpty else { return }
@@ -34,9 +34,9 @@ final class TokensFromTransactionsFetcher {
 
     private func addTokensFromUpdates(transactionsToPullContractsFrom transactions: [TransactionInstance], contractsAndTokenTypes: [AlphaWallet.Address: TokenType]) {
         let tokenUpdates = TokensFromTransactionsFetcher.functional.tokens(from: transactions, contractsAndTokenTypes: contractsAndTokenTypes)
-        let contracts = Array(Set(tokenUpdates.map { $0.address }))
+        let contractsAndServers = Array(Set(tokenUpdates.map { AddressAndRPCServer(address: $0.address, server: $0.server) }))
 
-        delegate?.didExtractTokens(in: self, contracts: contracts, tokenUpdates: tokenUpdates)
+        delegate?.didExtractTokens(in: self, contractsAndServers: contractsAndServers, tokenUpdates: tokenUpdates)
     }
 
     private var contractsToAvoid: [AlphaWallet.Address] {

--- a/AlphaWallet/Transactions/TransactionsService.swift
+++ b/AlphaWallet/Transactions/TransactionsService.swift
@@ -10,7 +10,7 @@ enum TransactionError: Error {
 
 protocol TransactionsServiceDelegate: AnyObject {
     func didCompleteTransaction(in service: TransactionsService, transaction: TransactionInstance)
-    func didExtractNewContracts(in service: TransactionsService, contracts: [AlphaWallet.Address])
+    func didExtractNewContracts(in service: TransactionsService, contractsAndServers: [AddressAndRPCServer])
 }
 
 class TransactionsService {
@@ -140,9 +140,9 @@ class TransactionsService {
 }
 
 extension TransactionsService: TokensFromTransactionsFetcherDelegate {
-    func didExtractTokens(in fetcher: TokensFromTransactionsFetcher, contracts: [AlphaWallet.Address], tokenUpdates: [TokenUpdate]) {
+    func didExtractTokens(in fetcher: TokensFromTransactionsFetcher, contractsAndServers: [AddressAndRPCServer], tokenUpdates: [TokenUpdate]) {
         tokensDataStore.add(tokenUpdates: tokenUpdates)
-        delegate?.didExtractNewContracts(in: self, contracts: contracts)
+        delegate?.didExtractNewContracts(in: self, contractsAndServers: contractsAndServers)
     }
 }
 

--- a/AlphaWalletTests/TokenScriptClient/AssetDefinitionStoreTests.swift
+++ b/AlphaWalletTests/TokenScriptClient/AssetDefinitionStoreTests.swift
@@ -23,7 +23,7 @@ class AssetDefinitionStoreTests: XCTestCase {
         let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
         let expectation = XCTestExpectation(description: "cached case should not be called")
         expectation.isInverted = true
-        store.fetchXML(forContract: contractAddress, useCacheAndFetch: true) { [weak self] result in
+        store.fetchXML(forContract: contractAddress, server: nil, useCacheAndFetch: true) { [weak self] result in
             guard self != nil else { return }
             switch result {
             case .cached:
@@ -40,7 +40,7 @@ class AssetDefinitionStoreTests: XCTestCase {
         let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
         store[contractAddress] = "something"
         let expectation = XCTestExpectation(description: "cached case should be called")
-        store.fetchXML(forContract: contractAddress, useCacheAndFetch: true) { [weak self] result in
+        store.fetchXML(forContract: contractAddress, server: nil, useCacheAndFetch: true) { [weak self] result in
             guard self != nil else { return }
             switch result {
             case .cached:


### PR DESCRIPTION
Closes #5110

Can verify it with:

token: 0xd915c8ad3241f459a45adcbbf8af42caa561a154
wallet: 0xbbce83173d5c1D122AE64856b4Af0D5AE07Fa362 (balance = 1)

The TokenScript actions Unlock and Lock (maybe a bit more) should be available