### PR TITLE
Added dark mode to show seed phrase screen

### DIFF
--- a/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseIntroductionViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseIntroductionViewController.swift
@@ -79,7 +79,7 @@ class ShowSeedPhraseIntroductionViewController: UIViewController {
     }
 
     private func configure() {
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         subtitleLabel.numberOfLines = 0
         subtitleLabel.attributedText = viewModel.attributedSubtitle

--- a/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseIntroductionViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseIntroductionViewModel.swift
@@ -32,7 +32,7 @@ struct ShowSeedPhraseIntroductionViewModel {
         attributeString.addAttributes([
             .paragraphStyle: style,
             .font: Screen.Backup.subtitleFont,
-            .foregroundColor: R.color.black()!,
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .kern: 0.0
         ], range: NSRange(location: 0, length: subtitle.count))
 
@@ -49,7 +49,7 @@ struct ShowSeedPhraseIntroductionViewModel {
         attributedString.addAttributes([
             .paragraphStyle: style,
             .font: Screen.Backup.descriptionFont,
-            .foregroundColor: Colors.appText,
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText,
             .kern: 0.0
         ], range: NSRange(location: 0, length: description.count))
 


### PR DESCRIPTION
Tap `Settings > Show seed phrase`
Before commit | After commit
-|-
![before-1](https://user-images.githubusercontent.com/1050309/196934472-85262d95-33e5-4dc1-8eb0-14edd98d5376.png) |  ![after-1](https://user-images.githubusercontent.com/1050309/196934506-6e411ae0-d474-490f-980a-267da080c5be.png)
