### PR TITLE
Fixed dark mode of background of Round button display wallet address

### DIFF
--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -255,7 +255,10 @@ struct Configuration {
             static let pendingState = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.cheese()!, darkColor: R.color.ocean()!)
             }
-            
+            static let roundButtonBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.mike()!, darkColor: R.color.mine()!)
+            }
+
             static let textViewFailed = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.silver()!, darkColor: R.color.porcelain()!)
             }

--- a/AlphaWallet/Common/Views/ViewModels/RoundedEnsViewModel.swift
+++ b/AlphaWallet/Common/Views/ViewModels/RoundedEnsViewModel.swift
@@ -16,5 +16,5 @@ struct RoundedEnsViewModel {
 
     var labelFont: UIFont = Fonts.semibold(size: ScreenChecker.size(big: 17, medium: 16, small: 14))
     var labelTextColor: UIColor = Configuration.Color.Semantic.labelTextActive
-    var backgroundColor: UIColor = UIColor(red: 237, green: 237, blue: 237)
+    var backgroundColor: UIColor = Configuration.Color.Semantic.roundButtonBackground
 }


### PR DESCRIPTION
Fixes #5725
I changed the background of the button from R:237, G:237, B:237 to mike (233, 233, 233) in light mode (nearest fit in the style guide) and mine (47, 47, 47) in dark mode.

Before | After
-|-
![before-dark](https://user-images.githubusercontent.com/1050309/200510090-e4b9b2e0-f510-4d2f-8a50-dd09040e19bf.png)|![after-dark](https://user-images.githubusercontent.com/1050309/200510102-c76a04fb-57cf-4fa8-942c-d3858cc5c9f4.png)
