### PR TITLE
Fix: Bool args in confirmation actionsheet should show up as "true" or "false", not "1"

### DIFF
--- a/AlphaWallet/Core/DecodedFunctionCall.swift
+++ b/AlphaWallet/Core/DecodedFunctionCall.swift
@@ -30,6 +30,9 @@ struct FunctionCall {
         private func toString(_ value: Any?) -> String {
             if let value = value as? AlphaWallet.Address {
                 return value.eip55String
+            //We special-case Bool otherwise it will be printed as "1" below
+            } else if type == .bool, let value = value as? Bool {
+                return value.description
             } else if let value = value as? CustomStringConvertible {
                 return value.description
             } else {

--- a/AlphaWalletTests/Core/Types/FunctionCallArgumentTests.swift
+++ b/AlphaWalletTests/Core/Types/FunctionCallArgumentTests.swift
@@ -27,6 +27,16 @@ class FunctionCallArgumentTests: XCTestCase {
         XCTAssertEqual(value.description, "1")
     }
 
+    func testBoolValue() throws {
+        let dataTrue = true as AnyObject
+        let valueTrue = FunctionCall.Argument(type: .bool, anyValue: dataTrue)
+        XCTAssertEqual(valueTrue.description, "true")
+
+        let dataFalse = false as AnyObject
+        let valueFalse = FunctionCall.Argument(type: .bool, anyValue: dataFalse)
+        XCTAssertEqual(valueFalse.description, "false")
+    }
+
     func testArrayValue() throws {
         let data = [
             BigUInt("0") as AnyObject,


### PR DESCRIPTION
(bottom of screenshots)

Before PR|After PR
-|-
<img width="200" alt="Screenshot 2022-08-25 at 1 19 03 PM" src="https://user-images.githubusercontent.com/56189/186595570-9277e2ee-f547-4e2e-a350-10e8f5d14913.png">|<img width="200" alt="Screenshot 2022-08-25 at 2 44 08 PM" src="https://user-images.githubusercontent.com/56189/186595596-fdc29b20-289c-4f43-94e2-e1df790cf74a.png">