### PR TITLE
Improve/fix ERC1155 NFT auto-detection

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		5E7C79DC5BDC391C983B6CAC /* ChainIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78DB6F47344EBBC2567F /* ChainIdTests.swift */; };
 		5E7C79E9A6A3DFB7FA680752 /* DappViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C793CDFA907BFDFECB6CB /* DappViewCell.swift */; };
 		5E7C79EB8A6EC89F6F033268 /* CreateInitialWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74A5B5B9D8AD0BD913C1 /* CreateInitialWalletViewController.swift */; };
+		5E7C7A0D678C2CE065CC8BB1 /* Erc1155TokenIdsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C719EC2B8B381C56F8440 /* Erc1155TokenIdsFetcherTests.swift */; };
 		5E7C7A4384A8E3F22D3F8249 /* SetSellTokensCardExpiryDateViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C700CD3E43689E88FBE9B /* SetSellTokensCardExpiryDateViewControllerViewModel.swift */; };
 		5E7C7A4700C79350AA486E09 /* SeedPhraseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C791C60E8AAF3F4239375 /* SeedPhraseCell.swift */; };
 		5E7C7A496E69849D06DF2731 /* AssetDefinitionStoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7D58E7A5DE05425623D2 /* AssetDefinitionStoreCoordinator.swift */; };
@@ -1054,6 +1055,7 @@
 		5E7C7171B802C0C2718EEED0 /* MyDappsViewControllerHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyDappsViewControllerHeaderView.swift; sourceTree = "<group>"; };
 		5E7C7177F1DDDDDDE020CB4D /* ChooseSendPrivateTransactionsProviderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChooseSendPrivateTransactionsProviderViewController.swift; sourceTree = "<group>"; };
 		5E7C717B39E95B653F384AA0 /* SeedPhraseCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedPhraseCellViewModel.swift; sourceTree = "<group>"; };
+		5E7C719EC2B8B381C56F8440 /* Erc1155TokenIdsFetcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Erc1155TokenIdsFetcherTests.swift; sourceTree = "<group>"; };
 		5E7C71A8BE594C1D126AB309 /* FakeEventsDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeEventsDataStore.swift; sourceTree = "<group>"; };
 		5E7C71ADDDAB65DEF4096A8D /* PromptViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromptViewController.swift; sourceTree = "<group>"; };
 		5E7C71C2C110B621EFDE336F /* TokensCardViewControllerTitleHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensCardViewControllerTitleHeader.swift; sourceTree = "<group>"; };
@@ -2798,6 +2800,14 @@
 			path = OpenSea;
 			sourceTree = "<group>";
 		};
+		5E7C733DEBED923B8D281682 /* Tokens */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C7CC82D5F600655CF9FA7 /* Logic */,
+			);
+			path = Tokens;
+			sourceTree = "<group>";
+		};
 		5E7C73525655EA2FFC74E66B /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -3060,6 +3070,7 @@
 				5E7C7B8EB45ABD915B9BFF61 /* LocalPopularTokensCollectionTests.swift */,
 				5E7C7219AA7DCFFA11F4139D /* CoinTicker */,
 				8722324528D8607F001A9BCC /* Oneinch */,
+				5E7C733DEBED923B8D281682 /* Tokens */,
 			);
 			path = AlphaWalletFoundation;
 			sourceTree = "<group>";
@@ -3160,6 +3171,14 @@
 				872A98652862EC0C00196EA3 /* base64_image_example.txt */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		5E7C7CC82D5F600655CF9FA7 /* Logic */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C719EC2B8B381C56F8440 /* Erc1155TokenIdsFetcherTests.swift */,
