### PR TITLE
Update foundation with manually defining dependency version for 'SwiftProtobuf', '1.20.1' #5362

### DIFF
--- a/AlphaWalletFoundation.podspec
+++ b/AlphaWalletFoundation.podspec
@@ -48,5 +48,6 @@ Pod::Spec.new do |spec|
   spec.dependency 'AlphaWalletOpenSea'
   spec.dependency 'Apollo'
   spec.dependency 'CombineExt', '1.8.0'
+  spec.dependency 'SwiftProtobuf', '1.20.1'
 
 end


### PR DESCRIPTION
Closes #5362