### PR TITLE
Fixed UISearchBar dark mode background color in the iOS Document Browser.

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -21,7 +21,6 @@ func applyStyle() {
     UIToolbar.appearance().tintColor = Colors.appTint
 
     //Background (not needed in iOS 12.1 on simulator)
-    UISearchBar.appearance().backgroundColor = Colors.appBackground
     //Cancel button
     UISearchBar.appearance().tintColor = Configuration.Color.Semantic.searchbarTint
     //Cursor color


### PR DESCRIPTION
From the wallet main screen, tap the upper left corner, tap the `+` sign, tap `Import Wallet`, tap `Keystore JSON`, tap `Import from iCloud/Dropbox/Google Drive`, tap `iCloud/Dropbox/Google Drive`.

Before | After
-|-
![Before](https://user-images.githubusercontent.com/1050309/200472134-1d76da9c-8c34-4b96-9ccf-5222a372f1fb.png)|![After](https://user-images.githubusercontent.com/1050309/200472140-994f18c7-7908-4549-bf4a-30b8254ff9ed.png)
