### PR TITLE
Fix: Cryptokitties token title wrong in wallet tab

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		5E7C7F808D0B0B19ECEA6623 /* ETH.tsml in Resources */ = {isa = PBXBuildFile; fileRef = 5E7C768D3C3F400E0B88B575 /* ETH.tsml */; };
 		5E7C7F8271F730462D4E3D93 /* FakeBlockiesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C737AF4E3BED49DD63CF4 /* FakeBlockiesGenerator.swift */; };
 		5E7C7F906FE07C75F357569B /* DAI.tsml in Resources */ = {isa = PBXBuildFile; fileRef = 5E7C75D9C3EA9FF978ECF8E5 /* DAI.tsml */; };
+		5E7C7FA36B12D00E131398CF /* TokenScriptOverrides+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74CB1950B1EC558685A4 /* TokenScriptOverrides+Extensions.swift */; };
 		5E7C7FC0770A411DB09F8C09 /* FungibleTokenViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C077372C3F2A4349FA1 /* FungibleTokenViewCell.swift */; };
 		5E7C7FC3D8846843465B0F90 /* ServersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78EFAF641C41F06C46BF /* ServersCoordinatorTests.swift */; };
 		5E7C7FC76A025AD91D57B960 /* HistoriesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C715BBA7416942FDA8516 /* HistoriesViewModel.swift */; };
@@ -1066,6 +1067,7 @@
 		5E7C74BE9900543A755CB76A /* DappsAutoCompletionCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsAutoCompletionCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C74BEC095303B66FB4B1E /* ProtectionCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtectionCoordinator.swift; sourceTree = "<group>"; };
 		5E7C74C0C1803DD17FE9EBA7 /* ServersViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServersViewController.swift; sourceTree = "<group>"; };
+		5E7C74CB1950B1EC558685A4 /* TokenScriptOverrides+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TokenScriptOverrides+Extensions.swift"; sourceTree = "<group>"; };
 		5E7C74D2C599646C65B95E2F /* DappsAutoCompletionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DappsAutoCompletionCell.swift; sourceTree = "<group>"; };
 		5E7C74DCC21272EC231A20E2 /* RequestViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestViewController.swift; sourceTree = "<group>"; };
 		5E7C75273010A92461EE5CD7 /* SendTransactionErrorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTransactionErrorViewController.swift; sourceTree = "<group>"; };
@@ -1990,6 +1992,7 @@
 				2977CAF21F7E0C3A009682A0 /* ViewModels */,
 				2977CAF11F7E0C33009682A0 /* ViewControllers */,
 				2977CAF01F7E0C2E009682A0 /* Views */,
+				5E7C74CB1950B1EC558685A4 /* TokenScriptOverrides+Extensions.swift */,
 			);
 			path = Tokens;
 			sourceTree = "<group>";
@@ -5239,6 +5242,7 @@
 				5E7C76AFBBACDD13BEF25DA9 /* ToolsViewModel.swift in Sources */,
 				5E7C78621C94C8AC509067AC /* ActiveWalletSessionView.swift in Sources */,
 				872A987328645F1D00196EA3 /* SendFungiblesTransactionViewModel.swift in Sources */,
