### PR TITLE
Support Carthage DEX for swapping Candle

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -121,6 +121,7 @@ class AppCoordinator: NSObject, Coordinator {
             honeySwapService,
             quickSwap,
             Oneinch(action: R.string.localizable.aWalletTokenErc20ExchangeOn1inchButtonTitle()),
+            Carthage(action: R.string.localizable.aWalletTokenErc20ExchangeCarthageButtonTitle()),
             //uniswap
         ]
         availableSwapProviders += Features.default.isAvailable(.isSwapEnabled) ? [SwapTokenNativeProvider(tokenSwapper: tokenSwapper)] : []

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Convert to DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Convert to Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Buy xDai";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Convert to DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Convert to Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Buy xDai";

--- a/AlphaWallet/Localization/fi.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/fi.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Muunna valuutaksi DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Muunna valuutaksi Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Osta xDai";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Convert to DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Convert to Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Buy xDai";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Convert to DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Convert to Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Buy xDai";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -561,6 +561,7 @@
 "a.wallet.token.erc20ExchangeOnQuickSwap.button.title" = "Swap using QuickSwap";
 "a.wallet.token.erc20ExchangeOn1inch.button.title" = "Swap using 1inch";
 "a.wallet.token.erc20ExchangeHoneyswap.button.title" = "Swap using Honeyswap";
+"a.wallet.token.erc20ExchangeCarthage.button.title" = "Swap using Carthage";
 "a.wallet.token.xDaiBridge.button.title" = "Convert to DAI";
 "a.wallet.token.arbitrumBridge.button.title" = "Convert to Arbitrum";
 "a.wallet.token.buy.xDai.title" = "Buy xDai";

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Analytics/Models/AnalyticsTypes.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Analytics/Models/AnalyticsTypes.swift
@@ -34,6 +34,7 @@ public enum Analytics {
         case onxDaiBridge = "Screen: xDai Bridge"
         case onHoneyswap = "Screen: Honeyswap"
         case onOneinch = "Screen: Oneinch"
+        case onCarthage = "Screen: Carthage"
         case onArbitrumBridge = "Screen: Arbitrum Bridge"
         case onQuickSwap = "Screen: QuickSwap"
         case fallback = "Screen: <Fallback>"

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/SwapToken/Carthage/Carthage.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/SwapToken/Carthage/Carthage.swift
@@ -1,0 +1,57 @@
+//
+//  Carthage.swift
+//  AlphaWalletFoundation
+//
+//  Created by Jeffrey Sun on 9/3/22.
+//
+
+import Foundation
+import Combine
+
+public class Carthage: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
+    public var objectWillChange: AnyPublisher<Void, Never> {
+        objectWillChangeSubject.eraseToAnyPublisher()
+    }
+    private var objectWillChangeSubject = PassthroughSubject<Void, Never>()
+
+    public let action: String
+    private var supportedServers: [RPCServer] {
+        return [.candle]
+    }
+
+    public func rpcServer(forToken token: TokenActionsIdentifiable) -> RPCServer? {
+        if supportedServers.contains(where: { $0 == token.server }) {
+            return token.server
+        } else {
+            return .main
+        }
+    }
+    public let analyticsNavigation: Analytics.Navigation = .onCarthage
+    public let analyticsName: String = "Carthage"
+
+    public func url(token: TokenActionsIdentifiable) -> URL? {
+        return URL(string: "https://app.carthagedex.com/#/swap?chain=candle")
+    }
+
+    public func actions(token: TokenActionsIdentifiable) -> [TokenInstanceAction] {
+        return [
+            .init(type: .swap(service: self))
+        ]
+    }
+
+    public func isSupport(token: TokenActionsIdentifiable) -> Bool {
+        switch token.server {
+        case .candle:
+            return true
+        case .main, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .arbitrum, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .palm, .palmTestnet, .arbitrumRinkeby, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+            return false
+        }
+    }
+
+    public init(action: String) {
+        self.action = action
+    }
+
+    public func start() {
+    }
+}


### PR DESCRIPTION
1-liner summary: Allows the user to swap Candle (CNDL) by opening the Carthage DEX link. 

![carthage](https://user-images.githubusercontent.com/3321825/188541572-cddf3899-2529-4502-aa1c-f1c80941a9da.png)


Anything particular to test:

I've tested choosing to swap CNDL to open the Carthage DEX. 