### PR TITLE
Hide and disable Coinbase Pay behind a feature flag

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Features/Features.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Features/Features.swift
@@ -99,6 +99,7 @@ public enum FeaturesAvailable: String, CaseIterable, Codable {
     case isTokenScriptSignatureStatusEnabled
     case isFirebaseEnabled
     case isSwapEnabled
+    case isCoinbasePayEnabled
 
     public var defaultValue: Bool {
         switch self {
@@ -149,6 +150,8 @@ public enum FeaturesAvailable: String, CaseIterable, Codable {
         case .isFirebaseEnabled:
             return true
         case .isSwapEnabled:
+            return false
+        case .isCoinbasePayEnabled:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Settings/Types/Constants.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Settings/Types/Constants.swift
@@ -106,6 +106,7 @@ public struct Constants {
     }
 
     public static func buyWithCoinBaseUrl(blockchain: String, wallet: Wallet) -> String? {
+        guard Features.default.isAvailable(.isCoinbasePayEnabled) else { return nil }
         let key = Constants.Credentials.coinBaseAppId
         guard !key.isEmpty else { return nil }
         let base = "https://pay.coinbase.com/buy/select-asset?appId=\(key)"


### PR DESCRIPTION
Since it doesn't seem to work correctly at the moment — might not be due to our integration.