### PR TITLE
Rename `CallForAssetAttributeCoordinator` with `CallForAssetAttributeProvider`, #5353

### DIFF
--- a/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
+++ b/AlphaWalletTests/TokenScriptClient/XMLHandlerTest.swift
@@ -904,7 +904,7 @@ class XMLHandlerTest: XCTestCase {
         let contractAddress = AlphaWallet.Address(string: "0xA66A3F08068174e8F005112A8b2c7A507a822335")!
         let store = AssetDefinitionStore(backingStore: AssetDefinitionInMemoryBackingStore())
 
-        XMLHandler.callForAssetAttributeCoordinator = CallForAssetAttributeCoordinator()
+        XMLHandler.assetAttributeProvider = CallForAssetAttributeProvider()
 
         store[contractAddress] = xml
         let xmlHandler = XMLHandler(contract: contractAddress, tokenType: .erc20, assetDefinitionStore: store)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttribute.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttribute.swift
@@ -134,9 +134,9 @@ public struct AssetAttribute {
         }
     }
 
-    public func value(from tokenIdOrEvent: TokenIdOrEvent, inWallet account: Wallet, server: RPCServer, callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator, userEntryValues: [AttributeId: String], tokenLevelNonSubscribableAttributesAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue]) -> AssetAttributeSyntaxValue {
+    public func value(from tokenIdOrEvent: TokenIdOrEvent, inWallet account: Wallet, server: RPCServer, assetAttributeProvider: CallForAssetAttributeProvider, userEntryValues: [AttributeId: String], tokenLevelNonSubscribableAttributesAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue]) -> AssetAttributeSyntaxValue {
         let valueFromOriginOptional: AssetInternalValue?
-        valueFromOriginOptional = origin.extractValue(fromTokenIdOrEvent: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: tokenLevelNonSubscribableAttributesAndValues, localRefs: localRefs)
+        valueFromOriginOptional = origin.extractValue(fromTokenIdOrEvent: tokenIdOrEvent, inWallet: account, server: server, assetAttributeProvider: assetAttributeProvider, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: tokenLevelNonSubscribableAttributesAndValues, localRefs: localRefs)
         guard let valueFromOrigin = valueFromOriginOptional else { return .init(defaultValueWithSyntax: syntax) }
 
         let valueAfterMapping: AssetInternalValue
@@ -165,9 +165,9 @@ extension Dictionary where Key == AttributeId, Value == AssetAttribute {
     public func resolve(withTokenIdOrEvent tokenIdOrEvent: TokenIdOrEvent, userEntryValues: [AttributeId: String], server: RPCServer, account: Wallet, additionalValues: [AttributeId: AssetAttributeSyntaxValue], localRefs: [AttributeId: AssetInternalValue]) -> [AttributeId: AssetAttributeSyntaxValue] {
         var attributeNameValues = [AttributeId: AssetAttributeSyntaxValue]()
         let (tokenIdBased, userEntryBased, functionBased, eventBased) = splitAttributesByOrigin
-        let callForAssetAttributeCoordinator = XMLHandler.callForAssetAttributeCoordinator
+        let assetAttributeProvider = XMLHandler.assetAttributeProvider
         for (attributeId, attribute) in tokenIdBased {
-            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: .init(), localRefs: localRefs)
+            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, assetAttributeProvider: assetAttributeProvider, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: .init(), localRefs: localRefs)
             attributeNameValues[attributeId] = value
         }
         for (attributeId, attribute) in eventBased {
@@ -176,18 +176,18 @@ extension Dictionary where Key == AttributeId, Value == AssetAttribute {
             case .tokenId:
                 break
             case .event:
-                let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
+                let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, assetAttributeProvider: assetAttributeProvider, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
                 attributeNameValues[attributeId] = value
             }
         }
         for (attributeId, attribute) in userEntryBased {
             let resolvedAttributes = attributeNameValues.merging(additionalValues) { (_, new) in new }
-            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
+            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, assetAttributeProvider: assetAttributeProvider, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
             attributeNameValues[attributeId] = value
         }
         for (attributeId, attribute) in functionBased {
             let resolvedAttributes = attributeNameValues.merging(additionalValues) { (_, new) in new }
-            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
+            let value = attribute.value(from: tokenIdOrEvent, inWallet: account, server: server, assetAttributeProvider: assetAttributeProvider, userEntryValues: userEntryValues, tokenLevelNonSubscribableAttributesAndValues: resolvedAttributes.mapValues { $0.value }, localRefs: localRefs)
             attributeNameValues[attributeId] = value
         }
         return attributeNameValues

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/FunctionOrigin.swift
@@ -153,7 +153,7 @@ public struct FunctionOrigin {
         self.bitShift = bitShift
     }
 
-    public func extractValue(withTokenId tokenId: TokenId, account: Wallet, server: RPCServer, attributeAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue], callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator) -> AssetInternalValue? {
+    public func extractValue(withTokenId tokenId: TokenId, account: Wallet, server: RPCServer, attributeAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue], assetAttributeProvider: CallForAssetAttributeProvider) -> AssetInternalValue? {
         guard let functionName = functionType.functionName else { return nil }
         guard let subscribable = callSmartContractFunction(
                 forAttributeId: attributeId,
@@ -165,7 +165,7 @@ public struct FunctionOrigin {
                 originContract: originContractOrRecipientAddress,
                 functionName: functionName,
                 output: functionType.output,
-                callForAssetAttributeCoordinator: callForAssetAttributeCoordinator) else { return nil }
+                assetAttributeProvider: assetAttributeProvider) else { return nil }
         let resultSubscribable = Subscribable<AssetInternalValue>(nil)
         subscribable.subscribe { value in
             guard let value = value else { return }
@@ -344,7 +344,7 @@ public struct FunctionOrigin {
             originContract: AlphaWallet.Address,
             functionName: String,
             output: AssetFunctionCall.ReturnType,
-            callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator
+            assetAttributeProvider: CallForAssetAttributeProvider
     ) -> Subscribable<AssetInternalValue>? {
         assert(functionType.isCall)
         guard let arguments = formArguments(withTokenId: tokenId, attributeAndValues: attributeAndValues, localRefs: localRefs, account: account) else { return nil }
@@ -356,6 +356,6 @@ public struct FunctionOrigin {
             return Subscribable<AssetInternalValue>(nil)
         }
 
-        return callForAssetAttributeCoordinator.getValue(forAttributeId: attributeId, tokenId: tokenId, functionCall: functionCall)
+        return assetAttributeProvider.getValue(forAttributeId: attributeId, tokenId: tokenId, functionCall: functionCall)
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/Origin.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/Origin.swift
@@ -122,13 +122,13 @@ enum Origin {
         return count - 1
     }
 
-    func extractValue(fromTokenIdOrEvent tokenIdOrEvent: TokenIdOrEvent, inWallet account: Wallet, server: RPCServer, callForAssetAttributeCoordinator: CallForAssetAttributeCoordinator, userEntryValues: [AttributeId: String], tokenLevelNonSubscribableAttributesAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue]) -> AssetInternalValue? {
+    func extractValue(fromTokenIdOrEvent tokenIdOrEvent: TokenIdOrEvent, inWallet account: Wallet, server: RPCServer, assetAttributeProvider: CallForAssetAttributeProvider, userEntryValues: [AttributeId: String], tokenLevelNonSubscribableAttributesAndValues: [AttributeId: AssetInternalValue], localRefs: [AttributeId: AssetInternalValue]) -> AssetInternalValue? {
         switch self {
         case .tokenId(let origin):
             return origin.extractValue(fromTokenId: tokenIdOrEvent.tokenId)
         case .function(let origin):
             //We don't pass in attributes with function-origins because the order is undefined at the moment
-            return origin.extractValue(withTokenId: tokenIdOrEvent.tokenId, account: account, server: server, attributeAndValues: tokenLevelNonSubscribableAttributesAndValues, localRefs: localRefs, callForAssetAttributeCoordinator: callForAssetAttributeCoordinator)
+            return origin.extractValue(withTokenId: tokenIdOrEvent.tokenId, account: account, server: server, attributeAndValues: tokenLevelNonSubscribableAttributesAndValues, localRefs: localRefs, assetAttributeProvider: assetAttributeProvider)
         case .userEntry(let origin):
             guard let input = userEntryValues[origin.attributeId] else { return nil }
             return origin.extractValue(fromUserEntry: input)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
@@ -760,7 +760,7 @@ final class ThreadSafe {
 
 /// This class delegates all the functionality to a singleton of the actual XML parser. 1 for each contract. So we just parse the XML file 1 time only for each contract
 public class XMLHandler {
-    public static var callForAssetAttributeCoordinator = CallForAssetAttributeCoordinator()
+    public static var assetAttributeProvider = CallForAssetAttributeProvider()
     fileprivate static var xmlHandlers: AtomicDictionary<AlphaWallet.Address, PrivateXMLHandler> = .init()
     fileprivate static var baseXmlHandlers: AtomicDictionary<String, PrivateXMLHandler> = .init()
     private let privateXMLHandler: PrivateXMLHandler


### PR DESCRIPTION
Closes #5353