+			);
+			path = Logic;
 			sourceTree = "<group>";
 		};
 		5E7C7D3F20599F40EC05F8DF /* Views */ = {
@@ -4429,7 +4448,7 @@
 			packageReferences = (
 				87FBF2AF28056AC200616B7D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				87BDF46E28423DC30018DC68 /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
-				87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */,
+				87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */,
 			);
 			productRefGroup = 2912CCF61F6A830700C6CBE3 /* Products */;
 			projectDirPath = "";
@@ -5608,6 +5627,7 @@
 				5E7C787EB90D113DA76574DD /* FileTokenEntriesProviderTests.swift in Sources */,
 				5E7C79DC5BDC391C983B6CAC /* ChainIdTests.swift in Sources */,
 				5E7C74B9BD63DEFE074BB80D /* ErrorTests.swift in Sources */,
+				5E7C7A0D678C2CE065CC8BB1 /* Erc1155TokenIdsFetcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6153,7 +6173,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */ = {
+		87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AlphaWallet/WalletConnectSwift.git";
 			requirement = {
@@ -6182,7 +6202,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		87B1B5D828C73C170072A5E2 /* WalletConnectSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */;
+			package = 87B1B5D728C73C170072A5E2 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */;
 			productName = WalletConnectSwift;
 		};
 		87BDF46F28423DC30018DC68 /* WalletConnect */ = {

--- a/AlphaWalletTests/modules/AlphaWalletFoundation/Tokens/Logic/Erc1155TokenIdsFetcherTests.swift
+++ b/AlphaWalletTests/modules/AlphaWalletFoundation/Tokens/Logic/Erc1155TokenIdsFetcherTests.swift
@@ -1,0 +1,55 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import XCTest
+@testable import AlphaWalletFoundation
+
+class Erc1155TokenIdsFetcherTests: XCTestCase {
+    func testCombinedBlockNumbersProcessed() {
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [], newEntry: (0, 10)), [0..<11])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [0..<2], newEntry: (0, 10)), [0..<11])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [0..<2, 4..<6], newEntry: (0, 10)), [0..<11])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [0..<2, 4..<6], newEntry: (2, 10)), [0..<11])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [0..<2, 4..<6, 9..<10], newEntry: (2, 10)), [0..<11])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [0..<2, 4..<6, 9..<10], newEntry: (2, 20)), [0..<21])
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [1..<2, 4..<6, 9..<10], newEntry: (2, 20)), [1..<21])
+        ////Catch up, so new entry is not at the end
+        XCTAssertEqual(Erc1155TokenIdsFetcher.functional.combinedBlockNumbersProcessed(old: [1..<2, 6..<8], newEntry: (4, 5)), [1..<2, 4..<8])
+    }
+
+    func testMakeBlockRangeToCatchUpForOlderEvents() {
+        //Test not done anything yet. Don't bother catching up
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: []) == nil)
+
+        //Test caught up
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: [0..<1]) == nil)
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: [0..<2]) == nil)
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: [0..<10]) == nil)
+
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: [0..<10, 15..<20])! == (13, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 2, excludingRanges: [15..<20])! == (13, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 5, excludingRanges: [8..<9, 15..<20])! == (10, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 5, excludingRanges: [1..<2, 8..<9,  15..<20])! == (10, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 1, excludingRanges: [1..<2, 8..<9, 15..<20])! == (14, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 6, excludingRanges: [1..<2, 8..<9, 15..<20])! == (9, 14))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: 15, excludingRanges: [0..<10, 15..<20])! == (10, 14))
+
+        //Test no maximum window size
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeToCatchUpForOlderEvents(maximumWindow: nil, excludingRanges: [0..<10, 15..<20])! == (10, 14))
+    }
+
+    func testMakeBlockRangeForEvents() {
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: 2, excludingRanges: [0..<2]) == (9, 10))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: 2, excludingRanges: [0..<10]) == (10, 10))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 24, maximumWindow: 2, excludingRanges: [0..<10, 15..<20]) == (23, 24))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 22, maximumWindow: 2, excludingRanges: [0..<10, 15..<20]) == (21, 22))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 21, maximumWindow: 2, excludingRanges: [0..<10, 15..<20]) == (20, 21))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 20, maximumWindow: 2, excludingRanges: [0..<10, 15..<20]) == (20, 20))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 20, maximumWindow: 2, excludingRanges: []) == (19, 20))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: 4, excludingRanges: [0..<5]) == (7, 10))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: 20, excludingRanges: [0..<5]) == (5, 10))
+
+        //Test no maximum window size
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: nil, excludingRanges: [0..<2]) == (2, 10))
+        XCTAssert(Erc1155TokenIdsFetcher.functional.makeBlockRangeForEvents(toBlockNumber: 10, maximumWindow: nil, excludingRanges: [0..<5]) == (5, 10))
+    }
+}

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
@@ -783,7 +783,7 @@ public enum RPCServer: Hashable, CaseIterable {
         }
     }
 
