### PR TITLE
Added dark mode to FungibleTokenViewController

### DIFF
--- a/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/ActivitiesViewModel.swift
@@ -12,15 +12,19 @@ struct ActivitiesViewModel {
     var collection: ActivityCollection
 
     var backgroundColor: UIColor {
-        Colors.appWhite
+        Configuration.Color.Semantic.tableViewBackground
+    }
+
+    var separatorColor: UIColor {
+        Configuration.Color.Semantic.tableViewSeparator
     }
 
     var headerBackgroundColor: UIColor {
-        GroupedTable.Color.background
+        Configuration.Color.Semantic.tableViewHeaderBackground
     }
 
     var headerTitleTextColor: UIColor {
-        GroupedTable.Color.title
+        Configuration.Color.Semantic.defaultForegroundText
     }
 
     var headerTitleFont: UIFont {

--- a/AlphaWallet/Activities/ViewModels/ActivityCellViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/ActivityCellViewModel.swift
@@ -12,7 +12,7 @@ struct ActivityCellViewModel {
     let activity: Activity
 
     var contentsBackgroundColor: UIColor {
-        .white
+        Configuration.Color.Semantic.tableViewCellBackground
     }
 
     var contentsCornerRadius: CGFloat {
@@ -20,6 +20,6 @@ struct ActivityCellViewModel {
     }
 
     var backgroundColor: UIColor {
-        return Colors.appBackground
+        return Configuration.Color.Semantic.tableViewCellBackground
     }
 }

--- a/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/DefaultActivityCellViewModel.swift
@@ -17,18 +17,18 @@ struct DefaultActivityCellViewModel {
 
     var contentsBackgroundColor: UIColor {
         if activityStateViewViewModel.isInPendingState {
-            return R.color.azure_sending()!
+            return Configuration.Color.Semantic.sendingState
         } else {
-            return .white
+            return Configuration.Color.Semantic.tableViewCellBackground
         }
     }
 
     var backgroundColor: UIColor {
-        Colors.appBackground
+        Configuration.Color.Semantic.tableViewCellBackground
     }
 
     var titleTextColor: UIColor {
-        R.color.black()!
+        Configuration.Color.Semantic.defaultForegroundText
     }
 
     var title: NSAttributedString {
@@ -159,11 +159,11 @@ struct DefaultActivityCellViewModel {
 
         switch activity.state {
         case .pending:
-            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: R.color.black()!])
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: Configuration.Color.Semantic.defaultForegroundText])
         case .completed:
-            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: R.color.black()!])
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: Configuration.Color.Semantic.defaultForegroundText])
         case .failed:
-            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: R.color.silver()!, .strikethroughStyle: NSUnderlineStyle.single.rawValue])
+            return NSAttributedString(string: string, attributes: [.font: Fonts.semibold(size: 17), .foregroundColor: Configuration.Color.Semantic.textViewFailed, .strikethroughStyle: NSUnderlineStyle.single.rawValue])
         }
     }
 
@@ -172,7 +172,7 @@ struct DefaultActivityCellViewModel {
     }
 
     var timestampColor: UIColor {
-        R.color.dove()!
+        Configuration.Color.Semantic.defaultSubtitleText
     }
     private static let formatter: DateFormatter = Date.formatter(with: "dd MMM yyyy h:mm:ss a")
     var timestamp: String {

--- a/AlphaWallet/Activities/ViewModels/GroupActivityCellViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/GroupActivityCellViewModel.swift
@@ -11,15 +11,15 @@ struct GroupActivityCellViewModel {
     let groupType: GroupType
 
     var contentsBackgroundColor: UIColor {
-        GroupedTable.Color.background
+        Configuration.Color.Semantic.tableViewCellBackground
     }
 
     var backgroundColor: UIColor {
-        GroupedTable.Color.background
+        Configuration.Color.Semantic.tableViewCellBackground
     }
 
     var titleTextColor: UIColor {
-        R.color.black()!
+        Configuration.Color.Semantic.defaultForegroundText
     }
 
     var title: NSAttributedString {

--- a/AlphaWallet/Activities/Views/ActivitiesView.swift
+++ b/AlphaWallet/Activities/Views/ActivitiesView.swift
@@ -44,6 +44,7 @@ class ActivitiesView: UIView {
         tableView.dataSource = self
         tableView.separatorStyle = .singleLine
         tableView.backgroundColor = viewModel.backgroundColor
+        tableView.separatorColor = viewModel.separatorColor
         tableView.estimatedRowHeight = Metrics.anArbitraryRowHeightSoAutoSizingCellsWorkIniOS10
 
         addSubview(tableView)

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -81,6 +81,19 @@ struct Configuration {
                 return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.dusty()!)
             }
 
+            static let periodButtonSelectedText = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
+            }
+            static let periodButtonSelectedBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: .darkGray, darkColor: .lightGray)
+            }
+            static let periodButtonNormalText = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.cod()!, darkColor: R.color.white()!)
+            }
+            static let periodButtonNormalBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
+            }
+
             static let labelTextActive = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.mine()!, darkColor: R.color.white()!)
             }
