### PR TITLE
Handle unknown errors in actionsheet confirmation better by displaying them so support/developer can hear from user about it and improve it

### DIFF
--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -93,6 +93,8 @@ class TransactionConfirmationCoordinator: Coordinator {
             break
         case .executionReverted:
             break
+        case .unknown:
+            break
         }
     }
 }
@@ -361,6 +363,8 @@ extension SendTransactionNotRetryableError {
             return "possibleChainIdMismatch"
         case .executionReverted:
             return "executionReverted"
+        case .unknown(_, let message):
+            return "unknown error: \(message)"
         }
     }
 }

--- a/AlphaWallet/Transfer/ViewControllers/SendTransactionErrorViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendTransactionErrorViewController.swift
@@ -87,7 +87,7 @@ class SendTransactionErrorViewController: UIViewController {
             switch viewModel.error {
             case .insufficientFunds:
                 analytics.log(navigation: Analytics.Navigation.openHelpUrl, properties: [Analytics.Properties.type.rawValue: Analytics.HelpUrl.insufficientFunds.rawValue])
-            case .nonceTooLow, .gasPriceTooLow, .gasLimitTooLow, .gasLimitTooHigh, .possibleChainIdMismatch, .executionReverted:
+            case .nonceTooLow, .gasPriceTooLow, .gasLimitTooLow, .gasLimitTooHigh, .possibleChainIdMismatch, .executionReverted, .unknown:
                 break
             }
             delegate?.linkTapped(url, forError: error, inController: self)

--- a/AlphaWallet/Transfer/ViewModels/SendTransactionErrorViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendTransactionErrorViewModel.swift
@@ -23,6 +23,8 @@ struct SendTransactionErrorViewModel {
             return message
         case .executionReverted(let message):
             return message
+        case .unknown:
+            return R.string.localizable.unknownError()
         }
     }
 
@@ -42,6 +44,8 @@ struct SendTransactionErrorViewModel {
             return R.string.localizable.tokenTransactionConfirmationErrorDescriptionPossibleChainIdMismatchError()
         case .executionReverted:
             return R.string.localizable.tokenTransactionConfirmationErrorDescriptionExecutionRevertedError()
+        case .unknown(_, let message):
+            return message
         }
     }
 
@@ -68,6 +72,9 @@ struct SendTransactionErrorViewModel {
         case .possibleChainIdMismatch:
             return nil
         case .executionReverted:
+            return nil
+        case .unknown:
+            //TODO probably to ask user to contact support
             return nil
         }
     }
@@ -105,6 +112,8 @@ extension SendTransactionNotRetryableError {
         case .possibleChainIdMismatch:
             return nil
         case .executionReverted:
+            return nil
+        case .unknown:
             return nil
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Extensions/Session+PromiseKit.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Extensions/Session+PromiseKit.swift
@@ -98,6 +98,7 @@ extension APIKitSession {
                         return SendTransactionNotRetryableError.insufficientFunds(message: message)
                     } else {
                         RemoteLogger.instance.logRpcOrOtherWebError("JSONRPCError.responseError | code: \(code) | message: \(message)", url: baseUrl.absoluteString)
+                        return SendTransactionNotRetryableError.unknown(code: code, message: message)
                     }
                 case .responseNotFound(_, let object):
                     RemoteLogger.instance.logRpcOrOtherWebError("JSONRPCError.responseNotFound | object: \(object)", url: baseUrl.absoluteString)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/SendTransaction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/SendTransaction.swift
@@ -118,7 +118,7 @@ public class SendTransaction {
         switch error {
         case .nonceTooLow:
             analytics.log(error: Analytics.Error.sendTransactionNonceTooLow)
-        case .insufficientFunds, .gasPriceTooLow, .gasLimitTooLow, .gasLimitTooHigh, .possibleChainIdMismatch, .executionReverted:
+        case .insufficientFunds, .gasPriceTooLow, .gasLimitTooLow, .gasLimitTooHigh, .possibleChainIdMismatch, .executionReverted, .unknown:
             break
         }
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/SendTransactionError.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/SendTransactionError.swift
@@ -10,6 +10,7 @@ public enum SendTransactionNotRetryableError: Error {
     case gasLimitTooHigh(message: String)
     case possibleChainIdMismatch(message: String)
     case executionReverted(message: String)
+    case unknown(code: Int, message: String)
 }
 
 public enum RpcNodeRetryableRequestError: LocalizedError {


### PR DESCRIPTION
Before PR|After PR
-|-
<img width="200" alt="Screenshot 2022-10-04 at 1 05 47 PM" src="https://user-images.githubusercontent.com/56189/193755483-be938abf-aefd-424b-918e-d81d5f924290.png">|<img width="200" alt="Screenshot 2022-10-04 at 2 50 00 PM" src="https://user-images.githubusercontent.com/56189/193755508-c99042b6-5240-4700-83be-4c378c6821b1.png">

The handling of this particular message (in the "after" screenshot) will be improve separately. This PR is just to improve handling when the error is unknown.
