### PR TITLE
Make `decimals` be stored as `Int` instead of `UInt8`. Latter (to match actual source data in ERC20) seems unnecessary

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -242,7 +242,7 @@ class NewTokenViewController: UIViewController {
         nameTextField.value = name
     }
 
-    public func updateDecimalsValue(_ decimals: UInt8) {
+    public func updateDecimalsValue(_ decimals: Int) {
         decimalsTextField.value = String(decimals)
     }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/TrustClient/Models/RawTransaction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/TrustClient/Models/RawTransaction.swift
@@ -112,7 +112,7 @@ extension TransactionInstance {
                     when(fulfilled: getContractName, getContractSymbol, getDecimals, getTokenType)
                 }.then(on: session.queue, { name, symbol, decimals, tokenType -> Promise<[LocalizedOperationObjectInstance]> in
                     let operationType = mapTokenTypeToTransferOperationType(tokenType, functionCall: functionCall)
-                    let result = LocalizedOperationObjectInstance(from: transaction.from, to: recipient.eip55String, contract: contract, type: operationType.rawValue, value: String(value), tokenId: "", symbol: symbol, name: name, decimals: Int(decimals))
+                    let result = LocalizedOperationObjectInstance(from: transaction.from, to: recipient.eip55String, contract: contract, type: operationType.rawValue, value: String(value), tokenId: "", symbol: symbol, name: name, decimals: decimals)
                     return .value([result])
                 }).recover(on: session.queue, { _ -> Promise<[LocalizedOperationObjectInstance]> in
                     //NOTE: Return an empty array when failure to fetch contracts data, instead of failing whole TransactionInstance creating

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/ContractDataDetector.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/ContractDataDetector.swift
@@ -8,9 +8,9 @@ public enum ContractData {
     case name(String)
     case symbol(String)
     case balance(balance: NonFungibleBalance, tokenType: TokenType)
-    case decimals(UInt8)
+    case decimals(Int)
     case nonFungibleTokenComplete(name: String, symbol: String, balance: NonFungibleBalance, tokenType: TokenType)
-    case fungibleTokenComplete(name: String, symbol: String, decimals: UInt8)
+    case fungibleTokenComplete(name: String, symbol: String, decimals: Int)
     case delegateTokenComplete
     case failed(networkReachable: Bool?)
 }
@@ -23,7 +23,7 @@ public class ContractDataDetector {
     private let symbolPromise: Promise<String>
     private let tokenTypePromise: Promise<TokenType>
     private let (nonFungibleBalancePromise, nonFungibleBalanceSeal) = Promise<NonFungibleBalance>.pending()
-    private let (decimalsPromise, decimalsSeal) = Promise<UInt8>.pending()
+    private let (decimalsPromise, decimalsSeal) = Promise<Int>.pending()
     private var failed = false
     private var completion: ((ContractData) -> Void)?
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/GetContractDecimals.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/GetContractDecimals.swift
@@ -11,11 +11,11 @@ public class GetContractDecimals {
         self.server = server
     }
 
-    public func getDecimals(for contract: AlphaWallet.Address) -> Promise<UInt8> {
+    public func getDecimals(for contract: AlphaWallet.Address) -> Promise<Int> {
         let functionName = "decimals"
-        return callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: Web3.Utils.erc20ABI).map { dictionary -> UInt8 in
-            guard let decimalsOfUnknownType = dictionary["0"], let decimals = UInt8(String(describing: decimalsOfUnknownType)) else {
-                throw CastError(actualValue: dictionary["0"], expectedType: UInt8.self)
+        return callSmartContract(withServer: server, contract: contract, functionName: functionName, abiString: Web3.Utils.erc20ABI).map { dictionary -> Int in
+            guard let decimalsOfUnknownType = dictionary["0"], let decimals = Int(String(describing: decimalsOfUnknownType)) else {
+                throw CastError(actualValue: dictionary["0"], expectedType: Int.self)
             }
 
             return decimals

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokensDataStore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokensDataStore.swift
@@ -35,7 +35,7 @@ public protocol TokensDataStore: NSObjectProtocol {
 }
 
 extension TokensDataStore {
-    
+
     @discardableResult func updateToken(addressAndRpcServer: AddressAndRPCServer, action: TokenUpdateAction) -> Bool? {
         let primaryKey = TokenObject.generatePrimaryKey(fromContract: addressAndRpcServer.address, server: addressAndRpcServer.server)
         return updateToken(primaryKey: primaryKey, action: action)
@@ -72,7 +72,7 @@ public enum TokenOrContract {
     case delegateContracts([AddressAndRPCServer])
     case deletedContracts([AddressAndRPCServer])
     /// We re-use the existing balance value to avoid the `Wallets` tab showing that token (if it already exist) as `balance = 0` momentarily
-    case fungibleTokenComplete(name: String, symbol: String, decimals: UInt8, contract: AlphaWallet.Address, server: RPCServer, onlyIfThereIsABalance: Bool)
+    case fungibleTokenComplete(name: String, symbol: String, decimals: Int, contract: AlphaWallet.Address, server: RPCServer, onlyIfThereIsABalance: Bool)
     case none
 
     var addressAndRPCServer: AddressAndRPCServer? {
@@ -142,7 +142,7 @@ public enum NonFungibleBalance {
     public struct NftAssetRawValue {
         public let json: JsonString
         public var source: Source = .undefined
-        
+
         public init(json: JsonString, source: Source) {
             self.json = json
             self.source = source

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/TokenProviderType.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/TokenProviderType.swift
@@ -13,7 +13,7 @@ import BigInt
 public protocol TokenProviderType: class {
     func getContractName(for address: AlphaWallet.Address) -> Promise<String>
     func getContractSymbol(for address: AlphaWallet.Address) -> Promise<String>
-    func getDecimals(for address: AlphaWallet.Address) -> Promise<UInt8>
+    func getDecimals(for address: AlphaWallet.Address) -> Promise<Int>
     func getTokenType(for address: AlphaWallet.Address) -> Promise<TokenType>
     func getEthBalance(for address: AlphaWallet.Address) -> Promise<Balance>
     func getERC20Balance(for address: AlphaWallet.Address) -> Promise<BigInt>
@@ -42,7 +42,7 @@ public class TokenProvider: TokenProviderType {
         //NOTE: retrying is performing via APIKit.session request
         return getEthBalance.getBalance(for: address)
     }
-    
+
     public func getContractName(for address: AlphaWallet.Address) -> Promise<String> {
         let server = server
         return firstly {
@@ -63,7 +63,7 @@ public class TokenProvider: TokenProviderType {
         }
     }
 
-    public func getDecimals(for address: AlphaWallet.Address) -> Promise<UInt8> {
+    public func getDecimals(for address: AlphaWallet.Address) -> Promise<Int> {
         let server = server
         return firstly {
             attempt(maximumRetryCount: numberOfTimesToRetryFetchContractData, shouldOnlyRetryIf: TokenProvider.shouldRetry(error:)) {


### PR DESCRIPTION
A little undecided on this. Correctness vs simplicity. Let's try it anyway