### PR TITLE
Add dark mode to WhereIsWalletAddressFoundOverlayView

### DIFF
--- a/AlphaWallet/Configuration.swift
+++ b/AlphaWallet/Configuration.swift
@@ -182,6 +182,14 @@ struct Configuration {
             static let collectionViewBackground = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.shark()!)
             }
+
+            static let overlayBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!.withAlphaComponent(0.3), darkColor: R.color.white()!.withAlphaComponent(0.3))
+            }
+
+            static let dialogBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.black()!)
+            }
         }
     }
 }

--- a/AlphaWallet/UI/WhereIsWalletAddressFoundOverlayView.swift
+++ b/AlphaWallet/UI/WhereIsWalletAddressFoundOverlayView.swift
@@ -14,7 +14,7 @@ class WhereIsWalletAddressFoundOverlayView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = .init(red: 0, green: 0, blue: 0, alpha: 0.3)
+        backgroundColor = Configuration.Color.Semantic.overlayBackground
 
         let blurEffect = UIBlurEffect(style: .regular)
         let blurView = UIVisualEffectView(effect: blurEffect)
@@ -115,16 +115,16 @@ private class Dialog: UIView {
     }
 
     func configure() {
-        backgroundColor = Colors.appWhite
+        backgroundColor = Configuration.Color.Semantic.dialogBackground
 
         titleLabel.font = Fonts.regular(size: 24)
-        titleLabel.textColor = .init(red: 33, green: 33, blue: 33)
+        titleLabel.textColor = Configuration.Color.Semantic.defaultForegroundText
         titleLabel.textAlignment = .center
         titleLabel.text = R.string.localizable.onboardingNewWalletBackupWalletTitle()
 
         descriptionLabel.numberOfLines = 0
         descriptionLabel.font = Fonts.regular(size: 18)
-        descriptionLabel.textColor = .init(red: 102, green: 102, blue: 102)
+        descriptionLabel.textColor = Configuration.Color.Semantic.defaultSubtitleText
         descriptionLabel.textAlignment = .center
         descriptionLabel.text = R.string.localizable.onboardingNewWalletBackupWalletDescription()
 


### PR DESCRIPTION
Run `xcrun simctl uninstall booted com.stormbird.alphawallet` on the command line in the `alpha-wallet-ios` directory before running the app.

Will delete commit for setting appearance to automatic before merging.

![light-mode](https://user-images.githubusercontent.com/1050309/186059347-07572322-79a6-4854-9f3d-7a80fc4a2b4b.jpg) ![dark-mode](https://user-images.githubusercontent.com/1050309/186059357-c6ab6cbb-0136-475b-9a72-98c15bedf34a.jpg)

