### PR TITLE
Added dark mode to Transaction In Progress screen

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/TransactionInProgressViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionInProgressViewModel.swift
@@ -17,7 +17,7 @@ struct TransactionInProgressViewModel {
         return NSAttributedString(string: R.string.localizable.aWalletTokenTransactionInProgressTitle(), attributes: [
             .paragraphStyle: style,
             .font: Fonts.regular(size: 28),
-            .foregroundColor: Colors.black
+            .foregroundColor: Configuration.Color.Semantic.defaultTitleText
         ])
     }
 
@@ -30,7 +30,7 @@ struct TransactionInProgressViewModel {
         return NSMutableAttributedString(string: x, attributes: [
             .paragraphStyle: style,
             .font: Fonts.regular(size: 17),
-            .foregroundColor: R.color.mine()!
+            .foregroundColor: Configuration.Color.Semantic.defaultHeadlineText
         ])
     }
 
@@ -43,7 +43,7 @@ struct TransactionInProgressViewModel {
     }
 
     var backgroundColor: UIColor {
-        return Colors.appBackground
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 }
 


### PR DESCRIPTION
Send some test Eth to another wallet.

Before | After (Light mode) | After (Dark mode)
-|-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 15 39 53](https://user-images.githubusercontent.com/1050309/199190810-cb53b80e-efbe-46ec-8ab2-5495a4cf2af0.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 16 17 53](https://user-images.githubusercontent.com/1050309/199190833-71e36bd4-f097-4b0c-afb7-499659cecb2d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 16 17 50](https://user-images.githubusercontent.com/1050309/199190855-dc77ffc1-ea16-4b8c-9ddd-bfe3eccdd573.png)
