### PR TITLE
Fix: Speed up/cancel transaction's confirmation actionsheet does not display the network correctly #5186

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -267,7 +267,7 @@ class TransactionConfirmationViewModel {
             viewModel.updateBalance(balanceViewModel)
         }
     }
-} 
+}
 
 extension TransactionConfirmationViewModel {
 
@@ -470,9 +470,11 @@ extension TransactionConfirmationViewModel {
                 switch section {
                 case .gas:
                     views += [.header(viewModel: viewModel.headerViewModel(section: sectionIndex), isEditEnabled: _viewModel.canUserChangeGas)]
-                case .description, .network:
+                case .description:
                     let vm = TransactionRowDescriptionTableViewCellViewModel(title: section.title)
                     views += [.details(viewModel: vm)]
+                case .network:
+                    views += [.header(viewModel: viewModel.headerViewModel(section: sectionIndex), isEditEnabled: false)]
                 }
             }
         case .cancelTransaction(let viewModel):
@@ -480,9 +482,11 @@ extension TransactionConfirmationViewModel {
                 switch section {
                 case .gas:
                     views += [.header(viewModel: viewModel.headerViewModel(section: sectionIndex), isEditEnabled: _viewModel.canUserChangeGas)]
-                case .description, .network:
+                case .description:
                     let vm = TransactionRowDescriptionTableViewCellViewModel(title: section.title)
                     views += [.details(viewModel: vm)]
+                case .network:
+                    views += [.header(viewModel: viewModel.headerViewModel(section: sectionIndex), isEditEnabled: false)]
                 }
             }
         case .swapTransaction(let viewModel):


### PR DESCRIPTION
Fixes #5186

Before PR|After PR
-|-
<img width="200" alt="Screenshot 2022-08-16 at 12 26 35 PM" src="https://user-images.githubusercontent.com/56189/185546703-dfc4df67-f107-4e0b-9c59-02595ba0467f.png">|<img width="200" alt="Screenshot 2022-08-19 at 12 54 21 PM" src="https://user-images.githubusercontent.com/56189/185546717-b8fa9e3a-f792-44d8-8784-00d48629b93d.png">
<img width="200" alt="Screenshot 2022-08-19 at 12 52 00 PM" src="https://user-images.githubusercontent.com/56189/185546715-9bac2a33-4eff-46c8-a0bc-b88c84deaaaa.png">|<img width="200" alt="Screenshot 2022-08-19 at 12 53 57 PM" src="https://user-images.githubusercontent.com/56189/185546722-a88ff6de-f618-4ec9-aff0-142256237e05.png">
