### PR TITLE
Fix: Gnosis' native token xDai shows wrong fiat rate

### DIFF
--- a/AlphaWallet/Core/CoinTicker/CoinTickersStorage.swift
+++ b/AlphaWallet/Core/CoinTicker/CoinTickersStorage.swift
@@ -47,6 +47,7 @@ class CoinTickersFileStorage: NSObject {
         knownTickersIdsStore = .init(fileName: "knownTickersIds", storage: storage, defaultValue: [:])
         super.init()
         CoinTickersFileStorage.migrateTickerIdsFrom_v1To_v2(config: config, storage: self)
+        CoinTickersFileStorage.fixGnosisXdaiNativeTokenTicker(config: config, tickersStore: tickersStore)
     }
 
 }
@@ -59,6 +60,16 @@ extension CoinTickersFileStorage {
         config.tickerIdsHasMigratedTo_v2 = true
         config.tickerIdsLastFetchedDate = nil
         storage.removeTickerIds()
+    }
+
+    //TODO remove after sometime once users no longer have this problem
+    static func fixGnosisXdaiNativeTokenTicker(config: Config, tickersStore: Storage<[AssignedCoinTickerId: CoinTicker]>) {
+        //Fix older code
+        if tickersStore.value.contains(where: { k, v in k == "gnosis" && v.symbol == "gno" }) {
+            tickersStore.removeAll()
+        } else {
+            //no-op
+        }
     }
 }
 
@@ -102,7 +113,7 @@ extension CoinTickersFileStorage: ChartHistoryStorage {
 
     func chartHistory(period: ChartHistoryPeriod, for tickerId: AssignedCoinTickerId) -> MappedChartHistory? {
         return historyStore.value[tickerId]?[period]
-    } 
+    }
 }
 
 extension CoinTickersFileStorage: TickerIdsStorage {

--- a/AlphaWallet/Core/CoinTicker/Types/TokenMappedToTicker.swift
+++ b/AlphaWallet/Core/CoinTicker/Types/TokenMappedToTicker.swift
@@ -27,7 +27,7 @@ struct TokenMappedToTicker {
         } else if server == .klaytnCypress && contractAddress == Constants.nativeCryptoAddressInDatabase {
             return "klay-token"
         } else if server == .xDai && contractAddress == Constants.nativeCryptoAddressInDatabase {
-            return "gnosis"
+            return "xdai"
         } else if server == .arbitrum && contractAddress == Constants.nativeCryptoAddressInDatabase {
             return "ethereum"
         } else {
@@ -49,7 +49,7 @@ extension TokenMappedToTicker: Hashable, Codable {
         contractAddress = token.contractAddress
         server = token.server
         coinGeckoId = token.info.coinGeckoId
-    } 
+    }
 }
 
 extension TokenMappedToTicker: Equatable {

--- a/AlphaWallet/Core/Types/NativecryptoBalanceViewModel.swift
+++ b/AlphaWallet/Core/Types/NativecryptoBalanceViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import BigInt 
+import BigInt
 
 struct NativecryptoBalanceViewModel: BalanceViewModelType {
     var ticker: CoinTicker?
@@ -42,12 +42,10 @@ struct NativecryptoBalanceViewModel: BalanceViewModelType {
 
     private func cryptoRate(forServer server: RPCServer) -> Rate? {
         guard let rate = ticker?.rate else { return nil }
-        
+
         let code = mapSymbolToCodeInRates(server)
         let symbol = server.symbol.lowercased()
         if let value = rate.rates.first(where: { $0.code == code }) {
-            return value
-        } else if let value = rate.rates.first(where: { $0.code == "gno" }), server == .xDai {
             return value
         } else if let value = rate.rates.first(where: { $0.code == symbol }) {
             return value


### PR DESCRIPTION
Fixes #5237

It was using GNO token's price

Before PR (way more than $1/token)|After PR (~$1/token)
-|-
<img width="200" alt="Screenshot 2022-08-31 at 2 58 24 PM" src="https://user-images.githubusercontent.com/56189/187616225-b94ca61e-c758-4cdb-ac71-9d629b5ec716.png">|<img width="200" alt="Screenshot 2022-08-31 at 2 59 27 PM" src="https://user-images.githubusercontent.com/56189/187616217-003575e1-d7fc-4fcf-8af5-7f5815f517f6.png">

This PR includes a fix for users with the old price so the first time the user runs this it will go through this states:

old price|no price|correct price
-|-|-
<img width="200" alt="Screenshot 2022-08-31 at 3 01 03 PM" src="https://user-images.githubusercontent.com/56189/187616187-e685c96a-c16b-48cb-91b1-ad183c7a87de.png">|<img width="200" alt="Screenshot 2022-08-31 at 2 59 27 PM" src="https://user-images.githubusercontent.com/56189/187616217-003575e1-d7fc-4fcf-8af5-7f5815f517f6.png">|<img width="200" alt="Screenshot 2022-08-31 at 2 58 24 PM" src="https://user-images.githubusercontent.com/56189/187616225-b94ca61e-c758-4cdb-ac71-9d629b5ec716.png">

(Ignore the swap button in screenshots, forgot to switch it off)
