### PR TITLE
Fix: ERC20 tokens sent wrongly to token contract (instead of intended address)

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendViewModel.swift
@@ -209,7 +209,7 @@ final class SendViewModel {
                     data = Data()
                 case .erc20Token(let token, _, _):
                     contract = token.contractAddress
-                    data = (try? Erc20Transfer(recipient: token.contractAddress, value: BigUInt(value)).encodedABI()) ?? Data()
+                    data = (try? Erc20Transfer(recipient: recipient, value: BigUInt(value)).encodedABI()) ?? Data()
                 case .erc875Token, .erc721Token, .erc721ForTicketToken, .erc1155Token:
                     fatalError("Impossible Code Path")
                 }


### PR DESCRIPTION
Fixes #5811