### PR TITLE
Fixed dark mode in select active networks test net screen

### DIFF
--- a/AlphaWallet/Settings/Views/RPCDisplaySelectableTableViewCell.swift
+++ b/AlphaWallet/Settings/Views/RPCDisplaySelectableTableViewCell.swift
@@ -44,11 +44,11 @@ class RPCDisplaySelectableTableViewCell: UITableViewCell {
         return imageView
     }()
     private let infoView: ServerInformationView = ServerInformationView()
-    private let topSeparator: UIView = UIView.spacer(backgroundColor: R.color.mike()!)
+    private let topSeparator: UIView = UIView.spacer(backgroundColor: Configuration.Color.Semantic.tableViewSeparator)
     private lazy var unavailableToSelectView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white.withAlphaComponent(0.4)
+        view.backgroundColor = (Configuration.Color.Semantic.defaultViewBackground).withAlphaComponent(0.4)
         view.isHidden = false
 
         return view


### PR DESCRIPTION
Tap `Settings > Select Active Networks`, then toggle the `Testnet` switch to on. Tap the `enable testate` button on the pop up dialog.

Before | After
-|-
![before-1](https://user-images.githubusercontent.com/1050309/197729092-d29e7387-1959-4163-9e0c-d7421aefb61f.png)|![after-1](https://user-images.githubusercontent.com/1050309/197729075-0da430ae-c841-4a54-a81b-df411dcf0ed4.png)
