### PR TITLE
Added dark mode to NFTAssetViewController

### DIFF
--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
@@ -40,7 +40,7 @@ class NFTAssetViewModel {
     private (set) var tokenId: TokenId
     private (set) var tokenHolder: TokenHolder
     let assetDefinitionStore: AssetDefinitionStore
-    var backgroundColor: UIColor = Colors.appBackground
+    var backgroundColor: UIColor = Configuration.Color.Semantic.defaultViewBackground
     var transferTransactionType: TransactionType {
         tokenHolder.select(with: .allFor(tokenId: tokenHolder.tokenId))
         return TransactionType(nonFungibleToken: token, tokenHolders: [tokenHolder])
@@ -74,7 +74,7 @@ class NFTAssetViewModel {
 
     var previewViewContentBackgroundColor: UIColor {
         if displayHelper.imageHasBackgroundColor {
-            return Colors.appBackground
+            return Configuration.Color.Semantic.defaultViewBackground
         } else {
             if let color = tokenHolder.values.backgroundColorStringValue.nilIfEmpty {
                 return UIColor(hex: color)


### PR DESCRIPTION
Main wallet tab, tap collectible tab, tap collectible with at least 1 token, tap any row.

1|2|3
-|-|-
![Simulator Screen Shot - iPhone 13 - 2022-10-18 at 22 49 55 copy](https://user-images.githubusercontent.com/1050309/196465192-5d3d636d-605f-4ff0-aa02-5b3c4e2418e3.png)|![Simulator Screen Shot - iPhone 13 - 2022-10-18 at 22 49 58 copy](https://user-images.githubusercontent.com/1050309/196465225-f64fb678-b664-4ae5-b119-0bb56ab5cca8.png)|![Simulator Screen Shot - iPhone 13 - 2022-10-18 at 22 50 00 copy](https://user-images.githubusercontent.com/1050309/196465269-6649de8f-227c-4a81-ac7e-97844b9f7915.png)


Top before commit | Top after commit
-|-
![before-top](https://user-images.githubusercontent.com/1050309/196463191-c72ec755-cf90-4871-8fd2-d541087c28b3.png) | ![after-top](https://user-images.githubusercontent.com/1050309/196463257-fcf060eb-1591-4ca5-a888-889be6feebbb.png)
Bottom before commit | Bottom after commit
![before-bottom](https://user-images.githubusercontent.com/1050309/196463381-5189da2f-4163-4e3c-bd76-959272c3ef7d.png) | ![after-bottom](https://user-images.githubusercontent.com/1050309/196463413-3b495e6a-0133-423f-a4ae-2bf1516e53d8.png)
