### PR TITLE
Added dark mode to back up this wallet screen

### DIFF
--- a/AlphaWallet/Wallet/ViewModels/SeedPhraseBackupIntroductionViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/SeedPhraseBackupIntroductionViewModel.swift
@@ -27,7 +27,7 @@ struct SeedPhraseBackupIntroductionViewModel {
         attributeString.addAttributes([
             .paragraphStyle: style,
             .font: Screen.Backup.subtitleFont,
-            .foregroundColor: R.color.black()!
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText
         ], range: NSRange(location: 0, length: subtitle.count))
         
         return attributeString
@@ -43,7 +43,7 @@ struct SeedPhraseBackupIntroductionViewModel {
         attributeString.addAttributes([
             .paragraphStyle: style,
             .font: Screen.Backup.descriptionFont,
-            .foregroundColor: Colors.appText
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText
         ], range: NSRange(location: 0, length: description.count))
         
         return attributeString

--- a/AlphaWallet/Wallet/ViewModels/SeedPhraseCollectionViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/SeedPhraseCollectionViewModel.swift
@@ -11,7 +11,7 @@ struct SeedPhraseCollectionViewModel {
     let shouldShowSequenceNumber: Bool
 
     var backgroundColor: UIColor {
-        return Colors.appWhite
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 
     var seedPhraseWordCount: Int {

--- a/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseViewModel.swift
@@ -13,7 +13,7 @@ struct ShowSeedPhraseViewModel {
     var buttonTitle: String = R.string.localizable.walletsShowSeedPhraseTestSeedPhrase()
     
     var subtitleColor: UIColor {
-        return Screen.Backup.subtitleColor
+        return Configuration.Color.Semantic.defaultSubtitleText
     }
 
     var subtitleFont: UIFont {

--- a/AlphaWallet/Wallet/ViewModels/VerifySeedPhraseViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/VerifySeedPhraseViewModel.swift
@@ -42,7 +42,7 @@ struct VerifySeedPhraseViewModel {
 
     //Make it the same as the background. Trick to maintain the height of the error label even when there's no error by putting some dummy text. The dummy text must still make sense for accessibility
     var noErrorColor: UIColor {
-        return backgroundColor
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 
     var errorFont: UIFont {
@@ -59,7 +59,7 @@ struct VerifySeedPhraseViewModel {
     }
 
     var subtitleColor: UIColor {
-        return Screen.Backup.subtitleColor
+        return Configuration.Color.Semantic.defaultSubtitleText
     }
 
     var subtitleFont: UIFont {


### PR DESCRIPTION
Tap Settings > Back up this wallet

Before | After
-|-
![1-before copy](https://user-images.githubusercontent.com/1050309/196858866-a9739f6c-932d-490b-a69c-97331a38703c.png) | ![1-after copy](https://user-images.githubusercontent.com/1050309/196858908-930394c8-5df7-4667-9899-b5031b1d03ef.png)
![2-before copy](https://user-images.githubusercontent.com/1050309/196858964-63556f05-72e2-479f-82b5-7d3f20353702.png) | ![2-after copy](https://user-images.githubusercontent.com/1050309/196859084-a83bdfe7-9d5d-4aec-a7a9-9cb374c7fccc.png)
![3-before copy](https://user-images.githubusercontent.com/1050309/196859071-3cf1b83b-bc0d-40d5-9439-4e0a8396a2a5.png) | ![3-after copy](https://user-images.githubusercontent.com/1050309/196859007-aa2e2051-73f0-4f16-b6cb-d7b3a5ef60d8.png)



