### PR TITLE
Added dark mode to ActivityViewController

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivityViewController.swift
@@ -162,7 +162,7 @@ class ActivityViewController: UIViewController {
         titleLabel.textAlignment = .center
         subTitleLabel.textAlignment = .center
 
-        separator.backgroundColor = GroupedTable.Color.cellSeparator
+        separator.backgroundColor = Configuration.Color.Semantic.tableViewSeparator
 
         switch viewModel.activity.nativeViewType {
         case .erc20Received, .erc20Sent, .erc20OwnerApproved, .erc20ApprovalObtained, .erc721Sent, .erc721Received, .erc721OwnerApproved, .erc721ApprovalObtained, .nativeCryptoSent, .nativeCryptoReceived:

--- a/AlphaWallet/Activities/ViewModels/ActivityViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/ActivityViewModel.swift
@@ -17,11 +17,11 @@ struct ActivityViewModel {
     }
 
     var backgroundColor: UIColor {
-        Screen.TokenCard.Color.background
+        Configuration.Color.Semantic.defaultViewBackground
     }
 
     var titleTextColor: UIColor {
-        R.color.black()!
+        Configuration.Color.Semantic.defaultTitleText
     }
 
     var titleFont: UIFont {
@@ -99,7 +99,7 @@ struct ActivityViewModel {
     }
 
     var subTitleTextColor: UIColor {
-        R.color.dove()!
+        Configuration.Color.Semantic.defaultSubtitleText
     }
 
     var subTitleFont: UIFont {
@@ -111,7 +111,7 @@ struct ActivityViewModel {
     }
 
     var timestampColor: UIColor {
-        R.color.dove()!
+        Configuration.Color.Semantic.defaultSubtitleText
     }
 
     var timestamp: String {

--- a/AlphaWallet/Activities/ViewModels/DefaultActivityViewModel.swift
+++ b/AlphaWallet/Activities/ViewModels/DefaultActivityViewModel.swift
@@ -16,11 +16,11 @@ struct DefaultActivityViewModel {
     let activity: Activity
 
     var contentsBackgroundColor: UIColor {
-        .white
+        Configuration.Color.Semantic.defaultViewBackground
     }
 
     var backgroundColor: UIColor {
-        Colors.appBackground
+        Configuration.Color.Semantic.defaultViewBackground
     }
 
     var amount: NSAttributedString {
@@ -66,9 +66,9 @@ struct DefaultActivityViewModel {
 
         switch activity.state {
         case .pending:
-            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28), .foregroundColor: R.color.black()!])
+            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28), .foregroundColor: Configuration.Color.Semantic.defaultForegroundText])
         case .completed:
-            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28), .foregroundColor: R.color.black()!])
+            return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28), .foregroundColor: Configuration.Color.Semantic.defaultForegroundText])
         case .failed:
             return NSAttributedString(string: string, attributes: [.font: Fonts.regular(size: 28), .foregroundColor: R.color.silver()!, .strikethroughStyle: NSUnderlineStyle.single.rawValue])
         }


### PR DESCRIPTION
In main wallet tab, tap `ETH (Goerli) > Activity tab > Any display activity row`.

Before PR | Light mode | Dark mode
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-13 at 11 01 48 copy](https://user-images.githubusercontent.com/1050309/195492022-96885992-03ec-4a2b-b039-a7dc9e741595.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-10-13 at 10 48 12 copy](https://user-images.githubusercontent.com/1050309/195492044-58877386-06d8-4f2e-a03b-0dda66bd3d5e.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-10-13 at 10 48 15 copy](https://user-images.githubusercontent.com/1050309/195492053-467f0fce-0f89-402a-88c4-74ebbc31ee02.png)
