### PR TITLE
Fix: ERC20 token's titles in wrong font in Wallet tab

### DIFF
--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
@@ -23,7 +23,7 @@ struct FungibleTokenViewCellViewModel {
 
     var titleAttributedString: NSAttributedString {
         return NSAttributedString(string: token.tokenScriptOverrides?.shortTitleInPluralForm ?? "", attributes: [
-            .foregroundColor: Configuration.Color.Semantic.defaultSubtitleText,
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .font: Screen.TokenCard.Font.title
         ])
     }


### PR DESCRIPTION
Fixes #5178

Before|After
-|-
<img width="220" alt="Screenshot 2022-08-19 at 1 20 28 PM" src="https://user-images.githubusercontent.com/56189/185548388-0d63cc7e-6ce9-459e-8062-f360fcbdfa81.png">|<img width="200" alt="Screenshot 2022-08-19 at 1 19 48 PM" src="https://user-images.githubusercontent.com/56189/185548404-b1d79fe9-8fdf-4212-a449-c684b2b7657a.png">
