### PR TITLE
Added dark mode to passcode / faceid screen

### DIFF
--- a/AlphaWallet/Lock/ViewControllers/LockPasscodeViewController.swift
+++ b/AlphaWallet/Lock/ViewControllers/LockPasscodeViewController.swift
@@ -18,7 +18,7 @@ class LockPasscodeViewController: UIViewController {
 	override func viewDidLoad() {
 		self.navigationItem.hidesBackButton = true
 		NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-		self.view.backgroundColor = Colors.appBackground
+        self.view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 		self.configureInvisiblePasscodeField()
 		self.configureNavigationItems()
 		self.configureLockView()

--- a/AlphaWallet/Lock/Views/LockView.swift
+++ b/AlphaWallet/Lock/Views/LockView.swift
@@ -33,7 +33,7 @@ class LockView: UIView {
 		lockTitle.font = Fonts.regular(size: 20)
 		lockTitle.textAlignment = .center
 		lockTitle.translatesAutoresizingMaskIntoConstraints = false
-		lockTitle.textColor = Colors.appText
+        lockTitle.textColor = Configuration.Color.Semantic.defaultForegroundText
 	}
 	private func applyConstraints() {
 		characterView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
@@ -44,7 +44,7 @@ class LockView: UIView {
 		lockTitle.bottomAnchor.constraint(equalTo: characterView.topAnchor, constant: -20).isActive = true
 	}
 	private func addUiElements() {
-		backgroundColor = Colors.appBackground
+        backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 		addSubview(lockTitle)
 		addSubview(characterView)
 	}

--- a/AlphaWallet/Lock/Views/PasscodeCharacterView.swift
+++ b/AlphaWallet/Lock/Views/PasscodeCharacterView.swift
@@ -30,7 +30,7 @@ class PasscodeCharacterView: UIView {
 		let radius: CGFloat = bounds.width / 2 - borderWidth
 		let circle = CAShapeLayer()
 		circle.path = UIBezierPath(roundedRect: CGRect(x: borderWidth, y: borderWidth, width: 2.0 * radius, height: 2.0 * radius), cornerRadius: radius).cgPath
-		let circleColor: UIColor? = Colors.appText
+        let circleColor: UIColor? = Configuration.Color.Semantic.defaultForegroundText
 		circle.fillColor = circleColor?.cgColor
 		circle.strokeColor = circleColor?.cgColor
 		circle.borderWidth = borderWidth
@@ -52,7 +52,7 @@ class PasscodeCharacterView: UIView {
 		hyphenPath.addLine(to: rightBottomCorner)
 		hyphenPath.addLine(to: leftBottomCorner)
 		hyphen.path = hyphenPath.cgPath
-		let hyphenColor: UIColor? = Colors.appText
+		let hyphenColor: UIColor? = Configuration.Color.Semantic.defaultForegroundText
 		hyphen.fillColor = hyphenColor?.cgColor
 		hyphen.strokeColor = hyphenColor?.cgColor
 		layer.addSublayer(hyphen)


### PR DESCRIPTION
Tap `Settings > Passcode/FaceId`
Before | After
-|-
![before-1](https://user-images.githubusercontent.com/1050309/196938414-ba353f3b-2d28-4b31-a3a2-01f9960654b3.png)|![after-1](https://user-images.githubusercontent.com/1050309/196938461-238fdb0c-3d82-499b-8aa8-b9ddd9dad38a.png)
![before-2](https://user-images.githubusercontent.com/1050309/196938488-063c4f4f-7296-48f1-8c50-b8d660a12839.png)|![after-2](https://user-images.githubusercontent.com/1050309/196938499-f736b70b-ae3c-45df-b59d-a2fb247ee290.png)
