### PR TITLE
[DEV] Remove Cocoapods caching with Travis because we are using development pods for our inhouse modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: objective-c
 osx_image: xcode13.3
 cache:
   bundler: true
-  cocoapods: true
 branches:
   only:
     - master


### PR DESCRIPTION
If caching is enabled, adding a file to an existing module doesn't modify `Podfile.lock` and breaks the build on Travis