### PR TITLE
[TokenScript] Fix infinite recursion when we drop in a TokenScript file for a contract which has a official TokenScript file in the central repo

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -206,6 +206,13 @@ public class AssetDefinitionStore: NSObject {
         if useCacheAndFetch && self[contract] != nil {
             completionHandler?(.cached)
         }
+
+        //If we override with a TokenScript file that is for a contract that also has an official TokenScript file but the files are different, we'll enter an infinite recursion where we keep fetching the official TokenScript file, store it, think it has changed, invalid cache, re-download from the official repo and loops. The simple solution is to just not attempt to download or check against the official repo if the there's an overriding TokenScript file
+        if !backingStore.isOfficial(contract: contract) {
+            completionHandler?(.cached)
+            return
+        }
+
         firstly {
             urlToFetch(contract: contract, server: server)
         }.done { result in


### PR DESCRIPTION
Fixes #5879