### PR TITLE
Track number of API calls made while running in simulator

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -4430,7 +4430,7 @@
 			packageReferences = (
 				87FBF2AF28056AC200616B7D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				87BDF46E28423DC30018DC68 /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
-				877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */,
+				877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */,
 			);
 			productRefGroup = 2912CCF61F6A830700C6CBE3 /* Products */;
 			projectDirPath = "";
@@ -4644,6 +4644,7 @@
 				"${BUILT_PRODUCTS_DIR}/AlphaWalletFoundation/AlphaWalletFoundation.framework",
 				"${BUILT_PRODUCTS_DIR}/AlphaWalletGoBack/AlphaWalletGoBack.framework",
 				"${BUILT_PRODUCTS_DIR}/AlphaWalletOpenSea/AlphaWalletOpenSea.framework",
+				"${BUILT_PRODUCTS_DIR}/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls.framework",
 				"${BUILT_PRODUCTS_DIR}/AlphaWalletWeb3/AlphaWalletWeb3.framework",
 				"${BUILT_PRODUCTS_DIR}/Apollo/Apollo.framework",
 				"${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework",
@@ -4690,6 +4691,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlphaWalletFoundation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlphaWalletGoBack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlphaWalletOpenSea.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlphaWalletTrackAPICalls.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AlphaWalletWeb3.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Apollo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BigInt.framework",
@@ -6149,7 +6151,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */ = {
+		877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AlphaWallet/WalletConnectSwift.git";
 			requirement = {
@@ -6178,7 +6180,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		877239CD28F806820062DC14 /* WalletConnectSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */;
+			package = 877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */;
 			productName = WalletConnectSwift;
 		};
 		87BDF46F28423DC30018DC68 /* WalletConnect */ = {

--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -5,6 +5,7 @@ import UIKit
 import PromiseKit
 import AlphaWalletCore
 import AlphaWalletFoundation
+import AlphaWalletTrackAPICalls
 
 extension TokenScript {
     static let baseTokenScriptFiles: [TokenType: String] = [
@@ -166,6 +167,11 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     func start() {
+        //Want to start as soon as possible
+        if AlphaWallet.Device.isSimulator {
+            TrackApiCalls.shared.start()
+        }
+
         if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
             Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
                 infoLog("Ticker ID positive matching counts: \(TickerIdFilter.matchCounts)")

--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -1,7 +1,7 @@
 // Copyright SIX DAY LLC. All rights reserved.
 import UIKit
 import AlphaWalletAddress
-import AlphaWalletFoundation 
+import AlphaWalletFoundation
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/AlphaWalletTrackAPICalls.podspec
+++ b/AlphaWalletTrackAPICalls.podspec
@@ -1,0 +1,26 @@
+#
+# Be sure to run `pod lib lint AlphaWalletTrackAPICalls.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'AlphaWalletTrackAPICalls'
+  s.version          = '1.0.0'
+  s.summary          = 'Track API calls'
+  s.description      = 'Track API calls'
+  s.homepage         = "https://github.com/AlphaWallet/alpha-wallet-ios/tree/master/modules/AlphaWalletTrackAPICalls"
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author             = { "Hwee-Boon Yar" => "hboon@motionobj.com" }
+  s.social_media_url   = "https://twitter.com/hboon"
+  s.ios.deployment_target = '13.0'
+  s.swift_version    = '4.2'
+  s.platform         = :ios, "13.0"
+  s.source           = { :git => 'git@github.com:AlphaWallet/alpha-wallet-ios.git', :tag => "#{s.version}" }
+  s.source_files     = 'modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/**/*.{h,m,swift}'
+  s.pod_target_xcconfig = { 'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule' }
+
+  s.frameworks       = 'Foundation'
+end

--- a/Podfile
+++ b/Podfile
@@ -27,6 +27,7 @@ target 'AlphaWallet' do
   pod 'AlphaWalletENS', :path => '.'
   pod 'AlphaWalletOpenSea', :path => '.'
   pod 'AlphaWalletFoundation', :path => '.'
+  pod 'AlphaWalletTrackAPICalls', :path => '.'
   pod 'AlphaWalletWeb3', :path => '.'
   pod 'MailchimpSDK'
   pod 'xcbeautify'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,6 +47,7 @@ PODS:
     - AlphaWalletCore
     - PromiseKit
     - SwiftyJSON (= 5.0.0)
+  - AlphaWalletTrackAPICalls (1.0.0)
   - AlphaWalletWeb3 (0.0.1):
     - BigInt
     - CryptoSwift
@@ -148,6 +149,7 @@ DEPENDENCIES:
   - AlphaWalletFoundation (from `.`)
   - AlphaWalletGoBack (from `.`)
   - AlphaWalletOpenSea (from `.`)
+  - AlphaWalletTrackAPICalls (from `.`)
   - AlphaWalletWeb3 (from `.`)
   - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870`)
   - BigInt (~> 3.1)
@@ -220,6 +222,8 @@ EXTERNAL SOURCES:
     :path: "."
   AlphaWalletOpenSea:
     :path: "."
+  AlphaWalletTrackAPICalls:
+    :path: "."
   AlphaWalletWeb3:
     :path: "."
   AlphaWalletWeb3Provider:
@@ -281,6 +285,7 @@ SPEC CHECKSUMS:
   AlphaWalletFoundation: 8251d9a334f219b89530659b0baadc0b92552a9b
   AlphaWalletGoBack: 1d55b51e6cfd999740d3cfab09d9fa723ba85ff2
   AlphaWalletOpenSea: 71e255612529b04ae4d66dca54bd181185593b1d
+  AlphaWalletTrackAPICalls: 1e5d1f0a1858bd4d383aa412677a642be7d21e17
   AlphaWalletWeb3: 86d0be33c612d75685a5797ef4492e42c295f1a5
   AlphaWalletWeb3Provider: 7ca1e1c1dc841dc1915f970daace48bf34931655
   APIKit: 9e1a4069608bf0ae5238811e6cfc26928ad4d01e
@@ -323,6 +328,6 @@ SPEC CHECKSUMS:
   TrustWalletCore: a92d85baa15932279cce925559e93695558cafdd
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: 6cb9ad60a47bfeda81717db008a3a752788806e1
+PODFILE CHECKSUM: c4183e373b5193db637d4e89857271582bbf138e
 
 COCOAPODS: 1.11.3

--- a/modules/AlphaWalletTrackAPICalls/.gitignore
+++ b/modules/AlphaWalletTrackAPICalls/.gitignore
@@ -1,0 +1,98 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Ignore when build
+.DS_Store
+.idea
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+xcshareddata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+#R
+*.generated.swift
+
+#Localization
+Trust.zip
+/Trust-Localizable.zip
+/Localizable.strings
+
+
+*.mobileprovision
+
+# VIM
+*.swp
+*.swo
+
+# node
+node_modules
+JS/staging
+
+# FBSnapshotTestCase temporary output files
+AlphaWalletTests/Snapshots/FailureDiffs
+
+# Additions
+.idea/

--- a/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls.h
+++ b/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls.h
@@ -1,0 +1,18 @@
+//
+//  AlphaWalletTrackAPICalls.h
+//  AlphaWalletTrackAPICalls
+//
+//  Created by Vladyslav Shepitko on 11.02.2022.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for AlphaWalletTrackAPICalls.
+FOUNDATION_EXPORT double AlphaWalletTrackAPICallsVersionNumber;
+
+//! Project version string for AlphaWalletTrackAPICalls.
+FOUNDATION_EXPORT const unsigned char AlphaWalletTrackAPICallsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <AlphaWalletTrackAPICalls/PublicHeader.h>
+
+

--- a/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/Logger.swift
+++ b/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/Logger.swift
@@ -1,0 +1,7 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+
+func infoLog(_ message: Any, callerFunctionName: String = #function) {
+    NSLog("\(message) from: \(callerFunctionName)")
+}

--- a/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/TrackApiCalls.swift
+++ b/modules/AlphaWalletTrackAPICalls/AlphaWalletTrackAPICalls/TrackApiCalls.swift
@@ -1,0 +1,77 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+
+//Has a singleton; have to a static interface because of usage in our overridden version of `URLSessionConfiguration.overriddenProtocolClasses()`
+public class TrackApiCalls: URLProtocol {
+    private static let printInterval: TimeInterval = 10
+    private static var counts: [String: Int] = .init()
+    private static var timer: Timer?
+
+    //Just to not expose the static interface to caller
+    public static var shared: TrackApiCalls = .init()
+    public static var isEnabled: Bool = false
+
+    public func start() {
+        guard !Self.isEnabled else { return }
+        swizzle()
+        Self.isEnabled = true
+        Self.timer = Timer.scheduledTimer(withTimeInterval: Self.printInterval, repeats: true) { [weak self] _ in
+            guard let strongSelf = self else { return }
+            let sorted = Self.counts.sorted { $0.value > $1.value }
+            //TODO does this log too much data? especially from `tokenURI()` accesses? Also sorting would be slow if there's many records. Since this is for development, we'll observe
+            infoLog("[TrackApiCalls] (sub)domains accessed: \(sorted.count). Calls for each (sub)domain: \(sorted)")
+        }
+    }
+
+    private func stop() {
+        Self.timer?.invalidate()
+        Self.timer = nil
+        Self.isEnabled = false
+    }
+
+    //This is not required since we are swizzling: `URLProtocol.registerClass(TrafficInterceptor.self)`
+    private func swizzle() {
+        let clazz: AnyClass = URLSessionConfiguration.self
+        let method1 = class_getInstanceMethod(clazz, #selector(getter: clazz.protocolClasses))!
+        let method2 = class_getInstanceMethod(clazz, #selector(URLSessionConfiguration.overriddenProtocolClasses))!
+
+        method_exchangeImplementations(method1, method2)
+    }
+
+    public override func startLoading() {
+        if let domainName = request.url?.host {
+            DispatchQueue.main.async {
+                let old = Self.counts[domainName] ?? 0
+                Self.counts[domainName] = old + 1
+            }
+        }
+    }
+
+    public override func stopLoading() {
+        //no-op
+    }
+
+    public override class func canInit(with task: URLSessionTask) -> Bool {
+        return true
+    }
+
+    public override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+}
+
+extension URLSessionConfiguration {
+    @objc func overriddenProtocolClasses() -> [AnyClass]? {
+        guard let original = self.overriddenProtocolClasses() else { return [] }
+        var results = original.filter { return $0 != TrackApiCalls.self }
+        if TrackApiCalls.isEnabled {
+            results.insert(TrackApiCalls.self, at: 0)
+        }
+        return results
+    }
+}

--- a/modules/AlphaWalletTrackAPICalls/LICENSE
+++ b/modules/AlphaWalletTrackAPICalls/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 AlphaWallet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #5589

Prints something like this every 10 seconds, only when running in simulator:

```
[TrackApiCalls] (sub)domains accessed: 16 Calls for each (sub)domain: [(key: "repo.tokenscript.org", value: 46), (key: "mainnet.infura.io", value: 45), (key: "rpc.ankr.com", value: 28), (key: "polygon-mainnet.infura.io", value: 23), (key: "api-cn.etherscan.com", value: 11), (key: "api.opensea.io", value: 10), (key: "api.polygonscan.com", value: 5), (key: "api.coingecko.com", value: 5), (key: "cloud.enjin.io", value: 5), (key: "blockscout.com", value: 4), (key: "li.quest", value: 2), (key: "api-instant.ramp.network", value: 1), (key: "firebaselogging-pa.googleapis.com", value: 1), (key: "raw.githubusercontent.com", value: 1), (key: "price.phi.network", value: 1), (key: "api.1inch.exchange", value: 1)] from: start()
```

