### PR TITLE
Added dark mode to add network dialog on Add Custom RPC network screen

### DIFF
--- a/AlphaWallet/AddMultipleCustomRpc/AddMultipleCustomRpcView.swift
+++ b/AlphaWallet/AddMultipleCustomRpc/AddMultipleCustomRpcView.swift
@@ -23,6 +23,7 @@ class AddMultipleCustomRpcView: UIView {
         label.font = Fonts.bold(size: 17)
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = Configuration.Color.Semantic.defaultForegroundText
         return label
     }()
 
@@ -40,6 +41,7 @@ class AddMultipleCustomRpcView: UIView {
         label.text = "…"
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = Configuration.Color.Semantic.defaultForegroundText
         return label
     }()
 
@@ -55,6 +57,7 @@ class AddMultipleCustomRpcView: UIView {
         label.text = "-"
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = Configuration.Color.Semantic.defaultForegroundText
         return label
     }()
 
@@ -84,7 +87,7 @@ class AddMultipleCustomRpcView: UIView {
         configureNetworkNameLabel()
         configureProgressLabel()
         configureButton()
-        backgroundColor = R.color.alabaster()!
+        backgroundColor = Configuration.Color.Semantic.progressDialogBackground
         layer.cornerRadius = 25.0
     }
 

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -259,6 +259,10 @@ struct Configuration {
             static let textViewFailed = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.silver()!, darkColor: R.color.porcelain()!)
             }
+            static let progressDialogBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.alabaster()!, darkColor: R.color.venus()!)
+            }
+
         }
     }
 }


### PR DESCRIPTION
Tap `Settings > Select Active Networks > + on top right corner`. Select two or more networks. Tap `Add Network` button.

Before commit | After commit
-|-
![before-1](https://user-images.githubusercontent.com/1050309/198925033-df0a9a54-5c58-49a7-8b3f-3e9793ff55ff.png)|![after-1](https://user-images.githubusercontent.com/1050309/198925044-d10a03b4-b69a-4093-8549-a2e32795cdf0.png)
