### PR TITLE
Capture rate limited errors (`429`s) for batched RPC/JSON requests #5164

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ target 'AlphaWallet' do
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/AlphaWallet/latest-keystore-snapshot', :commit => 'c0bdc4f6ffc117b103e19d17b83109d4f5a0e764'
   pod 'SwiftyJSON', '5.0.0'
-  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> 'a84b1ca9ce76ea862356dcec5740305fcd7255cf'
+  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> '72d6514f6ac29a68abb7b9cbab5685799c18d77a'
   pod 'SAMKeychain'
   pod 'PromiseKit/CorePromise'
   pod 'PromiseKit/Alamofire'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES:
   - TrustKeystore (from `https://github.com/AlphaWallet/latest-keystore-snapshot`, commit `c0bdc4f6ffc117b103e19d17b83109d4f5a0e764`)
   - TrustWalletCore (= 2.6.34)
   - WalletConnectSwift (from `https://github.com/AlphaWallet/WalletConnectSwift.git`, commit `b6556058331f619e15482b82d7c6ab57d9711399`)
-  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `a84b1ca9ce76ea862356dcec5740305fcd7255cf`)
+  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `72d6514f6ac29a68abb7b9cbab5685799c18d77a`)
   - xcbeautify
 
 SPEC REPOS:
@@ -255,7 +255,7 @@ EXTERNAL SOURCES:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: a84b1ca9ce76ea862356dcec5740305fcd7255cf
+    :commit: 72d6514f6ac29a68abb7b9cbab5685799c18d77a
     :git: https://github.com/AlphaWallet/web3swift.git
 
 CHECKOUT OPTIONS:
@@ -284,7 +284,7 @@ CHECKOUT OPTIONS:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: a84b1ca9ce76ea862356dcec5740305fcd7255cf
+    :commit: 72d6514f6ac29a68abb7b9cbab5685799c18d77a
     :git: https://github.com/AlphaWallet/web3swift.git
 
 SPEC CHECKSUMS:
@@ -343,6 +343,6 @@ SPEC CHECKSUMS:
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: a9ec18fa47385a933ccc020724e3f205990d324c
+PODFILE CHECKSUM: ae1728bb950319123cc28da1aeb8c1f511db4cad
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Closes #5164

Not sure if it actually fixes #5164, but it definitely makes it clearer that those `.typeMismatch` errors are 429s when rate limited by the RPC nodes.