### PR TITLE
Updated Makefile to allow user to specify iOS 14 and 15 subversions, and iPhone device on simulator, and clean the source code by version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,32 @@ vendor_path = ./vendor/bundle
 beautify_cmd = ./Pods/xcbeautify/xcbeautify
 curl_cmd = /usr/bin/curl
 compress_cmd = ./scripts/compress_chains
+iphone_destination ?= iPhone 12 Pro
+test14_target ?= 14.5
+test15_target ?= 15.2
 
 all: target
-	@echo "Please specify a target. Please use 'make target' to show targets."
+	@echo
+	@echo "Please specify a target."
+	@echo "iPhone destination is set to $(iphone_destination)."
 
 target:
-	@echo "install_bundle     : install the correct version of bundle."
-	@echo "install_gems       : install all the required gems."
-	@echo "install_pods       : install all the cocoapods."
-	@echo "install_all        : install gems then pods."
-	@echo "check_gems         : check to see if all the gems in the Gemfile are installed in the vendor directory."
-	@echo "bootstrap          : install bundle followed by install all."
-	@echo "test14             : run tests for iOS 14.5."
-	@echo "test15             : run tests for iOS 15.2."
-	@echo "test               : run the tests for latest iOS (15.2)."
-	@echo "clean              : remove all the pods and gems."
-	@echo "update_chains_file : update the chains.zip file in the project."
+	@echo "install_bundle       : install the correct version of bundle."
+	@echo "install_gems         : install all the required gems."
+	@echo "install_pods         : install all the cocoapods."
+	@echo "install_all          : install gems then pods."
+	@echo "check_gems           : check to see if all the gems in the Gemfile are installed in the vendor directory."
+	@echo "bootstrap            : install bundle followed by install all."
+	@echo "test14               : run tests for iOS $(test14_target)."
+	@echo "test15               : run tests for iOS $(test15_target)."
+	@echo "test                 : run the tests for latest iOS."
+	@echo "clean                : remove all the pods and gems and source clean the code."
+	@echo "remove_installed_dir : remove the installed pod and gems."
+	@echo "source_clean         : clean the source code of AlphaWallet for latest iOS."
+	@echo "source_clean14       : clean the source code of AlphaWallet for $(test14_target)."
+	@echo "source_clean15       : clean the source code of AlphaWallet for $(test15_target)."
+	@echo "source_clean_all     : clean the source code of AlphaWallet for $(test14_target), $(test15_target), and latest."
+	@echo "update_chains_file   : update the chains.zip file in the project."
 
 check_brew:
 	@$(brew_cmd) --version 1>/dev/null 2>/dev/null; \
@@ -45,6 +55,13 @@ check_gems: check_bundle setup_path
 		echo "Some or all gemfiles have not been installed. Please use 'make install_gems'."; \
 		exit 1; \
 	fi
+
+check_beautify_cmd:
+	@$(beautify_cmd) --version 1>/dev/null 2>/dev/null; \
+        if [ $$? -ne 0 ]; then \
+                echo "Beautify command is not installed. Please run make bootstrap."; \
+                exit 1; \
+        fi
 
 install_gems: check_bundle setup_path
 	@$(bundle_cmd) install --jobs=4; \
@@ -77,10 +94,22 @@ bootstrap: install_bundle install_all
 
 install_all: setup_path install_gems install_pods
 
-clean:
+clean: remove_installed_dir source_clean_all
+
+remove_installed_dir:
 	rm -rf $(vendor_path)
 	rm -rf ./Pods/*
-	@xcodebuild -quiet -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' clean
+
+source_clean:
+	@xcodebuild -quiet -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=latest' clean
+
+source_clean14:
+	@xcodebuild -quiet -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=$(test14_target)' clean
+
+source_clean15:
+	@xcodebuild -quiet -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=$(test15_target)' clean
+
+source_clean_all: source_clean source_clean14 source_clean15
 
 release:
 	fastlane release
@@ -91,22 +120,25 @@ setup_path:
 install_bundle:
 	@$(gem_cmd) install --install-dir=$(vendor_path) $(bundle_gem)
 
-test15:
-	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.4' test | $(beautify_cmd)
+test15: check_beautify_cmd
+	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=$(test15_target)' test | $(beautify_cmd)
 
-test14:
-	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5' test | $(beautify_cmd)
+test14: check_beautify_cmd
+	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=$(test14_target)' test | $(beautify_cmd)
 
 test_latest:
-	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 12,OS=latest' test | $(beautify_cmd)
+	@xcodebuild -disableAutomaticPackageResolution -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=latest' test | $(beautify_cmd)
 
 test: test_latest
 
-build_and_run_booted:
+build_and_run_booted: check_beautify_cmd
 	#The simulator "name" specified doesn't matter
-	@xcrun xcodebuild -disableAutomaticPackageResolution -scheme AlphaWallet -workspace AlphaWallet.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 12 Pro,OS=15.4' -derivedDataPath ./build | $(beautify_cmd)
+	@xcrun xcodebuild -disableAutomaticPackageResolution -scheme AlphaWallet -workspace AlphaWallet.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=15.4' -derivedDataPath ./build | $(beautify_cmd)
 	@xcrun simctl install booted ./build/Build/Products/Debug-iphonesimulator/AlphaWallet.app
 	@xcrun simctl launch booted com.stormbird.alphawallet
+
+build: check_beautify_cmd
+	@xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWallet -sdk iphonesimulator -destination 'platform=iOS Simulator,name=$(iphone_destination),OS=latest' build | $(beautify_cmd)
 
 update_chains_file:
 	@echo "Deleting chains file in scripts folder."


### PR DESCRIPTION
### Selection of device/os combo in tests

Allows user to specify the iPhone device and iOS subversions for iOS 14 and iOS 15. The default options are iPhone 12 Pro, iOS 14.5, iOS 15.2, and the latest iOS 16 (16.1). 

If you want to use a different iPhone device, use:
`iphone_target="iPhone X" make test`

If you want to use a different iPhone device and iOS subversion, use:
`iphone_target="iPhone 13" test14_target=14.2 make test14`

In order to make these changes permanent, you would need to export the variables (probably via your shell login script).
`export iphone_target="iPhone 12"`
`export test15_target=15.7`

If the device, os combination does not exist in your Xcode setup, `xcodebuild` will dump a list of installed device iOS combinations. You would need to download the specific device/os combo in Xcode `Window > Devices and Simulators`.

### New clean options
The old `make clean` only cleaned up the source code for iPhone 12 and the latest iOS. The newer option cleans up all the source code from iOS 14, 15, and 16.

`make source_clean, make source_clean14, make source_clean15, make source_clean_all` allows the user to just clean the source code without removing the gem and pod files.

`make remove_installed_dir` removes the pod and gem files without removing any of the compiled code.

### Information display
The selected iPhone device, iOS 14 and iOS 15 subversions are displayed when the user types `make`.

### Package resolution
`make build` has been added in order to fix the problem of fixing the package resolution issue when the SwiftPackage Manager packages have been updated.