@@ -213,6 +226,18 @@ struct Configuration {
 
             static let shadow = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
+            }
+
+            static let sendingState = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.solitude()!, darkColor: R.color.bali()!)
+            }
+
+            static let pendingState = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.cheese()!, darkColor: R.color.ocean()!)
+            }
+            
+            static let textViewFailed = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.silver()!, darkColor: R.color.porcelain()!)
             }
         }
     }

--- a/AlphaWallet/Resources/Assets.xcassets/bali.colorset/Contents.json
+++ b/AlphaWallet/Resources/Assets.xcassets/bali.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xF3",
-          "red" : "0xE6"
+          "blue" : "0xB8",
+          "green" : "0xA3",
+          "red" : "0x8A"
         }
       },
       "idiom" : "universal"

--- a/AlphaWallet/Resources/Assets.xcassets/cheese.colorset/Contents.json
+++ b/AlphaWallet/Resources/Assets.xcassets/cheese.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xF3",
-          "red" : "0xE6"
+          "blue" : "0x73",
+          "green" : "0xCA",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/AlphaWallet/Resources/Assets.xcassets/ocean.colorset/Contents.json
+++ b/AlphaWallet/Resources/Assets.xcassets/ocean.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0xFF",
-          "green" : "0xF3",
-          "red" : "0xE6"
+          "green" : "0x68",
+          "red" : "0x32"
         }
       },
       "idiom" : "universal"

--- a/AlphaWallet/Resources/Assets.xcassets/porcelain.colorset/Contents.json
+++ b/AlphaWallet/Resources/Assets.xcassets/porcelain.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
+          "blue" : "0xF4",
           "green" : "0xF3",
