### PR TITLE
Added dark mode to Transaction view

### DIFF
--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -40,6 +40,9 @@ struct Configuration {
             static let indicator = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.azure()!, darkColor: R.color.dodge()!)
             }
+            static let alternativeText = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: .darkGray, darkColor: .lightGray)
+            }
 
             static let defaultAttributedString = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.azure()!, darkColor: R.color.dodge()!)

--- a/AlphaWallet/Transactions/ViewModels/TransactionDetailsViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionDetailsViewModel.swift
@@ -37,7 +37,7 @@ struct TransactionDetailsViewModel {
     }
 
     var backgroundColor: UIColor {
-        return Screen.TokenCard.Color.background
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 
     var createdAt: String {

--- a/AlphaWallet/Transactions/Views/TransactionAppearance.swift
+++ b/AlphaWallet/Transactions/Views/TransactionAppearance.swift
@@ -10,13 +10,13 @@ struct TransactionAppearance {
         titleLabel.text = title
         titleLabel.font = Fonts.regular(size: 18)
         titleLabel.textAlignment = .left
-        titleLabel.textColor = Colors.darkGray
+        titleLabel.textColor = Configuration.Color.Semantic.alternativeText
 
         let subTitleLabel = UILabel(frame: .zero)
         subTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subTitleLabel.text = subTitle
         subTitleLabel.textAlignment = .left
-        subTitleLabel.textColor = Colors.black
+        subTitleLabel.textColor = Configuration.Color.Semantic.defaultForegroundText
         subTitleLabel.font = Fonts.regular(size: 15)
         subTitleLabel.numberOfLines = 0
 


### PR DESCRIPTION
Tap the activity tab, tap an entry listed, tap the icon in the upper right corner.
0 | 1 | 2
-|-|-
![0 copy](https://user-images.githubusercontent.com/1050309/196617459-a97e4e08-b057-4991-bec2-7c77c305f39b.png) | ![1 copy](https://user-images.githubusercontent.com/1050309/196617477-586fc55b-0eea-4328-b33d-99a941dc5c8f.png) | ![2 copy](https://user-images.githubusercontent.com/1050309/196617492-8ae0f08b-8986-4e65-88d5-50f8e348d40f.png)
.png)

Before commit | After commit
-|-
![before](https://user-images.githubusercontent.com/1050309/196616371-bfe1273a-7da6-46d0-88be-ce57ffa180d9.png) | ![after](https://user-images.githubusercontent.com/1050309/196616409-ca41cfcb-e5bd-43e4-ba1a-1243d12b0816.png)