+				5E7C7FA36B12D00E131398CF /* TokenScriptOverrides+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Tokens/TokenScriptOverrides+Extensions.swift
+++ b/AlphaWallet/Tokens/TokenScriptOverrides+Extensions.swift
@@ -1,0 +1,17 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+import AlphaWalletFoundation
+
+extension TokenScriptOverrides {
+    //TODO: Not good to require to use safeTitleInPluralForm. Easy to access wrong var
+    ///Use this instead of shortTitleInPluralForm directly
+    var safeShortTitleInPluralForm: String? {
+        let s = shortTitleInPluralForm
+        if s == Constants.katNameFallback {
+            return R.string.localizable.katTitlecase()
+        } else {
+            return s
+        }
+    }
+}

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -7,9 +7,9 @@ import AlphaWalletFoundation
 
 struct EthTokenViewCellViewModel {
     private let token: TokenViewModel
-    private let isVisible: Bool 
+    private let isVisible: Bool
     let accessoryType: UITableViewCell.AccessoryType
-    
+
     init(token: TokenViewModel, isVisible: Bool = true, accessoryType: UITableViewCell.AccessoryType = .none) {
         self.token = token
         self.isVisible = isVisible

--- a/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/EthTokenViewCellViewModel.swift
@@ -25,7 +25,7 @@ struct EthTokenViewCellViewModel {
     }
 
     var titleAttributedString: NSAttributedString {
-        return NSAttributedString(string: token.tokenScriptOverrides?.shortTitleInPluralForm ?? "", attributes: [
+        return NSAttributedString(string: token.tokenScriptOverrides?.safeShortTitleInPluralForm ?? "", attributes: [
             .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .font: Screen.TokenCard.Font.title
         ])
@@ -167,7 +167,7 @@ struct EthTokenViewCellViewModel {
 extension EthTokenViewCellViewModel: Hashable {
     static func == (lhs: EthTokenViewCellViewModel, rhs: EthTokenViewCellViewModel) -> Bool {
         return lhs.token == rhs.token &&
-            lhs.token.tokenScriptOverrides?.shortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
+            lhs.token.tokenScriptOverrides?.safeShortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
             lhs.token.tokenScriptOverrides?.symbolInPluralForm == rhs.token.tokenScriptOverrides?.symbolInPluralForm &&
             lhs.token.valueDecimal == rhs.token.valueDecimal &&
             lhs.token.balance.ticker == rhs.token.balance.ticker
@@ -178,7 +178,7 @@ extension EthTokenViewCellViewModel: Hashable {
         hasher.combine(accessoryType)
         hasher.combine(token.contractAddress)
         hasher.combine(token.server)
-        hasher.combine(token.tokenScriptOverrides?.shortTitleInPluralForm)
+        hasher.combine(token.tokenScriptOverrides?.safeShortTitleInPluralForm)
         hasher.combine(token.tokenScriptOverrides?.symbolInPluralForm)
         hasher.combine(token.valueDecimal)
         hasher.combine(token.balance.ticker)

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenViewCellViewModel.swift
@@ -23,7 +23,7 @@ struct FungibleTokenViewCellViewModel {
     }
 
     var titleAttributedString: NSAttributedString {
-        return NSAttributedString(string: token.tokenScriptOverrides?.shortTitleInPluralForm ?? "", attributes: [
+        return NSAttributedString(string: token.tokenScriptOverrides?.safeShortTitleInPluralForm ?? "", attributes: [
             .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .font: Screen.TokenCard.Font.title
         ])
@@ -134,7 +134,7 @@ struct FungibleTokenViewCellViewModel {
 extension FungibleTokenViewCellViewModel: Hashable {
     static func == (lhs: FungibleTokenViewCellViewModel, rhs: FungibleTokenViewCellViewModel) -> Bool {
         return lhs.token == rhs.token &&
-            lhs.token.tokenScriptOverrides?.shortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
+            lhs.token.tokenScriptOverrides?.safeShortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
             lhs.token.tokenScriptOverrides?.symbolInPluralForm == rhs.token.tokenScriptOverrides?.symbolInPluralForm &&
             lhs.token.valueDecimal == rhs.token.valueDecimal &&
             lhs.token.balance.ticker == rhs.token.balance.ticker
@@ -145,7 +145,7 @@ extension FungibleTokenViewCellViewModel: Hashable {
         hasher.combine(accessoryType)
         hasher.combine(token.contractAddress)
         hasher.combine(token.server)
-        hasher.combine(token.tokenScriptOverrides?.shortTitleInPluralForm)
+        hasher.combine(token.tokenScriptOverrides?.safeShortTitleInPluralForm)
         hasher.combine(token.tokenScriptOverrides?.symbolInPluralForm)
         hasher.combine(token.valueDecimal)
         hasher.combine(token.balance.ticker)

--- a/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/NonFungibleTokenViewCellViewModel.swift
@@ -57,7 +57,7 @@ struct NonFungibleTokenViewCellViewModel {
     }
 
     var titleAttributedString: NSAttributedString {
-        return .init(string: token.tokenScriptOverrides?.shortTitleInPluralForm ?? "-", attributes: [
+        return .init(string: token.tokenScriptOverrides?.safeShortTitleInPluralForm ?? "-", attributes: [
             .font: Screen.TokenCard.Font.title,
             .foregroundColor: Screen.TokenCard.Color.title
         ])
@@ -87,7 +87,7 @@ struct NonFungibleTokenViewCellViewModel {
 extension NonFungibleTokenViewCellViewModel: Hashable {
     static func == (lhs: NonFungibleTokenViewCellViewModel, rhs: NonFungibleTokenViewCellViewModel) -> Bool {
         return lhs.token == rhs.token &&
-            lhs.token.tokenScriptOverrides?.shortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
+            lhs.token.tokenScriptOverrides?.safeShortTitleInPluralForm == rhs.token.tokenScriptOverrides?.shortTitleInPluralForm &&
             lhs.token.nonZeroBalance.count.toString() == rhs.token.nonZeroBalance.count.toString()
     }
 
@@ -96,7 +96,7 @@ extension NonFungibleTokenViewCellViewModel: Hashable {
         hasher.combine(accessoryType)
         hasher.combine(token.contractAddress)
         hasher.combine(token.server)
-        hasher.combine(token.tokenScriptOverrides?.shortTitleInPluralForm)
+        hasher.combine(token.tokenScriptOverrides?.safeShortTitleInPluralForm)
         hasher.combine(token.nonZeroBalance.count)
     }
 }


### PR DESCRIPTION
Before PR|After PR
-|-
<img width="300" alt="Screenshot 2022-09-09 at 12 14 59 PM" src="https://user-images.githubusercontent.com/56189/189270726-2583b9bc-5eba-4a31-a682-f69603816c11.png">|<img width="300" alt="Screenshot 2022-09-09 at 12 07 28 PM" src="https://user-images.githubusercontent.com/56189/189270735-37d821f1-851d-4450-bc05-66fbfcd348ed.png">

The underlying code is fragile; the PR doesn't change this, so this is a short-term fix.