-          "red" : "0xE6"
+          "red" : "0xF0"
         }
       },
       "idiom" : "universal"

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/FungibleTokenHeaderViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/FungibleTokenHeaderViewModel.swift
@@ -41,7 +41,7 @@ final class FungibleTokenHeaderViewModel {
 
     var server: RPCServer { return transactionType.tokenObject.server }
     var backgroundColor: UIColor {
-        return Screen.TokenCard.Color.background
+        return Configuration.Color.Semantic.defaultViewBackground
     }
     var iconImage: Subscribable<TokenImage> {
         transactionType.tokenObject.icon(withSize: .s300)
@@ -119,7 +119,7 @@ final class FungibleTokenHeaderViewModel {
     private var testnetValueHintLabelAttributedString: NSAttributedString {
         return NSAttributedString(string: R.string.localizable.tokenValueTestnetWarning(), attributes: [
             .font: Screen.TokenCard.Font.placeholderLabel,
-            .foregroundColor: R.color.dove()!
+            .foregroundColor: Configuration.Color.Semantic.defaultSubtitleText
         ])
     }
 
@@ -150,7 +150,7 @@ final class FungibleTokenHeaderViewModel {
         }()
         return NSAttributedString(string: string, attributes: [
             .font: Screen.TokenCard.Font.placeholderLabel,
-            .foregroundColor: R.color.dove()!
+            .foregroundColor: Configuration.Color.Semantic.defaultSubtitleText
         ])
     }
 
@@ -165,7 +165,7 @@ final class FungibleTokenHeaderViewModel {
 
         let mutableAttributedString = NSMutableAttributedString(string: string, attributes: [
             .font: Screen.TokenCard.Font.placeholderLabel,
-            .foregroundColor: R.color.dove()!
+            .foregroundColor: Configuration.Color.Semantic.defaultSubtitleText
         ])
 
         let range = NSRange(valuePercentageChangeRange, in: string)
@@ -192,7 +192,7 @@ final class FungibleTokenHeaderViewModel {
     private func asTitleAttributedString(_ title: String) -> NSAttributedString {
         return NSAttributedString(string: title, attributes: [
             .font: Fonts.regular(size: ScreenChecker().isNarrowScreen ? 26 : 36),
-            .foregroundColor: Colors.black
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText
         ])
     }
 

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/TokenAttributeViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/TokenAttributeViewModel.swift
@@ -19,7 +19,7 @@ struct TokenAttributeViewModel: Equatable {
     private let title: String?
     let value: String?
     var attributedValue: NSAttributedString?
-    var separatorColor: UIColor = R.color.mercury()!
+    var separatorColor: UIColor = Configuration.Color.Semantic.tableViewSeparator
     var isSeparatorHidden: Bool = false
     var valueLabelNumberOfLines: Int = 0
 
@@ -42,19 +42,19 @@ struct TokenAttributeViewModel: Equatable {
     }
 
     static func defaultTitleAttributedString(_ value: String, alignment: NSTextAlignment = .left, lineBreakMode: NSLineBreakMode = .byTruncatingTail) -> NSAttributedString {
-        attributedString(value, alignment: alignment, font: Fonts.regular(size: 15), foregroundColor: R.color.dove()!, lineBreakMode: lineBreakMode)
+        attributedString(value, alignment: alignment, font: Fonts.regular(size: 15), foregroundColor: Configuration.Color.Semantic.defaultSubtitleText, lineBreakMode: lineBreakMode)
     }
 
     static func defaultValueAttributedString(_ value: String, alignment: NSTextAlignment = .right, lineBreakMode: NSLineBreakMode = .byTruncatingTail) -> NSAttributedString {
-        attributedString(value, alignment: alignment, font: Fonts.regular(size: 17), foregroundColor: Colors.black, lineBreakMode: lineBreakMode)
+        attributedString(value, alignment: alignment, font: Fonts.regular(size: 17), foregroundColor: Configuration.Color.Semantic.defaultForegroundText, lineBreakMode: lineBreakMode)
     }
 
     static func urlValueAttributedString(_ value: String, alignment: NSTextAlignment = .right, lineBreakMode: NSLineBreakMode = .byTruncatingTail) -> NSAttributedString {
-        attributedString(value, alignment: alignment, font: Fonts.semibold(size: 17), foregroundColor: Colors.appTint, lineBreakMode: lineBreakMode)
+        attributedString(value, alignment: alignment, font: Fonts.semibold(size: 17), foregroundColor: Configuration.Color.Semantic.defaultAttributedString, lineBreakMode: lineBreakMode)
     }
 
     static func boldValueAttributedString(_ value: String, alignment: NSTextAlignment = .right, lineBreakMode: NSLineBreakMode = .byTruncatingTail) -> NSAttributedString {
-        attributedString(value, alignment: alignment, font: Screen.TokenCard.Font.valueChangeValue, foregroundColor: Colors.black, lineBreakMode: lineBreakMode)
+        attributedString(value, alignment: alignment, font: Screen.TokenCard.Font.valueChangeValue, foregroundColor: Configuration.Color.Semantic.defaultForegroundText, lineBreakMode: lineBreakMode)
     }
 
     static func attributedString(_ value: String, alignment: NSTextAlignment, font: UIFont, foregroundColor: UIColor, lineBreakMode: NSLineBreakMode) -> NSAttributedString {

--- a/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
+++ b/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
@@ -42,7 +42,7 @@ class TokenHistoryChartView: UIView {
         let chartView = LineChartView()
 
         chartView.translatesAutoresizingMaskIntoConstraints = false
-        chartView.backgroundColor = .white
+        chartView.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
         chartView.drawGridBackgroundEnabled = false
         chartView.drawBordersEnabled = false
 

--- a/AlphaWallet/Tokens/Collectibles/Views/TokenInfoHeaderView.swift
+++ b/AlphaWallet/Tokens/Collectibles/Views/TokenInfoHeaderView.swift
@@ -17,7 +17,7 @@ struct TokenInfoHeaderViewModel {
     var attributedTitle: NSAttributedString {
         return .init(string: title, attributes: [
             .font: Fonts.bold(size: 24),
-            .foregroundColor: Colors.black
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText
         ])
     }
 }

--- a/AlphaWallet/Tokens/Collectibles/Views/TokenInfoPageView.swift
+++ b/AlphaWallet/Tokens/Collectibles/Views/TokenInfoPageView.swift
@@ -49,7 +49,7 @@ class TokenInfoPageView: ScrollableStackView, PageViewType {
             switch each {
             case .testnet:
                 stackView.addArrangedSubview(UIView.spacer(height: 40))
-                stackView.addArrangedSubview(UIView.spacer(backgroundColor: R.color.mike()!))
+                stackView.addArrangedSubview(UIView.spacer(backgroundColor: Configuration.Color.Semantic.tableViewSeparator))
 
                 let view = TestnetTokenInfoView()
                 view.configure(viewModel: .init())
@@ -59,7 +59,7 @@ class TokenInfoPageView: ScrollableStackView, PageViewType {
                 stackView.addArrangedSubview(chartView)
 
                 stackView.addArrangedSubview(UIView.spacer(height: 10))
-                stackView.addArrangedSubview(UIView.spacer(backgroundColor: R.color.mike()!))
+                stackView.addArrangedSubview(UIView.spacer(backgroundColor: Configuration.Color.Semantic.tableViewSeparator))
                 stackView.addArrangedSubview(UIView.spacer(height: 10))
             case .field(let viewModel):
                 let indexPath = IndexPath(row: 0, section: 0)

--- a/AlphaWallet/Transactions/ViewModels/TransactionRowCellViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionRowCellViewModel.swift
@@ -55,7 +55,7 @@ struct TransactionRowCellViewModel {
     }
 
     var titleTextColor: UIColor {
-        return Colors.appText
+        return Configuration.Color.Semantic.defaultForegroundText
     }
 
     var title: String {
@@ -105,9 +105,9 @@ struct TransactionRowCellViewModel {
     var contentsBackgroundColor: UIColor {
         switch transactionRow.state {
         case .completed, .error, .unknown, .failed:
-            return .white
+            return Configuration.Color.Semantic.defaultViewBackground
         case .pending:
-            return Colors.veryLightOrange
+            return Configuration.Color.Semantic.pendingState
         }
     }
 


### PR DESCRIPTION
Main wallet tab > Ethereum 



From created Wallet
Before PR | Light mode | Dark mode
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 12 24 50 copy 2](https://user-images.githubusercontent.com/1050309/194467606-267a674a-7303-4d3f-b1d1-5066ed32737c.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 10 39 56 copy 2](https://user-images.githubusercontent.com/1050309/194462195-c213d93b-a1f0-4b63-a1a6-062c70a7a25c.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 10 42 50 copy 2](https://user-images.githubusercontent.com/1050309/194461824-d2e3e450-a2f4-404b-b2bf-a6e01d4d785c.png)

From watched Wallet
Before PR | Light mode | Dark mode
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 12 20 58 copy 2](https://user-images.githubusercontent.com/1050309/194467861-45627b2f-c167-42e9-91b5-6a63bc8d8648.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 10 41 03 copy 2](https://user-images.githubusercontent.com/1050309/194462074-a9cca31f-eb4d-45e9-9683-46b17b2de14e.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 10 41 09 copy 2](https://user-images.githubusercontent.com/1050309/194462316-8a7f0c31-dd55-4f71-add9-6dcfb5a568e5.png)

From created Wallet
Before PR | Light mode | Dark mode
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 12 28 54 copy 2](https://user-images.githubusercontent.com/1050309/194468721-6f06ce7c-12ae-48d6-b151-3bfa65903aed.png) |  ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 12 33 33 copy 2](https://user-images.githubusercontent.com/1050309/194468737-4e88787c-6c73-4931-b402-0ef6db0485a9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-07 at 12 34 54 copy 2](https://user-images.githubusercontent.com/1050309/194468766-701c33ca-1a35-4a80-8e28-b8e3a262bdcf.png)

Push button animation below:

![Simulator Screen Recording - iPhone 14 Pro - 2022-10-07 at 10 39 40](https://user-images.githubusercontent.com/1050309/194462374-9e0ad2bb-91e8-48c1-a428-5d0cc3cef584.gif)

