### PR TITLE
Reduce chance of false-negatively identifying app as running in simulator

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Helpers/Device.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Helpers/Device.swift
@@ -371,7 +371,8 @@ extension AlphaWallet.Device {
             return .pad
         } else if versionCode.starts(with: "iPod") {
             return .pod
-        } else if versionCode == "i386" || versionCode == "x86_64" || versionCode == "arm64" {
+        } else if TARGET_OS_SIMULATOR != 0 {
+            //Original check was: `versionCode == "i386" || versionCode == "x86_64" || versionCode == "arm64"`. But we want this to have no false-negatives since wrongly identifying as simulator can cause certain functionality to be unlocked for production/appstore users
             return .simulator
         }
         return .unknown


### PR DESCRIPTION
Comment explains it:

> //Original check was: `versionCode == "i386" || versionCode == "x86_64" || versionCode == "arm64"`. But we want this to have no false-negatives since wrongly identifying as simulator can cause certain functionality to be unlocked for production/appstore users
