### PR TITLE
Fix error message with Klaytn KAS RPC node for eth_call: "err: insufficient balance of the fee payer to pay for gas (supplied gas 9223372036854775807) 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ target 'AlphaWallet' do
   pod 'TrezorCrypto', :git=>'https://github.com/AlphaWallet/trezor-crypto-ios.git', :commit => '50c16ba5527e269bbc838e80aee5bac0fe304cc7'
   pod 'TrustKeystore', :git => 'https://github.com/AlphaWallet/latest-keystore-snapshot', :commit => 'c0bdc4f6ffc117b103e19d17b83109d4f5a0e764'
   pod 'SwiftyJSON', '5.0.0'
-  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> 'add8d92ccda367c01d75dbec017eb9bf8619ba0e'
+  pod 'web3swift', :git => 'https://github.com/AlphaWallet/web3swift.git', :commit=> '6d7c01af26bcb75d8a02b6709b089e02ed99af98'
   pod 'SAMKeychain'
   pod 'PromiseKit/CorePromise'
   pod 'PromiseKit/Alamofire'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -200,7 +200,7 @@ DEPENDENCIES:
   - TrustKeystore (from `https://github.com/AlphaWallet/latest-keystore-snapshot`, commit `c0bdc4f6ffc117b103e19d17b83109d4f5a0e764`)
   - TrustWalletCore (= 2.6.34)
   - WalletConnectSwift (from `https://github.com/AlphaWallet/WalletConnectSwift.git`, commit `b6556058331f619e15482b82d7c6ab57d9711399`)
-  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `add8d92ccda367c01d75dbec017eb9bf8619ba0e`)
+  - web3swift (from `https://github.com/AlphaWallet/web3swift.git`, commit `6d7c01af26bcb75d8a02b6709b089e02ed99af98`)
   - xcbeautify
 
 SPEC REPOS:
@@ -282,7 +282,7 @@ EXTERNAL SOURCES:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: add8d92ccda367c01d75dbec017eb9bf8619ba0e
+    :commit: 6d7c01af26bcb75d8a02b6709b089e02ed99af98
     :git: https://github.com/AlphaWallet/web3swift.git
 
 CHECKOUT OPTIONS:
@@ -311,7 +311,7 @@ CHECKOUT OPTIONS:
     :commit: b6556058331f619e15482b82d7c6ab57d9711399
     :git: https://github.com/AlphaWallet/WalletConnectSwift.git
   web3swift:
-    :commit: add8d92ccda367c01d75dbec017eb9bf8619ba0e
+    :commit: 6d7c01af26bcb75d8a02b6709b089e02ed99af98
     :git: https://github.com/AlphaWallet/web3swift.git
 
 SPEC CHECKSUMS:
@@ -369,6 +369,6 @@ SPEC CHECKSUMS:
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: a34befb5061fb57077153f0ea80d7aa3125b8ad5
+PODFILE CHECKSUM: 1e631b96c01ba92ec16e5a70ab1469480bfa9585
 
 COCOAPODS: 1.11.2

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Settings/Types/RPCServers.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Settings/Types/RPCServers.swift
@@ -867,6 +867,15 @@ public enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    var shouldExcludeZeroGasPrice: Bool {
+        switch self {
+        case .klaytnCypress, .klaytnBaobabTestnet:
+            return true
+        case .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .optimistic, .polygon, .mumbai_testnet, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .main, .kovan, .ropsten, .rinkeby, .poa, .classic, .callisto, .phi, .goerli, .artis_sigma1, .artis_tau1, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .optimisticKovan, .sokol, .custom, .palm, .palmTestnet, .ioTeX, .ioTeXTestnet, .xDai:
+            return false
+        }
+    }
+
     private var rpcNodeBatchSupport: RpcNodeBatchSupport {
         switch self {
         case .klaytnCypress, .klaytnBaobabTestnet:

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Tokens/Helpers/CallSmartContractFunction.swift
@@ -94,10 +94,12 @@ public func callSmartContract(withServer server: RPCServer, contract: AlphaWalle
                 seal.reject(Web3Error(description: "Error calling \(contract.eip55String).\(functionName)() with parameters: \(parameters)"))
                 return
             }
+            var web3Options = Web3Options()
+            web3Options.excludeZeroGasPrice = server.shouldExcludeZeroGasPrice
 
             //callPromise() creates a promise. It doesn't "call" a promise. Bad name
             firstly {
-                promiseCreator.callPromise(options: nil)
+                promiseCreator.callPromise(options: web3Options)
             }.done(on: queue ?? .main, { d in
                 seal.fulfill(d)
             }).catch(on: queue ?? .main, { e in


### PR DESCRIPTION
Fixes #5261

The fix is special cased to Klaytn nodes because we don't know if other RPC nodes rely on gasPrice: 0x0 being around…