### PR TITLE
Switch `Charts` pod back to upstream so it can build with Travis (x86_64)

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -4459,7 +4459,7 @@
 			packageReferences = (
 				87FBF2AF28056AC200616B7D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				87BDF46E28423DC30018DC68 /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
-				877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */,
+				877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */,
 			);
 			productRefGroup = 2912CCF61F6A830700C6CBE3 /* Products */;
 			projectDirPath = "";
@@ -4720,6 +4720,7 @@
 				"${BUILT_PRODUCTS_DIR}/SAMKeychain/SAMKeychain.framework",
 				"${BUILT_PRODUCTS_DIR}/SipHash/SipHash.framework",
 				"${BUILT_PRODUCTS_DIR}/StatefulViewController/StatefulViewController.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftAlgorithms/Algorithms.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftProtobuf/SwiftProtobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/TrezorCrypto/TrezorCrypto.framework",
@@ -4767,6 +4768,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SAMKeychain.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SipHash.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/StatefulViewController.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Algorithms.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftProtobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TrezorCrypto.framework",
@@ -6202,7 +6204,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */ = {
+		877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AlphaWallet/WalletConnectSwift.git";
 			requirement = {
@@ -6231,7 +6233,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		877239CD28F806820062DC14 /* WalletConnectSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift" */;
+			package = 877239CC28F806820062DC14 /* XCRemoteSwiftPackageReference "WalletConnectSwift.git" */;
 			productName = WalletConnectSwift;
 		};
 		87BDF46F28423DC30018DC68 /* WalletConnect */ = {

--- a/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
+++ b/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
@@ -12,7 +12,7 @@ import AlphaWalletFoundation
 
 class TokenHistoryChartView: UIView {
 
-    private class YMinMaxOnlyAxisValueFormatter: IAxisValueFormatter {
+    private class YMinMaxOnlyAxisValueFormatter: AxisValueFormatter {
         //NOTE: helper index for determining right label position
         private var index: Int = 0
         private let formatter = Formatter.fiat
@@ -46,7 +46,7 @@ class TokenHistoryChartView: UIView {
         chartView.drawGridBackgroundEnabled = false
         chartView.drawBordersEnabled = false
 
-        chartView.chartDescription?.enabled = false
+        chartView.chartDescription.enabled = false
 
         chartView.pinchZoomEnabled = false
         chartView.dragEnabled = true
@@ -112,11 +112,11 @@ class TokenHistoryChartView: UIView {
 
         bind(viewModel: viewModel)
         periodSelectorView.set(selectedIndex: viewModel.selectedHistoryIndex)
-    } 
+    }
 
     required init?(coder: NSCoder) {
         return nil
-    } 
+    }
 
     private func bind(viewModel: TokenHistoryChartViewModel) {
         viewModel.lineChartDataSet

--- a/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
@@ -54,14 +54,14 @@ class TokenHistoryChartViewModel {
     init(chartHistories: AnyPublisher<[ChartHistory], Never>, coinTicker: AnyPublisher<CoinTicker?, Never>) {
         self.chartHistories = chartHistories
         self.coinTicker = coinTicker
-    } 
+    }
 
     func set(selectedHistoryIndex: Int) {
         self.selectedHistoryIndexSubject.send(selectedHistoryIndex)
     }
 
     var setGradientFill: Fill? {
-        return Fill.fillWithCGColor(UIColor.clear.cgColor)
+        return ColorFill(color: UIColor.clear)
     }
 
     private func chartSetColorForTicker(ticker: CoinTicker?) -> UIColor {

--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ target 'AlphaWallet' do
   pod 'Kanna', :git => 'https://github.com/tid-kijyun/Kanna.git', :commit => '06a04bc28783ccbb40efba355dee845a024033e8'
   pod 'Mixpanel-swift', '~> 3.1'
   pod 'EthereumABI', :git => 'https://github.com/AlphaWallet/EthereumABI.git', :commit => '877b77e8e7cbc54ab0712d509b74fec21b79d1bb'
-  pod 'Charts', :git => 'https://github.com/AlphaWallet/Charts.git', :commit => '85ec4d0f62b97829274c4f628f4840036939de64'
+  pod 'Charts'
   pod 'AlphaWalletAddress', :path => '.'
   pod 'AlphaWalletCore', :path => '.'
   pod 'AlphaWalletGoBack', :path => '.'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -61,9 +61,10 @@ PODS:
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
   - BlockiesSwift (0.1.2)
-  - Charts (3.6.0):
-    - Charts/Core (= 3.6.0)
-  - Charts/Core (3.6.0)
+  - Charts (4.1.0):
+    - Charts/Core (= 4.1.0)
+  - Charts/Core (4.1.0):
+    - SwiftAlgorithms (~> 1.0)
   - CocoaAsyncSocket (7.6.5)
   - CocoaLumberjack (3.7.0):
     - CocoaLumberjack/Core (= 3.7.0)
@@ -126,6 +127,7 @@ PODS:
   - secp256k1_ios (0.1.3)
   - SipHash (1.2.2)
   - StatefulViewController (3.0)
+  - SwiftAlgorithms (1.0.0)
   - SwiftFormat/CLI (0.50.3)
   - SwiftLint (0.40.3)
   - SwiftProtobuf (1.18.0)
@@ -154,7 +156,7 @@ DEPENDENCIES:
   - AlphaWalletWeb3 (from `.`)
   - AlphaWalletWeb3Provider (from `https://github.com/AlphaWallet/AlphaWallet-web3-provider`, commit `9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870`)
   - BigInt (~> 3.1)
-  - Charts (from `https://github.com/AlphaWallet/Charts.git`, commit `85ec4d0f62b97829274c4f628f4840036939de64`)
+  - Charts
   - EthereumABI (from `https://github.com/AlphaWallet/EthereumABI.git`, commit `877b77e8e7cbc54ab0712d509b74fec21b79d1bb`)
   - FloatingPanel
   - iOSSnapshotTestCase (= 6.2.0)
@@ -182,6 +184,7 @@ SPEC REPOS:
     - Apollo
     - BigInt
     - BlockiesSwift
+    - Charts
     - CocoaAsyncSocket
     - CocoaLumberjack
     - CombineExt
@@ -205,6 +208,7 @@ SPEC REPOS:
     - secp256k1_ios
     - SipHash
     - StatefulViewController
+    - SwiftAlgorithms
     - SwiftFormat
     - SwiftLint
     - SwiftProtobuf
@@ -232,9 +236,6 @@ EXTERNAL SOURCES:
   AlphaWalletWeb3Provider:
     :commit: 9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
-  Charts:
-    :commit: 85ec4d0f62b97829274c4f628f4840036939de64
-    :git: https://github.com/AlphaWallet/Charts.git
   EthereumABI:
     :commit: 877b77e8e7cbc54ab0712d509b74fec21b79d1bb
     :git: https://github.com/AlphaWallet/EthereumABI.git
@@ -258,9 +259,6 @@ CHECKOUT OPTIONS:
   AlphaWalletWeb3Provider:
     :commit: 9a4496d02b7ddb2f6307fd0510d8d7c9fcef9870
     :git: https://github.com/AlphaWallet/AlphaWallet-web3-provider
-  Charts:
-    :commit: 85ec4d0f62b97829274c4f628f4840036939de64
-    :git: https://github.com/AlphaWallet/Charts.git
   EthereumABI:
     :commit: 877b77e8e7cbc54ab0712d509b74fec21b79d1bb
     :git: https://github.com/AlphaWallet/EthereumABI.git
@@ -295,7 +293,7 @@ SPEC CHECKSUMS:
   Apollo: 204819ea82022fbc59ad05056820df867f19bd02
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   BlockiesSwift: 22d8d56dd187e6bfd16cb8c8fbd4fd4896c3e65d
-  Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
+  Charts: 354f86803d11d9c35de280587fef50d1af063978
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   CombineExt: c4daa97ef75754d8ef319bd79edeef82652f3eea
@@ -323,6 +321,7 @@ SPEC CHECKSUMS:
   secp256k1_ios: ac9ef04e761f43c58012b28548afa91493761f17
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   StatefulViewController: 4803bf900d44de26074344998e10e041113b5931
+  SwiftAlgorithms: 38dda4731d19027fdeee1125f973111bf3386b53
   SwiftFormat: 61cda3819dc3a7d69795ce0430e1e1d53c4a4fb2
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
@@ -332,6 +331,6 @@ SPEC CHECKSUMS:
   TrustWalletCore: a92d85baa15932279cce925559e93695558cafdd
   xcbeautify: b2c6b50c9cab6414296898e94cd153e4ea879662
 
-PODFILE CHECKSUM: b527af775f28dc3a2207db0692c4a97f878195f0
+PODFILE CHECKSUM: 70644902b70ae4a49b6894222db66f62c222cfc0
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
We don't need the fork now since it only adds a commit from upstream so it with Xcode 14 RC.

Also needed the updated pod for #5513 which makes Travis builds with Xcode 14 because Travis uses x86_64 and don't support Apple Silicon.