### PR TITLE
Add `RPCServerWithEnhancedSupport` to dramatically reduce number of files and changes required to add most new chains

### DIFF
--- a/AlphaWallet/Common/Services/LocalNotificationService.swift
+++ b/AlphaWallet/Common/Services/LocalNotificationService.swift
@@ -22,10 +22,10 @@ class LocalNotificationService: ScheduledNotificationService {
         let notificationCenter = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
         //TODO support other mainnets too
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .main, .xDai:
             content.body = R.string.localizable.transactionsReceivedEther(amount, server.symbol)
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             content.body = R.string.localizable.transactionsReceivedEther("\(amount) (\(server.name))", server.symbol)
         }
 

--- a/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
+++ b/AlphaWallet/Market/Coordinators/ImportMagicLinkCoordinator.swift
@@ -410,10 +410,10 @@ class ImportMagicLinkCoordinator: Coordinator {
 
     private func notEnoughEthForPaidImport(signedOrder: SignedOrder) {
         let errorMessage: String
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .xDai:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughXDAITitle()
-        case .classic, .main, .poa, .callisto, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet, .candle:
+        case .main, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             errorMessage = R.string.localizable.aClaimTokenFailedNotEnoughEthTitle()
         }
         let etherToken: Token = MultipleChainsTokensDataStore.functional.etherToken(forServer: server)

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenViewModel.swift
@@ -113,7 +113,7 @@ final class FungibleTokenViewModel {
         self.tokenActionsProvider = tokenActionsProvider
         self.coinTickersFetcher = coinTickersFetcher
         self.tokensService = tokensService
-    } 
+    }
 
     func tokenScriptWarningMessage(for action: TokenInstanceAction) -> TokenScriptWarningMessage? {
         if let tokenHolder = tokenHolder, let selection = action.activeExcludingSelection(selectedTokenHolders: [tokenHolder], forWalletAddress: wallet.address, fungibleBalance: fungibleBalance) {
@@ -219,10 +219,10 @@ final class FungibleTokenViewModel {
                     .init(type: .erc20Send),
                     .init(type: .erc20Receive)
                 ]
-                switch token.server {
+                switch token.server.serverWithEnhancedSupport {
                 case .xDai:
                     return [.init(type: .erc20Send), .init(type: .erc20Receive)] + tokenActionsProvider.actions(token: token)
-                case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet, .candle:
+                case .main, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
                     return actions + tokenActionsProvider.actions(token: token)
                 }
             }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
@@ -32,21 +32,21 @@ public final class GasPriceEstimator {
             return estimateGasPriceForUsingEtherscanApi(server: server)
                 .recover { _ in self.estimateGasPriceForUseRpcNode(server: server) }
         } else {
-            switch server {
+            switch server.serverWithEnhancedSupport {
             case .xDai:
                 return estimateGasPriceForXDai()
-            case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+            case .main, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
                 return estimateGasPriceForUseRpcNode(server: server)
             }
         }
     }
 
     public func estimateDefaultGasPrice(server: RPCServer, transaction: UnconfirmedTransaction) -> BigInt {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .xDai:
             //xdai transactions are always 1 gwei in gasPrice
             return GasPriceConfiguration.xDaiGasPrice
-        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             let maxPrice: BigInt = GasPriceConfiguration.maxPrice(forServer: server)
             let defaultPrice: BigInt = GasPriceConfiguration.defaultPrice(forServer: server)
             if let gasPrice = transaction.gasPrice, gasPrice > 0 {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/Models/EtherscanGasPriceEstimator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/Models/EtherscanGasPriceEstimator.swift
@@ -33,10 +33,10 @@ fileprivate extension RPCServer {
         } else {
             apiKeyParameter = ""
         }
-        switch self {
+        switch self.serverWithEnhancedSupport {
         case .main, .binance_smart_chain, .heco, .polygon:
             return etherscanApiRoot?.appendingQueryString("\("module=gastracker&action=gasoracle")\(apiKeyParameter)")
-        case .artis_sigma1, .artis_tau1, .binance_smart_chain_testnet, .callisto, .poa, .sokol, .classic, .xDai, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .mumbai_testnet, .cronosTestnet, .custom, .arbitrum, .arbitrumRinkeby, .kovan, .ropsten, .rinkeby, .goerli, .optimistic, .optimisticKovan, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet, .candle:
+        case .xDai, .candle, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return nil
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/NFT/Enjin/Enjin.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/NFT/Enjin/Enjin.swift
@@ -55,10 +55,10 @@ public final class Enjin {
     }
 
     static func isServerSupported(_ server: RPCServer) -> Bool {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .main:
             return true
-        case .rinkeby, .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/NFT/OpenSea/OpenSea.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/NFT/OpenSea/OpenSea.swift
@@ -19,11 +19,12 @@ public final class OpenSea {
     }
 
     public static func isServerSupported(_ server: RPCServer) -> Bool {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .main, .rinkeby:
             return true
-        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return false
+
         }
     }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Notifications/TransactionNotificationService.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Notifications/TransactionNotificationService.swift
@@ -96,12 +96,12 @@ public final class TransactionNotificationSourceService: NotificationSourceServi
                 .last
                 .flatMap { BigInt($0.value) }
 
-        switch server {
+        switch server.serverWithEnhancedSupport {
         //TODO make this work for other mainnets
         case .main:
             etherReceivedUsedForBackupPrompt
                 .flatMap { delegate?.showCreateBackupAfterReceiveNativeCryptoCurrencyPrompt(in: self, etherReceivedUsedForBackupPrompt: $0) }
-        case .classic, .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             break
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Models/SendPrivateTransactionsProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Models/SendPrivateTransactionsProvider.swift
@@ -9,18 +9,18 @@ public enum SendPrivateTransactionsProvider: String {
     public func rpcUrl(forServer server: RPCServer) -> URL? {
         switch self {
         case .ethermine:
-            switch server {
-            case .main: return URL(string: "https://rpc.ethermine.org")!
-            case .xDai, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .phi: return nil
-            case .klaytnCypress, .klaytnBaobabTestnet: return nil
-            case .ioTeX, .ioTeXTestnet: return nil
+            switch server.serverWithEnhancedSupport {
+            case .main:
+                return URL(string: "https://rpc.ethermine.org")!
+            case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
+                return nil
             }
         case .eden:
-            switch server {
-            case .main: return URL(string: "https://api.edennetwork.io/v1/rpc")!
-            case .ropsten, .xDai, .kovan, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .phi: return nil
-            case .klaytnCypress, .klaytnBaobabTestnet: return nil
-            case .ioTeX, .ioTeXTestnet: return nil
+            switch server.serverWithEnhancedSupport {
+            case .main:
+                return URL(string: "https://api.edennetwork.io/v1/rpc")!
+            case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
+                return nil
             }
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServerWithEnhancedSupport.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServerWithEnhancedSupport.swift
@@ -1,0 +1,18 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+
+//The existence of this type is to dramatically reduce the number of files (20 files as of 20220922) and changes needed to add a chain/RPCServer
+//Adding a new case here means more maintenance work when that type is updated.
+public enum RPCServerWithEnhancedSupport {
+    case main
+    case xDai
+    case candle
+    case polygon
+    case binance_smart_chain
+    case heco
+    case rinkeby
+    case arbitrum
+    case klaytnCypress
+    case klaytnBaobabTestnet
+}

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
@@ -852,6 +852,34 @@ public enum RPCServer: Hashable, CaseIterable {
         }
     }
 
+    //Implementation: Almost every chain should return nil here
+    public var serverWithEnhancedSupport: RPCServerWithEnhancedSupport? {
+        switch self {
+        case .main:
+            return .main
+        case .xDai:
+            return .xDai
+        case .candle:
+            return .candle
+        case .polygon:
+            return .polygon
+        case .binance_smart_chain:
+            return .binance_smart_chain
+        case .heco:
+            return .heco
+        case .rinkeby:
+            return .rinkeby
+        case .arbitrum:
+            return .arbitrum
+        case .klaytnCypress:
+            return .klaytnCypress
+        case .klaytnBaobabTestnet:
+            return .klaytnBaobabTestnet
+        case .main, .kovan, .ropsten, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain_testnet, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .palm, .palmTestnet, .arbitrumRinkeby, .phi, .ioTeX, .ioTeXTestnet:
+            return nil
+        }
+    }
+
     var coinGeckoPlatform: String? {
         switch self {
         case .main: return "ethereum"

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Carthage/Carthage.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Carthage/Carthage.swift
@@ -39,10 +39,10 @@ public class Carthage: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
     }
 
     public func isSupport(token: TokenActionsIdentifiable) -> Bool {
-        switch token.server {
+        switch token.server.serverWithEnhancedSupport {
         case .candle:
             return true
-        case .main, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .arbitrum, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .palm, .palmTestnet, .arbitrumRinkeby, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .xDai, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/HoneySwap/HoneySwap.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/HoneySwap/HoneySwap.swift
@@ -100,10 +100,10 @@ public class HoneySwap: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
     }
 
     public func isSupport(token: TokenActionsIdentifiable) -> Bool {
-        switch token.server {
+        switch token.server.serverWithEnhancedSupport {
         case .xDai:
             return true
-        case .main, .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Oneinch/Oneinch.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Oneinch/Oneinch.swift
@@ -87,10 +87,10 @@ public class Oneinch: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
     }
 
     public func isSupport(token: TokenActionsIdentifiable) -> Bool {
-        switch token.server {
+        switch token.server.serverWithEnhancedSupport {
         case .main, .arbitrum:
             return asset(for: token.contractAddress) != nil
-        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .palm, .palmTestnet, .arbitrumRinkeby, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/QuickSwap/QuickSwap.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/QuickSwap/QuickSwap.swift
@@ -103,10 +103,10 @@ public class QuickSwap: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
     }
 
     public func isSupport(token: TokenActionsIdentifiable) -> Bool {
-        switch token.server {
+        switch token.server.serverWithEnhancedSupport {
         case .polygon:
             return true
-        case .main, .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .custom, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .xDai, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .xDai, .candle, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/UniswapERC20Token.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/UniswapERC20Token.swift
@@ -16,10 +16,10 @@ struct UniswapERC20Token {
 extension UniswapERC20Token {
 
     static func isSupport(token: TokenActionsIdentifiable) -> Bool {
-        switch token.server {
+        switch token.server.serverWithEnhancedSupport {
         case .main:
             return availableTokens.contains(where: { $0.contract.sameContract(as: token.contractAddress) })
-        case .kovan, .ropsten, .rinkeby, .sokol, .goerli, .artis_sigma1, .artis_tau1, .custom, .poa, .callisto, .xDai, .classic, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             return false
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokensAutodetector/TokensAutodetector.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokensAutodetector/TokensAutodetector.swift
@@ -61,7 +61,7 @@ public class SingleChainTokensAutodetector: NSObject, TokensAutodetector {
     public func start() {
         //TODO we don't auto detect tokens if we are running tests. Maybe better to move this into app delegate's application(_:didFinishLaunchingWithOptions:)
         guard !isRunningTests() else { return }
-        
+
         //Since this is called at launch, we don't want it to block launching
         queue.async { [weak self] in
             self?.autoDetectTransactedTokens()
@@ -134,14 +134,14 @@ public class SingleChainTokensAutodetector: NSObject, TokensAutodetector {
     //TODO consolidate with adding `Constants.uefaMainnet` which is done elsewhere
     private func autoDetectPartnerTokens() {
         guard !session.config.development.isAutoFetchingDisabled else { return }
-        switch session.server {
+        switch session.server.serverWithEnhancedSupport {
         case .main:
             autoDetectMainnetPartnerTokens()
         case .xDai:
             autoDetectXDaiPartnerTokens()
         case .rinkeby:
             autoDetectRinkebyPartnerTokens()
-        case .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .goerli, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .custom, .heco_testnet, .heco, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             break
         }
     }
@@ -241,7 +241,7 @@ extension SingleChainTokensAutodetector: AutoDetectTokensOperationDelegate {
                 return false
             }
         }
-        
+
         tokensOrContractsDetectedSubject.send(tokensOrContracts)
     }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Covalent/TransactionProviders/NewlyAddedTransaction/NewlyAddedTransactionSchedulerProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Covalent/TransactionProviders/NewlyAddedTransaction/NewlyAddedTransactionSchedulerProvider.swift
@@ -103,11 +103,11 @@ extension Config {
 
 extension Covalent.NetworkProvider {
     static func isSupport(server: RPCServer) -> Bool {
-        switch server {
-        case .main, .classic, .callisto, .kovan, .ropsten, .custom, .rinkeby, .poa, .sokol, .goerli, .xDai, .artis_sigma1, .binance_smart_chain, .binance_smart_chain_testnet, .artis_tau1, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
-            return false
+        switch server.serverWithEnhancedSupport {
         case .klaytnCypress:
             return true
+        case .main, .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnBaobabTestnet, nil:
+            return false
         }
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/TransactionConfigurator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/TransactionConfigurator.swift
@@ -179,12 +179,12 @@ public class TransactionConfigurator {
         if let slowestConfig = configurations.slowestThirdPartyConfiguration, (configuration.gasPrice / BigInt(EthereumUnit.gwei.rawValue)) < (slowestConfig.gasPrice / BigInt(EthereumUnit.gwei.rawValue)) {
             return .tooLowCustomGasPrice
         }
-        switch session.server {
+        switch session.server.serverWithEnhancedSupport {
         case .main:
             if (configurations.standard.gasPrice / BigInt(EthereumUnit.gwei.rawValue)) > Constants.highStandardEthereumMainnetGasThresholdGwei {
                 return .networkCongested
             }
-        case .kovan, .ropsten, .rinkeby, .poa, .sokol, .classic, .callisto, .xDai, .goerli, .artis_sigma1, .artis_tau1, .binance_smart_chain, .fantom, .fantom_testnet, .binance_smart_chain_testnet, .custom, .heco, .heco_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .klaytnCypress, .klaytnBaobabTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .xDai, .candle, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             break
         }
         return nil

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GasLimitConfiguration.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GasLimitConfiguration.swift
@@ -7,10 +7,10 @@ public struct GasLimitConfiguration {
     public static let defaultGasLimit = BigInt(90_000)
     public static let minGasLimit = BigInt(21_000)
     public static func maxGasLimit(forServer server: RPCServer) -> BigInt {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .klaytnCypress, .klaytnBaobabTestnet:
             return BigInt(100_000_000)
-        default:
+        case .main, .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             //TODO make max be 1M unless for contract deployment then bigger, maybe 2M
             return BigInt(2_000_000)
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GasPriceConfiguration.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GasPriceConfiguration.swift
@@ -14,19 +14,19 @@ public struct GasPriceConfiguration {
 
 extension GasPriceConfiguration {
     public static func defaultPrice(forServer server: RPCServer) -> BigInt {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .klaytnCypress, .klaytnBaobabTestnet:
             return GasPriceConfiguration.klaytnMaxPrice
-        case .main, .rinkeby, .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return GasPriceConfiguration.defaultPrice
         }
     }
 
     public static func maxPrice(forServer server: RPCServer) -> BigInt {
-        switch server {
+        switch server.serverWithEnhancedSupport {
         case .klaytnCypress, .klaytnBaobabTestnet:
             return GasPriceConfiguration.klaytnMaxPrice
-        case .main, .rinkeby, .kovan, .ropsten, .poa, .sokol, .classic, .callisto, .custom, .goerli, .xDai, .artis_sigma1, .artis_tau1, .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet, .fantom, .fantom_testnet, .avalanche, .avalanche_testnet, .candle, .polygon, .mumbai_testnet, .optimistic, .optimisticKovan, .cronosTestnet, .arbitrum, .arbitrumRinkeby, .palm, .palmTestnet, .phi, .ioTeX, .ioTeXTestnet:
+        case .main, .xDai, .candle, .polygon, .binance_smart_chain, .heco, .rinkeby, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, nil:
             return GasPriceConfiguration.maxPrice
         }
     }


### PR DESCRIPTION
Contains 2 commits:

* 1st commit contains the changes for this PR
* 2nd commit is to show how many files and changes are needed to add a basic chain (4 files, but still many lines of changes) — will be removed before merging

With this PR, when we need to add a new chain that doesn't have more fancy features and exceptions, it should only touch 4 files instead of 20 (!) files. I've also noticed that since we moved lots of code out into pods, including `AlphaWalletFoundation`, when we add a new case to `RPCServer` and build, it no longer shows all the places which needs to be changed (i.e. with errors) like it used to. We have to change and build, repeat a few times to sweep through all the files, making it even slower.

@oa-s not sure if this approach is good. Thoughts?

Edit: have to change 4 files, not 2 files :)