### PR TITLE
Fix: wrong/overly-generic error messages displayed

### DIFF
--- a/AlphaWallet/Common/Types/Error.swift
+++ b/AlphaWallet/Common/Types/Error.swift
@@ -44,6 +44,7 @@ public struct UnknownError: LocalizedError { }
 
 extension Error {
     public var prettyError: String {
+        //TODO figure out how we can remove this switch-cases. Too fragile
         switch self {
         case let error as BuyCryptoError:
             return error.localizedDescription
@@ -61,6 +62,18 @@ extension Error {
             return error.localizedDescription
         case let error as KeystoreError:
             return error.errorDescription ?? UnknownError().localizedDescription
+        case let error as SendInputErrors:
+            return error.errorDescription ?? UnknownError().localizedDescription
+        case let error as RpcNodeRetryableRequestError:
+            return error.errorDescription ?? UnknownError().localizedDescription
+        case let error as DelayWalletConnectResponseError :
+            return error.localizedDescription
+        case let error as OpenURLError:
+            return error.localizedDescription
+        case let error as ConfigureTransactionError:
+            return error.localizedDescription
+        case let error as AddCustomChainError:
+            return error.localizedDescription
         case let error as LocalizedError:
             return error.errorDescription ?? UnknownError().localizedDescription
         case let error as NSError:


### PR DESCRIPTION
Finishing the work after #5332. This should clean up all the error sub-types. It's a little fragile having to list the error sub-types in a switch case, so we'll have to find a better way in the long run

Before PR|After PR (and recently)
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/190076179-76695243-b5a3-436c-98ad-3497428ef3cf.PNG'>|<img width="200" alt="Screenshot 2022-09-14 at 2 13 15 PM" src="https://user-images.githubusercontent.com/56189/190076195-8787af95-732e-4fc4-b920-12e2f0ef0254.png">