### PR TITLE
Amended storage.delete in TransactionsStorageTests to accept new syntax.

### DIFF
--- a/AlphaWalletTests/Transactions/Storage/TransactionsStorageTests.swift
+++ b/AlphaWalletTests/Transactions/Storage/TransactionsStorageTests.swift
@@ -57,7 +57,7 @@ class TransactionsStorageTests: XCTestCase {
 
         XCTAssertEqual(2, storage.transactionCount(forServer: .main))
 
-        storage.delete([one])
+        storage.delete(transactions: [one])
 
         XCTAssertEqual(1, storage.transactionCount(forServer: .main))
 


### PR DESCRIPTION
Fixes #5864

