### PR TITLE
Activity tab search bar does not update view for empty search results until tabs are switched. #5609

### DIFF
--- a/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
+++ b/AlphaWallet/Activities/ViewControllers/ActivitiesViewController.swift
@@ -110,6 +110,7 @@ extension ActivitiesViewController: UISearchResultsUpdating {
 
     private func processSearchWithKeywords() {
         activitiesView.applySearch(keyword: searchController.searchBar.text)
+        activitiesView.endLoading()
     }
 
 }


### PR DESCRIPTION
Closes #5609