### PR TITLE
Tweak log and logging levels

### DIFF
--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -207,7 +207,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
 
     func start(animated: Bool) {
         donateWalletShortcut()
-        
+
         setupResourcesOnMultiChain()
         walletConnectCoordinator.delegate = self
         setupTabBarController()
@@ -485,7 +485,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
         importToken.importToken(for: contract, server: server, onlyIfThereIsABalance: false)
             .done { _ in }
             .catch { error in
-                verboseLog("Error while adding imported token contract: \(contract.eip55String) server: \(server) wallet: \(self.wallet.address.eip55String) error: \(error)")
+                debugLog("Error while adding imported token contract: \(contract.eip55String) server: \(server) wallet: \(self.wallet.address.eip55String) error: \(error)")
             }
     }
 

--- a/AlphaWallet/BlockscanChat/BlockscanChatService.swift
+++ b/AlphaWallet/BlockscanChat/BlockscanChatService.swift
@@ -44,7 +44,7 @@ class BlockscanChatService {
         }
     }
     deinit {
-        debugLog("[BlockscanChat] BlockscanChatService deinit")
+        verboseLog("[BlockscanChat] BlockscanChatService deinit")
         periodicRefreshTimer?.invalidate()
     }
 

--- a/AlphaWallet/Browser/Types/DappAction.swift
+++ b/AlphaWallet/Browser/Types/DappAction.swift
@@ -101,7 +101,7 @@ extension DappAction {
     static func fromMessage(_ message: WKScriptMessage) -> DappOrWalletCommand? {
         let decoder = JSONDecoder()
         guard var body = message.body as? [String: AnyObject] else {
-            debugLog("[Browser] Invalid body in message: \(message.body)")
+            infoLog("[Browser] Invalid body in message: \(message.body)")
             return nil
         }
         if var object = body["object"] as? [String: AnyObject], object["gasLimit"] is [String: AnyObject] {
@@ -110,7 +110,7 @@ extension DappAction {
             body["object"] = object as AnyObject
         }
         guard let jsonString = body.jsonString else {
-            debugLog("[Browser] Invalid jsonString. body: \(body)")
+            infoLog("[Browser] Invalid jsonString. body: \(body)")
             return nil
         }
         let data = jsonString.data(using: .utf8)!

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -146,7 +146,7 @@ final class BrowserViewController: UIViewController {
 
     func goTo(url: URL) {
         hideErrorView()
-        verboseLog("[Browser] Loading URL: \(url.absoluteString)…")
+        infoLog("[Browser] Loading URL: \(url.absoluteString)…")
         webView.load(URLRequest(url: url))
     }
 
@@ -233,7 +233,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
         //TODO extract `DeepLink`, if reasonable
         if url.host == "aw.app" && url.path == "/wc", let components = URLComponents(url: url, resolvingAgainstBaseURL: false), components.queryItems.isEmpty {
-            NSLog("[Browser] Swallowing URL and doing a no-op, url: \(url.absoluteString)")
+            infoLog("[Browser] Swallowing URL and doing a no-op, url: \(url.absoluteString)")
             decisionHandler(.cancel)
             return
         }

--- a/AlphaWallet/Core/Helpers/FirebaseReportService.swift
+++ b/AlphaWallet/Core/Helpers/FirebaseReportService.swift
@@ -48,7 +48,7 @@ extension Crashlytics {
 
     func trackActiveWallet(wallet: Wallet) {
         guard Features.default.isAvailable(.isFirebaseEnabled) else { return }
-        
+
         let keysAndValues: [String: Any] = [
             ReportKey.activeWalletAddress.rawValue: wallet.description,
          ] as [String: Any]
@@ -72,7 +72,7 @@ extension Crashlytics {
                         if !isRunningTests() {
                             logStoreLargeNonFungible(address: address, server: server, fileSize: fileSizeInMb, source: each.source)
                         } else {
-                            debugLog("[Crashlytics] log large Nft asset json for address: \(address), server: \(server), fileSize: \(fileSizeInMb)MB, source: \(each.source.description)")
+                            infoLog("[Crashlytics] log large Nft asset json for address: \(address), server: \(server), fileSize: \(fileSizeInMb)MB, source: \(each.source.description)")
                         }
                     }
 

--- a/AlphaWallet/Core/TokensAutodetector/AutoDetectTransactedTokensOperation.swift
+++ b/AlphaWallet/Core/TokensAutodetector/AutoDetectTransactedTokensOperation.swift
@@ -52,7 +52,7 @@ final class AutoDetectTransactedTokensOperation: Operation {
             guard !strongSelf.isCancelled else { return }
             strongSelf.delegate?.didDetect(tokensOrContracts: values)
         }.catch { error in
-            verboseLog("Error while detecting tokens wallet: \(self.session.account.address.eip55String) error: \(error)")
+            warnLog("Error while detecting tokens wallet: \(self.session.account.address.eip55String) error: \(error)")
         }
     }
 }

--- a/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
+++ b/AlphaWallet/Core/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
@@ -44,7 +44,7 @@ class UnstoppableDomainsV2Resolver {
         return Just(name)
             .setFailureType(to: PromiseError.self)
             .flatMap { name -> AnyPublisher<AlphaWallet.Address, PromiseError> in
-                verboseLog("[UnstoppableDomains] resolving name: \(name)…")
+                infoLog("[UnstoppableDomains] resolving name: \(name)…")
                 return Alamofire
                     .request(url, method: .get, headers: ["Authorization": Constants.Credentials.unstoppableDomainsV2ApiKey])
                     .responseDataPublisher().tryMap { response -> AlphaWallet.Address in
@@ -54,7 +54,7 @@ class UnstoppableDomainsV2Resolver {
 
                         let value = try AddressResolution.Response(json: json)
                         if let owner = value.meta.owner {
-                            verboseLog("[UnstoppableDomains] resolved name: \(name) result: \(owner.eip55String)")
+                            infoLog("[UnstoppableDomains] resolved name: \(name) result: \(owner.eip55String)")
                             return owner
                         } else {
                             throw UnstoppableDomainsV2ApiError(localizedDescription: "Error calling \(baseURL) API isMainThread: \(Thread.isMainThread)")
@@ -83,7 +83,7 @@ class UnstoppableDomainsV2Resolver {
         return Just(address)
             .setFailureType(to: PromiseError.self)
             .flatMap { address -> AnyPublisher<String, PromiseError> in
-                verboseLog("[UnstoppableDomains] resolving address: \(address.eip55String)…")
+                infoLog("[UnstoppableDomains] resolving address: \(address.eip55String)…")
                 return Alamofire
                     .request(url, method: .get, headers: ["Authorization": Constants.Credentials.unstoppableDomainsV2ApiKey])
                     .responseDataPublisher().tryMap { response -> String in
@@ -93,7 +93,7 @@ class UnstoppableDomainsV2Resolver {
 
                         let value = try DomainResolution.Response(json: json)
                         if let record = value.data.first {
-                            verboseLog("[UnstoppableDomains] resolved address: \(address.eip55String) result: \(record.id)")
+                            infoLog("[UnstoppableDomains] resolved address: \(address.eip55String) result: \(record.id)")
                             return record.id
                         } else {
                             throw UnstoppableDomainsV2ApiError(localizedDescription: "Error calling \(baseURL) API isMainThread: \(Thread.isMainThread)")

--- a/AlphaWallet/EtherClient/Requests/GetTransactionRequest.swift
+++ b/AlphaWallet/EtherClient/Requests/GetTransactionRequest.swift
@@ -18,7 +18,7 @@ struct GetTransactionRequest: JSONRPCKit.Request {
 
     func response(from resultObject: Any) throws -> Response {
         if resultObject is NSNull {
-            debugLog("[RPC] Fetch transaction by hash: \(hash) is null")
+            infoLog("[RPC] Fetch transaction by hash: \(hash) is null")
             return nil
         }
         guard

--- a/AlphaWallet/Settings/Types/Constants+Credentials.swift
+++ b/AlphaWallet/Settings/Types/Constants+Credentials.swift
@@ -7,12 +7,12 @@ extension Constants {
 
         private static func readDevelopmentCredentialsFile() -> [String: String]? {
             guard let sourceRoot = ProcessInfo.processInfo.environment["SOURCE_ROOT"] else {
-                verboseLog("[Credentials] No .credentials file found for development")
+                debugLog("[Credentials] No .credentials file found for development")
                 return nil
             }
             let fileName = "\(sourceRoot)/.credentials"
             guard let fileContents = try? String(contentsOfFile: fileName) else {
-                verboseLog("[Credentials] No .credentials file found for development")
+                debugLog("[Credentials] No .credentials file found for development")
                 return nil
             }
             let lines = fileContents.components(separatedBy: .newlines)
@@ -25,7 +25,7 @@ extension Constants {
                 }
             }
             let dict = Dictionary(uniqueKeysWithValues: keyValues)
-            verboseLog("[Credentials] Loaded .credentials file found for development with key count: \(dict.count)")
+            debugLog("[Credentials] Loaded .credentials file found for development with key count: \(dict.count)")
             return dict
         }
 

--- a/AlphaWallet/TokenScriptClient/Coordinators/AssetDefinitionStoreCoordinator.swift
+++ b/AlphaWallet/TokenScriptClient/Coordinators/AssetDefinitionStoreCoordinator.swift
@@ -114,9 +114,9 @@ class AssetDefinitionStoreCoordinator: Coordinator {
     ///For development
     private func printInboxContents() {
         guard let contents = inboxContents else { return }
-        verboseLog("Contents of inbox:")
+        debugLog("Contents of inbox:")
         for each in contents {
-            verboseLog("  In inbox: \(each)")
+            debugLog("  In inbox: \(each)")
         }
     }
 

--- a/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/AlphaWallet/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -180,7 +180,7 @@ class AssetDefinitionStore: NSObject {
             self.fetchXML(forContract: contract, server: server, withUrl: url, useCacheAndFetch: useCacheAndFetch, completionHandler: completionHandler)
         }.catch { error in
             //no-op
-            debugLog("[TokenScript] unexpected error while fetching TokenScript file for contract: \(contract.eip55String) error: \(error)")
+            warnLog("[TokenScript] unexpected error while fetching TokenScript file for contract: \(contract.eip55String) error: \(error)")
         }
     }
 

--- a/AlphaWallet/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
+++ b/AlphaWallet/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
@@ -38,7 +38,7 @@ class TokenScriptSignatureVerifier {
     func verifyXMLSignatureViaAPI(xml: String, retryAttempt: Int = 0, completion: @escaping (VerifierResult) -> Void) {
         guard Features.default.isAvailable(.isTokenScriptSignatureStatusEnabled) else {
             //It is safe to return without calling `completion` here since we aren't supposed to be using the results with the feature flag above
-            infoLog("[TokenScript] Signature verification disabled")
+            verboseLog("[TokenScript] Signature verification disabled")
             //We call the completion handler so that if the caller is a `Promise`, it will resolve, in order to avoid the warning: "PromiseKit: warning: pending promise deallocated"
             completion(.success(domain: ""))
             return

--- a/AlphaWallet/Tokens/Helpers/CachedERC1155ContractDictionary.swift
+++ b/AlphaWallet/Tokens/Helpers/CachedERC1155ContractDictionary.swift
@@ -52,7 +52,7 @@ class CachedERC1155ContractDictionary {
             }
         } catch {
             // Do nothing
-            verboseLog("[CachedERC1155ContractDictionary] writeToFileUrl error: \(error)")
+            warnLog("[CachedERC1155ContractDictionary] writeToFileUrl error: \(error)")
         }
     }
 
@@ -63,9 +63,9 @@ class CachedERC1155ContractDictionary {
             let jsonData = try decoder.decode([AlphaWallet.Address: Bool].self, from: data)
             baseDictionary = jsonData
         } catch {
-            verboseLog("[CachedERC1155ContractDictionary] readFromFileUrl error: \(error)")
+            infoLog("[CachedERC1155ContractDictionary] readFromFileUrl error: \(error)")
             baseDictionary = [AlphaWallet.Address: Bool]()
         }
     }
-    
+
 }

--- a/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/AlphaWallet/Tokens/Helpers/CallSmartContractFunction.swift
@@ -161,7 +161,7 @@ func getEventLogs(
 
     return contractInstance.getIndexedEventsPromise(eventName: eventName, filter: filter)
         .recover { error -> Promise<[EventParserResultProtocol]> in
-            debugLog("[eth_getLogs] failure for server: \(server) with error: \(error)")
+            warnLog("[eth_getLogs] failure for server: \(server) with error: \(error)")
             return .init(error: error)
         }
 }

--- a/AlphaWallet/Tokens/Helpers/NonFungibleJsonBalanceFetcher.swift
+++ b/AlphaWallet/Tokens/Helpers/NonFungibleJsonBalanceFetcher.swift
@@ -73,7 +73,7 @@ class NonFungibleJsonBalanceFetcher {
         }.map(on: queue, { [tokensService] (data, _) -> NonFungibleBalanceAndItsSource in
             if let json = try? JSON(data: data) {
                 if let errorMessage = json["error"].string {
-                    verboseLog("Fetched token URI: \(originalUri.absoluteString) error: \(errorMessage)")
+                    warnLog("Fetched token URI: \(originalUri.absoluteString) error: \(errorMessage)")
                 }
                 if json["error"] == "Internal Server Error" {
                     throw Error()
@@ -105,11 +105,11 @@ class NonFungibleJsonBalanceFetcher {
                     }
                 }
             } else {
-                verboseLog("Fetched token URI: \(originalUri.absoluteString) failed")
+                warnLog("Fetched token URI: \(originalUri.absoluteString) failed")
                 throw Error()
             }
         }).recover { error -> Promise<NonFungibleBalanceAndItsSource> in
-            verboseLog("Fetching token URI: \(originalUri) error: \(error)")
+            warnLog("Fetching token URI: \(originalUri) error: \(error)")
             throw error
         }
     }

--- a/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
+++ b/AlphaWallet/Tokens/Logic/GetDASNameLookup.swift
@@ -31,14 +31,14 @@ public final class GetDASNameLookup {
 
     func resolve(rpcURL: URL, rpcHeaders: [String: String], value: String) -> Promise<AlphaWallet.Address> {
         guard GetDASNameLookup.isValid(value: value) else {
-            debugLog("[DAS] Invalid lookup: \(value)")
+            infoLog("[DAS] Invalid lookup: \(value)")
             return .init(error: DASNameLookupError.invalidInput)
         }
 
         let request = EtherServiceRequest(rpcURL: rpcURL, rpcHeaders: rpcHeaders, batch: BatchFactory().create(DASLookupRequest(value: value)))
-        debugLog("[DAS] Looking up value \(value)")
+        infoLog("[DAS] Looking up value \(value)…")
         return Session.send(request, server: server, analytics: analytics).map { response -> AlphaWallet.Address in
-            debugLog("[DAS] response for value: \(value) response : \(response)")
+            infoLog("[DAS] response for value: \(value) response : \(response)")
             if let record = response.records.first(where: { $0.key == GetDASNameLookup.ethAddressKey }), let address = AlphaWallet.Address(string: record.value) {
                 infoLog("[DAS] resolve value: \(value) to address: \(address)")
                 return address

--- a/AlphaWallet/Transactions/EtherscanSingleChainTransactionProvider.swift
+++ b/AlphaWallet/Transactions/EtherscanSingleChainTransactionProvider.swift
@@ -377,5 +377,5 @@ func error(value e: Error, pref: String = "", function f: String = #function, rp
     description += rpcServer.flatMap { " server: \($0)" } ?? ""
     description += address.flatMap { " address: \($0.eip55String)" } ?? ""
     description += " \(e)"
-    errorLog(description, callerFunctionName: f)
+    warnLog(description, callerFunctionName: f)
 }

--- a/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
+++ b/AlphaWallet/Transactions/Storage/TransactionsStorage.swift
@@ -306,7 +306,7 @@ class TransactionDataStore {
             try data.write(to: url)
             verboseLog("Written transactions for \(server) to JSON to: \(url.absoluteString)")
         } catch {
-            verboseLog("Error writing transactions for \(server) to JSON: \(url.absoluteString) error: \(error)")
+            warnLog("Error writing transactions for \(server) to JSON: \(url.absoluteString) error: \(error)")
         }
     }
 }

--- a/AlphaWallet/UI/SvgImageView.swift
+++ b/AlphaWallet/UI/SvgImageView.swift
@@ -23,7 +23,7 @@ final class SvgImageView: WKWebView {
     private (set) var pageHasLoaded: Bool = false
     var rounding: ViewRounding = .none
 
-    init() { 
+    init() {
         //NOTE: set initial frame to avoid `[ViewportSizing] maximumViewportInset cannot be larger than frame`
         super.init(frame: .init(x: 0, y: 0, width: 40, height: 40), configuration: svgImageViewSharedConfiguration)
 
@@ -60,7 +60,7 @@ final class SvgImageView: WKWebView {
 
                     try? ImageCache.default.diskStorage.store(value: data, forKey: url.absoluteString)
                 } else {
-                    debugLog("[SvgImageView] suppose to a svg image, but failure")
+                    warnLog("[SvgImageView] suppose to a svg image, but failure")
                 }
             }
         }

--- a/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Provider.swift
+++ b/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Provider.swift
@@ -69,7 +69,7 @@ class WalletConnectV1Provider: WalletConnectServer {
     }
 
     deinit {
-        debugLog("[WalletConnect] WalletConnectV1Provider.deinit")
+        verboseLog("[WalletConnect] WalletConnectV1Provider.deinit")
         server.unregister(handler: requestHandler)
     }
 
@@ -164,7 +164,7 @@ class WalletConnectV1Provider: WalletConnectServer {
 extension WalletConnectV1Provider: WalletConnectV1ServerRequestHandlerDelegate {
 
     func handler(_ handler: RequestHandlerToAvoidMemoryLeak, request: WalletConnectV1Request) {
-        debugLog("WalletConnect handler request: \(request.method) url: \(request.url.absoluteString)")
+        infoLog("WalletConnect handler request: \(request.method) url: \(request.url.absoluteString)")
 
         queue.async { [weak self] in
             guard let strongSelf = self else { return }
@@ -187,7 +187,7 @@ extension WalletConnectV1Provider: WalletConnectV1ServerRequestHandlerDelegate {
     }
 
     func handler(_ handler: RequestHandlerToAvoidMemoryLeak, canHandle request: WalletConnectV1Request) -> Bool {
-        debugLog("WalletConnect canHandle: \(request.method) url: \(request.url.absoluteString)")
+        infoLog("WalletConnect canHandle: \(request.method) url: \(request.url.absoluteString)")
         return true
     }
 }
@@ -199,7 +199,7 @@ extension WalletConnectV1Provider: ServerDelegate {
     }
 
     func server(_ server: Server, didFailToConnect url: WalletConnectV1URL) {
-        debugLog("WalletConnect didFailToConnect: \(url)")
+        infoLog("WalletConnect didFailToConnect: \(url)")
         queue.async {
             self.connectionTimeoutTimers[url] = nil
             self.removeSession(for: url)
@@ -263,14 +263,14 @@ extension WalletConnectV1Provider: ServerDelegate {
     }
 
     func server(_ server: Server, didUpdate session: Session) {
-        debugLog("WalletConnect didUpdate: \(session.url.absoluteString)")
+        infoLog("WalletConnect didUpdate: \(session.url.absoluteString)")
         queue.async {
             self.addOrUpdateSession(session: session)
         }
     }
 
     func server(_ server: Server, didConnect session: Session) {
-        debugLog("WalletConnect didConnect: \(session.url.absoluteString)")
+        infoLog("WalletConnect didConnect: \(session.url.absoluteString)")
         queue.async {
             let nativeSession: WalletConnectV1Session = self.addOrUpdateSession(session: session)
             if let delegate = self.delegate {

--- a/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Provider.swift
+++ b/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Provider.swift
@@ -86,7 +86,7 @@ class WalletConnectV2Provider: WalletConnectServer {
 
     func connect(url: AlphaWallet.WalletConnect.ConnectionUrl) throws {
         guard case .v2(let uri) = url else { return }
-        debugLog("[RESPONDER] Pairing to: \(uri.absoluteString)")
+        infoLog("[RESPONDER] Pairing to: \(uri.absoluteString)")
         Task { try await client.pair(uri: uri.absoluteString) }
     }
 
@@ -161,14 +161,14 @@ class WalletConnectV2Provider: WalletConnectServer {
     }
 
     private func reject(request: WalletConnectSign.Request, error: AlphaWallet.WalletConnect.ResponseError) {
-        debugLog("[RESPONDER] WC: Did reject session proposal: \(request) with error: \(error.message)")
+        infoLog("[RESPONDER] WC: Did reject session proposal: \(request) with error: \(error.message)")
 
         let response = JSONRPCErrorResponse(id: request.id, error: .init(code: error.code, message: error.message))
         client.respond(topic: request.topic, response: .error(response))
     }
 
     private func didReceive(request: WalletConnectSign.Request) {
-        debugLog("[RESPONDER] WC: Did receive session request")
+        infoLog("[RESPONDER] WC: Did receive session request")
 
         //NOTE: guard check to avoid passing unacceptable rpc server,(when requested server is disabled)
         //FIXME: update with ability ask user for enabled disaled server
@@ -198,29 +198,29 @@ class WalletConnectV2Provider: WalletConnectServer {
     }
 
     private func didDelete(topic: String, reason: WalletConnectSign.Reason) {
-        debugLog("[RESPONDER] WC: Did receive session delete")
+        infoLog("[RESPONDER] WC: Did receive session delete")
         storage.remove(for: .topic(string: topic))
     }
 
     private func didUpgrade(topic: String, namespaces: [String: SessionNamespace]) {
-        debugLog("[RESPONDER] WC: Did receive session upgrate")
+        infoLog("[RESPONDER] WC: Did receive session upgrate")
 
         _ = try? storage.update(.topic(string: topic), namespaces: namespaces)
     }
 
     private func didSettle(session: WalletConnectSign.Session) {
 
-        debugLog("[RESPONDER] WC: Did settle session")
+        infoLog("[RESPONDER] WC: Did settle session")
         for each in client.getSessions() {
             storage.addOrUpdate(session: each)
         }
     }
 
     private func _didReceive(proposal: WalletConnectSign.Session.Proposal, completion: @escaping () -> Void) {
-        debugLog("[RESPONDER] WC: Did receive session proposal")
+        infoLog("[RESPONDER] WC: Did receive session proposal")
 
         func reject(proposal: WalletConnectSign.Session.Proposal) {
-            debugLog("[RESPONDER] WC: Did reject session proposal: \(proposal)")
+            infoLog("[RESPONDER] WC: Did reject session proposal: \(proposal)")
             client.reject(proposal: proposal, reason: .disapprovedChains)
             completion()
         }

--- a/AlphaWallet/WalletConnect/Types/WalletConnectRequestConverter.swift
+++ b/AlphaWallet/WalletConnect/Types/WalletConnectRequestConverter.swift
@@ -15,11 +15,11 @@ struct WalletConnectRequestConverter {
         guard let rpcServer: RPCServer = request.server else {
             return .init(error: WalletConnectRequestConverter.sessionRequestRPCServerMissing)
         }
-        debugLog("WalletConnect convert request: \(request.method) url: \(request.description)")
+        infoLog("WalletConnect convert request: \(request.method) url: \(request.description)")
 
         let token = MultipleChainsTokensDataStore.functional.token(forServer: rpcServer)
         let data: AlphaWallet.WalletConnect.Request
-        do { 
+        do {
             data = try AlphaWallet.WalletConnect.Request(request: request)
         } catch let error {
             return .init(error: error)
@@ -109,6 +109,6 @@ extension AlphaWallet.WalletConnect.Request {
                 }
                 return try values[position].decode(to: type)
             }
-        } 
+        }
     }
 }

--- a/AlphaWalletTests/Redeem/CreateRedeemTests.swift
+++ b/AlphaWalletTests/Redeem/CreateRedeemTests.swift
@@ -21,11 +21,11 @@ class CreateRedeemTests: XCTestCase {
         do {
             let signature = try keyStore.signMessageData(data!, for: account.dematerialize().address)
             //message and signature is to go in qr code
-            debugLog("message: " + message)
-            debugLog(try "signature: " + signature.dematerialize().hexString)
+            verboseLog("message: " + message)
+            verboseLog(try "signature: " + signature.dematerialize().hexString)
             //TODO no test?
         } catch {
-            debugLog(error)
+            warnLog(error)
         }
     }
 }


### PR DESCRIPTION
Tweaked our logging so:

* verboseLog() — like debug, but not want to show it by default (since we configure our loggers to `.debug`) because it's too verbose/noisy. This includes logging in `deinit{}` and things that happen too frequently, yet not useful (eg. skipping TokenScript signature verification)
* debugLog() — like info, but more for debugging purposes. This is our default logging level for console, so must not be so excessive that the console is unreadable
* infoLog() — should be the most common. Refreshes, etc. This is our default logging level for log files (currently unused, but we'll let user attach them to support emails in the future)
* warnLog() - unexpected errors that are unhandled, mostly. So we can look out for these and fix/handle them
* errorLog() — not used

cc @eviltofu 