### PR TITLE
Fix: we should use dapp provided gas price even if it's lower than expected

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
@@ -49,7 +49,8 @@ public final class GasPriceEstimator {
             let maxPrice: BigInt = GasPriceConfiguration.maxPrice(forServer: server)
             let defaultPrice: BigInt = GasPriceConfiguration.defaultPrice(forServer: server)
             if let gasPrice = transaction.gasPrice, gasPrice > 0 {
-                return min(max(gasPrice, GasPriceConfiguration.minPrice), maxPrice)
+                //We don't compare to `GasPriceConfiguration.minPrice` because if the transaction already has a price (from speedup/cancel or dapp), we should use it
+                return min(gasPrice, maxPrice)
             } else {
                 let defaultGasPrice = min(max(transaction.gasPrice ?? defaultPrice, GasPriceConfiguration.minPrice), maxPrice)
                 return defaultGasPrice


### PR DESCRIPTION
Fix #5492