### PR TITLE
Modified AppCoordinator and AppDelegate to handle UIAlertController not having the correct tint colours.

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -179,7 +179,6 @@ class AppCoordinator: NSObject, Coordinator {
         runServices()
         appTracker.start()
         notificationService.registerForReceivingRemoteNotifications()
-        applyStyle()
 
         setupAssetDefinitionStoreCoordinator()
         migrateToStoringRawPrivateKeysInKeychain()

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -23,9 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        applyStyle()
         window = UIWindow(frame: UIScreen.main.bounds)
-        //Necessary to make UIAlertController have the correct tint colors, despite already doing: `UIWindow.appearance().tintColor = Colors.appTint`
-        window?.tintColor = Colors.appTint
 
         do {
             if Features.default.isAvailable(.isFirebaseEnabled) {


### PR DESCRIPTION
```
window = UIWindow(frame: UIScreen.main.bounds)
//Necessary to make UIAlertController have the correct tint colors, despite already doing: `UIWindow.appearance().tintColor = Colors.appTint`
window?.tintColor = Colors.appTint
```

Modified code to remove this.