### PR TITLE
Removed —repo-update option in pod install command which causes errors when switching between Xcode 13.x and 14.x.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install_gems: check_bundle setup_path
 	fi
 
 install_pods: check_gems
-	@$(bundle_cmd) exec pod install --repo-update; \
+	@$(bundle_cmd) exec pod install; \
 	if [ $$? -eq 0 ]; then \
 		echo "All pods installed."; \
 	else \


### PR DESCRIPTION
Removed --repo-update option in cocoa pods install command. 