### PR TITLE
Fixed table view cell color in dark mode when sending currency in activity tab

### DIFF
--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -249,7 +249,7 @@ struct Configuration {
             }
 
             static let sendingState = UIColor { trait in
-                return colorFrom(trait: trait, lightColor: R.color.solitude()!, darkColor: R.color.bali()!)
+                return colorFrom(trait: trait, lightColor: R.color.solitude()!, darkColor: R.color.luckyPoint()!)
             }
 
             static let pendingState = UIColor { trait in

--- a/AlphaWallet/Resources/Assets.xcassets/luckyPoint.colorset/Contents.json
+++ b/AlphaWallet/Resources/Assets.xcassets/luckyPoint.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB8",
-          "green" : "0xA3",
-          "red" : "0x8A"
+          "blue" : "0x50",
+          "green" : "0x32",
+          "red" : "0x32"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Fixes #5614

Light mode | Dark mode
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 15 40 34](https://user-images.githubusercontent.com/1050309/199194759-4523408f-a59a-423f-8f70-c9c4192d4e28.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-01 at 15 40 00](https://user-images.githubusercontent.com/1050309/199194775-fb225114-9d07-4747-9bca-36083a6da14c.png)

The colour is named luckyPoint based on a Google search for #323250. https://www.htmlcsscolor.com/hex/323250