### PR TITLE
Stop matching ticker id by ignoring platform

### DIFF
--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -193,6 +193,12 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     func start() {
+        if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
+            Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
+                infoLog("Ticker ID positive matching counts: \(TickerIdFilter.matchCounts)")
+            }
+        }
+
         protectionCoordinator.didFinishLaunchingWithOptions()
         initializers()
         runServices()

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/CoinTicker/Types/TickerIdFilter.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/CoinTicker/Types/TickerIdFilter.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 public class TickerIdFilter {
+    //TODO remove if we don't use it for debugging anymore
+    //Used during development to observe how often positive matching happens when platforms don't match, to see how many potential false positives get. Eg. https://candleexplorer.com/address/0x6Ee592139e9DD84587a32831A33a32202d1f0F12 would match USDC with price = $1 because name = "USDC" and symbol = "USDC", but anyone can create such a token on any chain
+    public static var matchCounts: [String: Int] = [:]
 
     //https://polygonscan.com/address/0x0000000000000000000000000000000000001010
     static private let polygonMaticContract = AlphaWallet.Address(string: "0x0000000000000000000000000000000000001010")!
@@ -15,10 +18,19 @@ public class TickerIdFilter {
     func tickerId(for token: TokenMappedToTicker, in tickerIds: [TickerId]) -> TickerIdString? {
         return tickerIds.first(where: { filterMathesInPlatforms(token: token, tickerId: $0) }).flatMap { $0.id }
     }
-    
+
     private func filterMathesInPlatforms(token: TokenMappedToTicker, tickerId: TickerId) -> Bool {
         func isMatchingSymbolAndName(token: TokenMappedToTicker, tickerId: TickerId) -> Bool {
-            tickerId.symbol.localizedLowercase == token.symbol.localizedLowercase && tickerId.name.localizedLowercase == token.name.localizedLowercase
+            let result = tickerId.symbol.localizedLowercase == token.symbol.localizedLowercase && tickerId.name.localizedLowercase == token.name.localizedLowercase
+            if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) && result {
+                Self.matchCounts["by symbol+name, ignoring platform", default: 0] += 1
+            }
+            //Logging enabled has a side effect. This matching regardless of platform will be applied. Otherwise the counts logged will be incorrect
+            if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) && result {
+                return result
+            } else {
+                return result
+            }
         }
 
         //We just filter out those that we don't think are supported by the API. One problem this helps to alleviate is in the API output, certain tickers have a non-empty platform yet the platform list might not be complete, eg. Ether on Ethereum mainnet:
@@ -36,10 +48,20 @@ public class TickerIdFilter {
 
         if let contract = tickerId.platforms.first(where: { $0.server == token.server }) {
             if contract.address.sameContract(as: Constants.nullAddress) {
-                return tickerId.symbol.localizedLowercase == token.symbol.localizedLowercase
+                let result = tickerId.symbol.localizedLowercase == token.symbol.localizedLowercase
+                if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) && result {
+                    Self.matchCounts["by platform+symbol for 0x0", default: 0] += 1
+                }
+                return result
             } else if contract.address.sameContract(as: token.contractAddress) {
+                if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
+                    Self.matchCounts["by platform+contract", default: 0] += 1
+                }
                 return true
             } else if token.server == .polygon && token.contractAddress == Constants.nativeCryptoAddressInDatabase && contract.address.sameContract(as: Self.polygonMaticContract) {
+                if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
+                    Self.matchCounts["by platform + Polygon 0x0 = Matic contract", default: 0] += 1
+                }
                 return true
             } else {
                 return false

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/CoinTicker/Types/TickerIdFilter.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/CoinTicker/Types/TickerIdFilter.swift
@@ -29,7 +29,8 @@ public class TickerIdFilter {
             if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) && result {
                 return result
             } else {
-                return result
+                //Force is so we no longer match by ignoring the platform, this produces false positives. Eg. https://candleexplorer.com/address/0x6Ee592139e9DD84587a32831A33a32202d1f0F12 would match USDC with price = $1 because name = "USDC" and symbol = "USDC", but anyone can create such a token on any chain
+                return false
             }
         }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Features/Features.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Core/Features/Features.swift
@@ -100,6 +100,7 @@ public enum FeaturesAvailable: String, CaseIterable, Codable {
     case isFirebaseEnabled
     case isSwapEnabled
     case isCoinbasePayEnabled
+    case isLoggingEnabledForTickerMatches
 
     public var defaultValue: Bool {
         switch self {
@@ -152,6 +153,8 @@ public enum FeaturesAvailable: String, CaseIterable, Codable {
         case .isSwapEnabled:
             return false
         case .isCoinbasePayEnabled:
+            return false
+        case .isLoggingEnabledForTickerMatches:
             return false
         }
     }


### PR DESCRIPTION
Includes some logging so we can come back and revisit it by setting `Features.isLoggingEnabledForTickerMatches`