-    private var maximumBlockRangeForEvents: UInt64? {
+    var maximumBlockRangeForEvents: UInt64? {
         switch self {
         case .binance_smart_chain, .binance_smart_chain_testnet, .heco, .heco_testnet:
             //These do not allow range more than 5000

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/NonFungibleErc1155JsonBalanceFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/NonFungibleErc1155JsonBalanceFetcher.swift
@@ -40,17 +40,14 @@ public class NonFungibleErc1155JsonBalanceFetcher {
     }
 
     public func fetchErc1155NonFungibleJsons(enjinTokens: EnjinTokenIdsToSemiFungibles) -> Promise<[AlphaWallet.Address: [NonFungibleBalanceAndItsSource<NonFungibleFromTokenUri>]]> {
-        //Local copies so we don't access the wrong ones during async operation
-
         return firstly {
             erc1155TokenIdsFetcher.detectContractsAndTokenIds()
-        }.then(on: queue, { contractsAndTokenIds in
+        }.then(on: queue, { contractsAndTokenIds -> Promise<Erc1155TokenIds.ContractsAndTokenIds> in
             self.addUnknownErc1155ContractsToDatabase(contractsAndTokenIds: contractsAndTokenIds.tokens)
         }).then(on: queue, { contractsAndTokenIds -> Promise<(contractsAndTokenIds: Erc1155TokenIds.ContractsAndTokenIds, tokenIdMetaDatas: [TokenIdMetaData])> in
-                self._fetchErc1155NonFungibleJsons(contractsAndTokenIds: contractsAndTokenIds, enjinTokens: enjinTokens)
-                    .map { (contractsAndTokenIds: contractsAndTokenIds, tokenIdMetaDatas: $0) }
+            self._fetchErc1155NonFungibleJsons(contractsAndTokenIds: contractsAndTokenIds, enjinTokens: enjinTokens)
+                .map { (contractsAndTokenIds: contractsAndTokenIds, tokenIdMetaDatas: $0) }
         }).then(on: queue, { [erc1155BalanceFetcher, queue] (contractsAndTokenIds, tokenIdMetaDatas) -> Promise<[AlphaWallet.Address: [NonFungibleBalanceAndItsSource<NonFungibleFromTokenUri>]]> in
-
             let contractsToTokenIds: [AlphaWallet.Address: [BigInt]] = contractsAndTokenIds
                 .mapValues { tokenIds -> [BigInt] in tokenIds.compactMap { BigInt($0) } }
 
@@ -77,6 +74,7 @@ public class NonFungibleErc1155JsonBalanceFetcher {
                 return contractToOpenSeaNonFungiblesWithUpdatedBalances
             })
         })
+
         //TODO: log error remotely
     }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/WalletBalance/TokenBalanceFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/WalletBalance/TokenBalanceFetcher.swift
@@ -34,7 +34,7 @@ public class TokenBalanceFetcher: TokenBalanceFetcherType {
 
     private lazy var nonErc1155BalanceFetcher: TokenProviderType = session.tokenProvider
     private lazy var nonFungibleJsonBalanceFetcher = NonFungibleJsonBalanceFetcher(server: session.server, tokensService: tokensService, queue: queue)
-    private lazy var erc1155TokenIdsFetcher = Erc1155TokenIdsFetcher(address: session.account.address, server: session.server, config: session.config, queue: queue)
+    private lazy var erc1155TokenIdsFetcher = Erc1155TokenIdsFetcher(analytics: analytics, session: session, server: session.server, config: session.config)
     private lazy var erc1155BalanceFetcher = Erc1155BalanceFetcher(address: session.account.address, server: session.server)
     private lazy var erc1155JsonBalanceFetcher: NonFungibleErc1155JsonBalanceFetcher = {
         return NonFungibleErc1155JsonBalanceFetcher(assetDefinitionStore: assetDefinitionStore, analytics: analytics, tokensService: tokensService, account: session.account, server: session.server, erc1155TokenIdsFetcher: erc1155TokenIdsFetcher, nonFungibleJsonBalanceFetcher: nonFungibleJsonBalanceFetcher, erc1155BalanceFetcher: erc1155BalanceFetcher, queue: queue)
@@ -43,7 +43,7 @@ public class TokenBalanceFetcher: TokenBalanceFetcherType {
     private let etherToken: Token
 
     weak public var delegate: TokenBalanceFetcherDelegate?
-    weak public var erc721TokenIdsFetcher: Erc721TokenIdsFetcher? 
+    weak public var erc721TokenIdsFetcher: Erc721TokenIdsFetcher?
 
     public init(session: WalletSession, nftProvider: NFTProvider, tokensService: TokenProvidable & TokenAddable, etherToken: Token, assetDefinitionStore: AssetDefinitionStore, analytics: AnalyticsLogger, queue: DispatchQueue) {
         self.session = session


### PR DESCRIPTION
Closes #5462

A chain with short blocktimes and limit on eventlog fetching window like Polygon (~2 seconds + 3500 window) means that fetching events starting from block 0 could take a long time before reaching the current block. As of writing it could take > 6 days of the app running for it to catch up for a fresh install. So ERC1155s will not show up.

With this PR, we always do these 2 steps in a refresh cycle:

A. Fetch start from the latest block (capped by the maximum eventlog window if there is one)
B. then, catch up with the newest window that we haven't fetched

So while we might not detect all the tokens immediately (if there is a eventlog window cap), we will usually be able to fetch recent tokens fairly soon and catch up with older ones. Note that ERC1155 fetching has always been 2-step:

1. Fetch contracts + token IDs
2. Fetch balance for each token ID

So as long as we know the contract + token ID (which is improved with this PR), we will get the balance for that contract + token ID combo (separately).

In the future, we might be more aggressive with step B, leaving step A to just fetch 1 window with each refresh

---

@oa-s I've modified a little how the internal queue is used in `Erc1155TokenIdsFetcher` and I think it should be a good reference. There's this:

```
extension Erc1155TokenIdsFetcher.functional {
    //This is only for development purposes to keep the PromiseKit `Resolver`(s) from being deallocated when they aren't resolved so PromiseKit don't show a warning and create noise and confusion
    private static var fetchEventsPromiseKitResolversKeptForDevelopmentFeatureFlagOnly: [Resolver<[Erc1155TransferEvent]>] = .init()

    private static let queue: DispatchQueue = .global(qos: .utility)
```

We do all work explictly on `.main` in the file and only few select things in `queue` (which is `.utility`). The `queue` is managed by `Erc1155TokenIdsFetcher` only, not passed in and not accessible from outside. We *could* expand it so that a module (possible few files within an inhouse pod) shares the same queue, but same thing, never passed around, and not accessible from outside. Output from functions are always dispatched on `.main` to the callers outside.

This seems like a good balance of speed and tidiness? What do you think @oa-s?
