### PR TITLE
Inject tokenscript attributes in token view

### DIFF
--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
@@ -102,7 +102,7 @@ class NFTAssetViewModel {
         self.tokenHolder = tokenHolder
         self.assetDefinitionStore = assetDefinitionStore
         self.displayHelper = OpenSeaNonFungibleTokenDisplayHelper(contract: tokenHolder.contractAddress)
-        self.tokenHolderHelper = TokenInstanceViewConfigurationHelper(tokenId: tokenId, tokenHolder: tokenHolder)
+        self.tokenHolderHelper = TokenInstanceViewConfigurationHelper(tokenId: tokenId, tokenHolder: tokenHolder, assetDefinitionStore: assetDefinitionStore)
         self.contractViewModel = TokenAttributeViewModel(title: R.string.localizable.nonfungiblesValueContract(), attributedValue: TokenAttributeViewModel.urlValueAttributedString(token.contractAddress.truncateMiddle))
     }
 

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionInfoPageViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionInfoPageViewModel.swift
@@ -51,14 +51,14 @@ final class NFTCollectionInfoPageViewModel {
 
     var previewViewContentBackgroundColor: UIColor { return Configuration.Color.Semantic.defaultViewBackground }
 
-    init(token: Token, previewViewType: NFTPreviewViewType, tokenHolder: TokenHolder, tokenId: TokenId, tokenHolders: AnyPublisher<[TokenHolder], Never>, nftProvider: NFTProvider) {
+    init(token: Token, previewViewType: NFTPreviewViewType, tokenHolder: TokenHolder, tokenId: TokenId, tokenHolders: AnyPublisher<[TokenHolder], Never>, nftProvider: NFTProvider, assetDefinitionStore: AssetDefinitionStore) {
         self.previewViewType = previewViewType
         self.nftProvider = nftProvider
         self.tokenHolders = tokenHolders
         self.token = token
         self.tokenHolder = tokenHolder
         self.tokenId = tokenId
-        self.tokenHolderHelper = TokenInstanceViewConfigurationHelper(tokenId: tokenId, tokenHolder: tokenHolder)
+        self.tokenHolderHelper = TokenInstanceViewConfigurationHelper(tokenId: tokenId, tokenHolder: tokenHolder, assetDefinitionStore: assetDefinitionStore)
     }
 
     var blockChainTagViewModel: BlockchainTagLabelViewModel {

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionViewModel.swift
@@ -48,7 +48,7 @@ final class NFTCollectionViewModel {
     private (set) lazy var infoPageViewModel: NFTCollectionInfoPageViewModel = {
         let tokenHolder = tokenHolders.value[0]
         let tokenId = tokenHolder.tokenIds[0]
-        return NFTCollectionInfoPageViewModel(token: token, previewViewType: previewViewType, tokenHolder: tokenHolder, tokenId: tokenId, tokenHolders: tokenHolders.eraseToAnyPublisher(), nftProvider: nftProvider)
+        return NFTCollectionInfoPageViewModel(token: token, previewViewType: previewViewType, tokenHolder: tokenHolder, tokenId: tokenId, tokenHolders: tokenHolders.eraseToAnyPublisher(), nftProvider: nftProvider, assetDefinitionStore: assetDefinitionStore)
     }()
 
     private (set) lazy var nftAssetsPageViewModel = NFTAssetsPageViewModel(token: token, assetDefinitionStore: assetDefinitionStore, tokenHolders: tokenHolders.eraseToAnyPublisher(), layout: .list)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeToUserinterfaceConvertor.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeToUserinterfaceConvertor.swift
@@ -1,0 +1,28 @@
+// Copyright © 2022 Stormbird PTE. LTD.
+
+import Foundation
+
+public struct AssetAttributeToUserInterfaceConvertor {
+    public init() {}
+    //Numbers must be formatted as string (or maybe later a suitable JavaScript big number type), but not as numbers in JavaScript because they can lose precision
+    public func formatAsTokenScriptString(value: AssetInternalValue) -> String? {
+        switch value {
+        case .address(let address):
+            return address.eip55String
+        case .string(let string):
+            return string
+        case .bytes(let bytes):
+            return bytes.hexEncoded
+        case .int(let int):
+            return String(int)
+        case .uint(let uint):
+            return String(uint)
+        case .generalisedTime(let generalisedTime):
+            return generalisedTime.formatAsGeneralisedTime
+        case .bool(let bool):
+            return bool ? "true" : "false"
+        case .subscribable, .openSeaNonFungibleTraits:
+            return nil
+        }
+    }
+}

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
@@ -910,6 +910,10 @@ public struct XMLHandler {
         return fieldIdsAndNames
     }
 
+    public var fieldIdsAndNamesExcludingBase: [AttributeId: String] {
+        return privateXMLHandler.fieldIdsAndNames
+    }
+
     public init(token: TokenScriptSupportable, assetDefinitionStore: AssetDefinitionStore) {
         self.init(contract: token.contractAddress, tokenType: token.type, assetDefinitionStore: assetDefinitionStore)
     }

--- a/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSeaNonFungibleTrait.swift
+++ b/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSeaNonFungibleTrait.swift
@@ -14,8 +14,15 @@ public struct OpenSeaNonFungibleTrait: Codable {
     public let value: String
 
     init(json: JSON) {
-        count = json["trait_count"].intValue
-        type = json["trait_type"].stringValue
-        value = json["value"].stringValue
+        let count = json["trait_count"].intValue
+        let type = json["trait_type"].stringValue
+        let value = json["value"].stringValue
+        self.init(count: count, type: type, value: value)
+    }
+
+    public init(count: Int, type: String, value: String) {
+        self.count = count
+        self.type = type
+        self.value = value
     }
 }


### PR DESCRIPTION
Closes #5862

Includes #5918

TokenScript-level attributes look like this (like how OpenSea traits does) — the "IsRedeemed" and "IsRedeemedBool" attributes from `wget https://alphawallet.infura-ipfs.io/ipfs/QmcxMgfV4dsZpr5S6w2GXKXPA6LLErxxGY7WPY5JwEK957`

<img width="400" alt="Screenshot 2022-12-08 at 7 37 59 PM" src="https://user-images.githubusercontent.com/56189/206437303-306f64fa-eff0-4014-b98d-005ae578985d.png">
