### PR TITLE
remove unused remark from locale files - fix issue #5415

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Name this Wallet";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Save Name";
-"wallet.rename.enterNameTitle" = "Enter Name (min. 5 characters)";
+"wallet.rename.enterNameTitle" = "Enter Name";
 "wallets.hideToken.error.AddTokenFailure" = "Add token failure";
 "addCustomChain.unnamed" = "Unnamed";
 "addCustomChain.error.invalidChainId" = "Invalid chain ID provided: %@";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Name this Wallet";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Save Name";
-"wallet.rename.enterNameTitle" = "Enter Name (min. 5 characters)";
+"wallet.rename.enterNameTitle" = "Enter Name";
 "wallets.hideToken.error.AddTokenFailure" = "Add token failure";
 "addCustomChain.unnamed" = "Unnamed";
 "addCustomChain.error.invalidChainId" = "Invalid chain ID provided: %@";

--- a/AlphaWallet/Localization/fi.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/fi.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Nimeä lompakko";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Tallenna";
-"wallet.rename.enterNameTitle" = "Uusi nimi (min. 5 merkkiä pitkä)";
+"wallet.rename.enterNameTitle" = "Uusi nimi";
 "wallets.hideToken.error.AddTokenFailure" = "Rahakkeen lisääminen epäonnistui";
 "addCustomChain.unnamed" = "Nimetön";
 "addCustomChain.error.invalidChainId" = "Ketjun tunniste (Chain ID) on virheellinen: %@";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Name this Wallet";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Save Name";
-"wallet.rename.enterNameTitle" = "Enter Name (min. 5 characters)";
+"wallet.rename.enterNameTitle" = "Enter Name";
 "wallets.hideToken.error.AddTokenFailure" = "Add token failure";
 "addCustomChain.unnamed" = "Unnamed";
 "addCustomChain.error.invalidChainId" = "Invalid chain ID provided: %@";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Name this Wallet";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Save Name";
-"wallet.rename.enterNameTitle" = "Enter Name (min. 5 characters)";
+"wallet.rename.enterNameTitle" = "Enter Name";
 "wallets.hideToken.error.AddTokenFailure" = "Add token failure";
 "addCustomChain.unnamed" = "Unnamed";
 "addCustomChain.error.invalidChainId" = "Invalid chain ID provided: %@";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -664,7 +664,7 @@
 "settings.wallet.rename" = "Name this Wallet";
 "settings.blockscanChat" = "Blockscan Chat";
 "wallet.rename.save" = "Save Name";
-"wallet.rename.enterNameTitle" = "Enter Name (min. 5 characters)";
+"wallet.rename.enterNameTitle" = "Enter Name";
 "wallets.hideToken.error.AddTokenFailure" = "Add token failure";
 "addCustomChain.unnamed" = "Unnamed";
 "addCustomChain.error.invalidChainId" = "Invalid chain ID provided: %@";


### PR DESCRIPTION

Closes #5415

1-liner summary:
I had checked for limit validation on the name and there was no validation so that we could remove the unused remark.

