### PR TITLE
[DEV] Support building with Xcode 14 RC

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ target 'AlphaWallet' do
   pod 'EthereumABI', :git => 'https://github.com/AlphaWallet/EthereumABI.git', :commit => '877b77e8e7cbc54ab0712d509b74fec21b79d1bb'
   pod 'BlockiesSwift'
   pod 'PaperTrailLumberjack/Swift'
-  pod 'Charts'
+  pod 'Charts', :git => 'https://github.com/AlphaWallet/Charts.git', :commit => '85ec4d0f62b97829274c4f628f4840036939de64'
   pod 'CocoaLumberjack', '3.7.0'
   pod 'AlphaWalletAddress', :path => '.'
   pod 'AlphaWalletCore', :path => '.'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,7 +164,7 @@ DEPENDENCIES:
   - Apollo
   - BigInt (~> 3.1)
   - BlockiesSwift
-  - Charts
+  - Charts (from `https://github.com/AlphaWallet/Charts.git`, commit `85ec4d0f62b97829274c4f628f4840036939de64`)
   - CocoaLumberjack (= 3.7.0)
   - CombineExt (= 1.8.0)
   - CryptoSwift (~> 1.4)
@@ -203,7 +203,6 @@ SPEC REPOS:
     - Apollo
     - BigInt
     - BlockiesSwift
-    - Charts
     - CocoaAsyncSocket
     - CocoaLumberjack
     - CombineExt
@@ -251,6 +250,9 @@ EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
     :commit: 9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
+  Charts:
+    :commit: 85ec4d0f62b97829274c4f628f4840036939de64
+    :git: https://github.com/AlphaWallet/Charts.git
   EthereumABI:
     :commit: 877b77e8e7cbc54ab0712d509b74fec21b79d1bb
     :git: https://github.com/AlphaWallet/EthereumABI.git
@@ -277,6 +279,9 @@ CHECKOUT OPTIONS:
   AlphaWalletWeb3Provider:
     :commit: 9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
+  Charts:
+    :commit: 85ec4d0f62b97829274c4f628f4840036939de64
+    :git: https://github.com/AlphaWallet/Charts.git
   EthereumABI:
     :commit: 877b77e8e7cbc54ab0712d509b74fec21b79d1bb
     :git: https://github.com/AlphaWallet/EthereumABI.git
@@ -352,6 +357,6 @@ SPEC CHECKSUMS:
   web3swift: 06118d4c4edc801444aaa995bbbddeda176b97ef
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: 93ffd4175cf4a75489495924069a5b1c6547fa32
+PODFILE CHECKSUM: f0a23b9a340a9dc67d8c9623eed6a172a7556a01
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Fixes build error:

```
alpha-wallet-ios/Pods/Charts/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift:530:1: Type 'ChartDataSet' does not conform to protocol 'RangeReplaceableCollection'
alpha-wallet-ios/Pods/Charts/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift:530:1: Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'
```

Still builds with Xcode 13.3.1

We'll switch to Xcode 14 soon, when it's available, but only when we update `.xcode-version`.

But not sure if chart data is showing up correctly. #5325