### PR TITLE
Added dark mode to Tokenscript Overrides screen

### DIFF
--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -863,3 +863,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -862,3 +862,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/Localization/fi.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/fi.lproj/Localizable.strings
@@ -862,3 +862,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -862,3 +862,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -862,3 +862,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -862,3 +862,4 @@
 "accept.deepLink.field.url.title" = "URL";
 "accept.deepLink.field.note.title" = "Note";
 "accept.walletConnect.field.methods.title" = "Methods";
+"tokenscript.overrides.empty" = "There are no TokenScript overrides";

--- a/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
+++ b/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
@@ -12,6 +12,11 @@ class AssetDefinitionsOverridesViewController: UIViewController {
     private let tableView = UITableView(frame: .zero, style: .grouped)
     private let fileExtension: String
     private var overriddenURLs: [URL] = []
+    private lazy var emptyView: UIView = {
+        let emptyView = EmptyTableView(title: R.string.localizable.tokenscriptOverridesEmpty(), image: R.image.iconsIllustrationsSearchResults()!, heightAdjustment: 0.0)
+        emptyView.isHidden = true
+        return emptyView
+    }()
     weak var delegate: AssetDefinitionsOverridesViewControllerDelegate?
 
     init(fileExtension: String) {
@@ -25,7 +30,7 @@ class AssetDefinitionsOverridesViewController: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.separatorStyle = .singleLine
-        tableView.backgroundColor = GroupedTable.Color.background
+        tableView.backgroundColor = Configuration.Color.Semantic.tableViewBackground
         tableView.tableFooterView = UIView.tableFooterToRemoveEmptyCellSeparators()
 
         view.addSubview(tableView)
@@ -33,6 +38,7 @@ class AssetDefinitionsOverridesViewController: UIViewController {
         NSLayoutConstraint.activate([
             tableView.anchorsConstraint(to: view),
         ])
+        configureEmptyView()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -43,6 +49,15 @@ class AssetDefinitionsOverridesViewController: UIViewController {
         self.overriddenURLs = urls
         tableView.reloadData()
     }
+
+    private func configureEmptyView() {
+        tableView.addSubview(emptyView)
+        NSLayoutConstraint.activate([
+            emptyView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            emptyView.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
+        ])
+    }
+
 }
 
 extension AssetDefinitionsOverridesViewController: UITableViewDelegate {
@@ -65,7 +80,9 @@ extension AssetDefinitionsOverridesViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return overriddenURLs.count
+        let rows = overriddenURLs.count
+        handleEmptyTableAction(rows)
+        return rows
     }
 
     //Hide the header
@@ -83,4 +100,11 @@ extension AssetDefinitionsOverridesViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         nil
     }
+
+    private func handleEmptyTableAction(_ rows: Int) {
+        let newViewHiddenState = rows != 0
+        guard emptyView.isHidden != newViewHiddenState else { return }
+        emptyView.isHidden = newViewHiddenState
+    }
+
 }


### PR DESCRIPTION
Closes: #5629

Tap `Settings > Advanced > TokenScript Overrides`.

Before | After (Light mode) | After (Dark mode)
-|-|-
![Screen Shot 2022-10-31 at 5 20 51 PM](https://user-images.githubusercontent.com/1050309/198974499-7595b7ab-22a0-414b-a159-e9a78d98f78e.png) | ![Screen Shot 2022-10-31 at 5 11 56 PM](https://user-images.githubusercontent.com/1050309/198973748-9c140fed-2bc2-46b2-8f92-116a94d5b027.png) | ![Screen Shot 2022-10-31 at 5 12 08 PM](https://user-images.githubusercontent.com/1050309/198973776-f2e5ffce-375f-4d02-9f05-53b08ad6a9f8.png)

