### PR TITLE
Fix: empty tab bar button appears in the middle on devices because Swap is now enabled

### DIFF
--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -33,7 +33,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
         let tokenGroupIdentifier: TokenGroupIdentifierProtocol = TokenGroupIdentifier.identifier(fromFileName: "tokens")!
         return TokensFilter(assetDefinitionStore: assetDefinitionStore, tokenActionsService: tokenActionsService, coinTickersFetcher: coinTickersFetcher, tokenGroupIdentifier: tokenGroupIdentifier)
     }()
-    
+
     private let tokenCollection: TokenCollection
 
     private var transactionCoordinator: TransactionCoordinator? {
@@ -131,7 +131,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
     private let tokenSwapper: TokenSwapper
     private let tokensService: DetectedContractsProvideble & TokenProvidable & TokenAddable
     private let lock: Lock
-    
+
     init(
             navigationController: UINavigationController = NavigationController(),
             walletAddressesStore: WalletAddressesStore,
@@ -395,7 +395,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
         } else {
             viewControllers.append(transactionCoordinator.navigationController)
         }
-        if Features.default.isAvailable(.isSwapEnabled) {
+        if Environment.isDebug && Features.default.isAvailable(.isSwapEnabled) {
             let swapDummyViewController = UIViewController()
             swapDummyViewController.tabBarItem = ActiveWalletViewModel.Tabs.swap.tabBarItem
             viewControllers.append(swapDummyViewController)


### PR DESCRIPTION
Refer to tab bar in screenshots:

Before PR|After PR
-|-
<img width='200' src='https://user-images.githubusercontent.com/56189/201006419-cd19eb3f-11aa-4760-b52f-fe84d53d75bb.png'>|<img width="250" alt="Screenshot 2022-11-10 at 1 19 24 PM" src="https://user-images.githubusercontent.com/56189/201007091-e92e10c7-24b0-4aec-b4d8-fbe02356413b.png">
