### PR TITLE
Fixed position of text and QRCode in My Wallet Address screen

### DIFF
--- a/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/RequestViewController.swift
@@ -65,7 +65,7 @@ class RequestViewController: UIViewController {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 15),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -15),
-            stackView.topAnchor.constraint(equalTo: view.topAnchor),
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor),
         ])
     }


### PR DESCRIPTION
Fixes #5723
On the main wallet screen tap ... > Show My Wallet Address on the upper right corner.
iPhone 14 Pro
Before | After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-02 at 11 26 43](https://user-images.githubusercontent.com/1050309/199389996-0be763fd-97f4-497c-afb7-2b4fee9cca2e.png)|![after](https://user-images.githubusercontent.com/1050309/199389959-cdc82555-ffe1-463c-a26c-494f9f8890c2.png)

