### PR TITLE
Support overriding (some) API keys in `.credentials` file at root of project for development purpose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ AlphaWalletTests/Snapshots/FailureDiffs
 /.bundle
 /vendor
 .ruby-version
+
+.credentials

--- a/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWallet.xcscheme
+++ b/AlphaWallet.xcworkspace/xcshareddata/xcschemes/AlphaWallet.xcscheme
@@ -89,6 +89,11 @@
             value = "$(SOURCE_ROOT)/AlphaWalletTests/Snapshots/FailureDiffs"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SOURCE_ROOT"
+            value = "$(SOURCE_ROOT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption


### PR DESCRIPTION
With this PR, we can create a file `.credentials` at the root of the project directory and when running in debug mode on the simulator, keys will be read from the file.

```
INFURAKEY=xyz
OPENSEAKEY=abc
```

Going to try this out to see if it's better than replacing the ones in `Constants+Credentials.swift`. Using `.credentials` has some advantages over changing `Constants+Credentials.swift` locally since it's much harder to accidentally check the file in
