### PR TITLE
Added dark mode to DappBrowserNavigationBar and ButtonsBarBackgroundView

### DIFF
--- a/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
+++ b/AlphaWallet/Browser/Views/DappBrowserNavigationBar.swift
@@ -30,16 +30,16 @@ final class DappBrowserNavigationBar: UINavigationBar {
     private let stackView = UIStackView()
     private let moreButton: UIButton = {
         let moreButton = UIButton(type: .system)
-        moreButton.tintColor = Colors.black
+        moreButton.tintColor = Configuration.Color.Semantic.navigationbarPrimaryFont
         moreButton.adjustsImageWhenHighlighted = true
         moreButton.setImage(R.image.toolbarMenu(), for: .normal)
-        moreButton.backgroundColor = Colors.appWhite
+        moreButton.backgroundColor = Configuration.Color.Semantic.navigationbarBackgroundColor
         return moreButton
     }()
 
     private let homeButton: UIButton = {
         let homeButton = UIButton(type: .system)
-        homeButton.tintColor = Colors.black
+        homeButton.tintColor = Configuration.Color.Semantic.navigationbarPrimaryFont
         homeButton.adjustsImageWhenHighlighted = true
         homeButton.setImage(R.image.iconsSystemHome(), for: .normal)
 
@@ -63,7 +63,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
     }()
     private let closeButton: UIButton = {
         let closeButton = UIButton(type: .system)
-        closeButton.tintColor = Colors.black
+        closeButton.tintColor = Configuration.Color.Semantic.navigationbarPrimaryFont
         closeButton.isHidden = true
         closeButton.setTitle(R.string.localizable.done(), for: .normal)
         closeButton.setTitleColor(Configuration.Color.Semantic.navigationbarButtonItemTint, for: .normal)
@@ -98,7 +98,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
     private let domainNameLabel = UILabel()
     private let backButton: UIButton = {
         let backButton = UIButton(type: .system)
-        backButton.tintColor = Colors.black
+        backButton.tintColor = Configuration.Color.Semantic.navigationbarPrimaryFont
         backButton.adjustsImageWhenHighlighted = true
         backButton.setImage(R.image.toolbarBack(), for: .normal)
 
@@ -106,7 +106,7 @@ final class DappBrowserNavigationBar: UINavigationBar {
     }()
     private let forwardButton: UIButton = {
         let forwardButton = UIButton(type: .system)
-        forwardButton.tintColor = Colors.black
+        forwardButton.tintColor = Configuration.Color.Semantic.navigationbarPrimaryFont
         forwardButton.adjustsImageWhenHighlighted = true
         forwardButton.setImage(R.image.toolbarForward(), for: .normal)
 

--- a/AlphaWallet/Common/Views/ButtonsBar/ButtonsBarBackgroundView.swift
+++ b/AlphaWallet/Common/Views/ButtonsBar/ButtonsBarBackgroundView.swift
@@ -31,7 +31,7 @@ class ButtonsBarBackgroundView: UIView {
         addSubview(separatorLine)
         addSubview(buttonsBar)
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = Colors.appWhite
+        backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         NSLayoutConstraint.activate([
             separatorLine.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/AlphaWallet/Transfer/ViewModels/RequestViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/RequestViewModel.swift
@@ -40,7 +40,7 @@ struct RequestViewModel {
 	}
 
 	var labelColor: UIColor? {
-		return R.color.mine()
+        return Configuration.Color.Semantic.labelTextActive
 	}
 
 	var addressFont: UIFont {


### PR DESCRIPTION
On the main wallet menu, tap the `...` button on the upper right corner, then tap `buy crypto` or `rename wallet`.

![rename-wallet-dark](https://user-images.githubusercontent.com/1050309/190411883-dcdc0ef4-313a-4bf3-82f5-2a930df2dc32.jpg) ![rename-wallet-light](https://user-images.githubusercontent.com/1050309/190411897-84a5c49d-4192-4741-94db-843c2a713cfc.jpg)
![buy-crypto-dark](https://user-images.githubusercontent.com/1050309/190411901-6b9d6a74-bb08-4dec-b7c3-93c91b8f4678.jpg) ![buy-crypto-light](https://user-images.githubusercontent.com/1050309/190411903-d66ed22a-6b78-4b7e-888d-611ba96a7078.jpg)
