### PR TITLE
Replace delete cell function with `trailingSwipeActionsConfigurationForRowAt` for asset definitions overrides screen #5923

### DIFF
--- a/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
+++ b/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
@@ -95,9 +95,19 @@ extension AssetDefinitionsOverridesViewController: PopNotifiable {
 }
 
 extension AssetDefinitionsOverridesViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        guard editingStyle == .delete else { return }
-        deletion.send(dataSource.item(at: indexPath).url)
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let hideAction = UIContextualAction(style: .destructive, title: R.string.localizable.delete()) { [deletion, dataSource] _, _, completionHandler in
+            deletion.send(dataSource.item(at: indexPath).url)
+            completionHandler(true)
+        }
+
+        hideAction.backgroundColor = Colors.appRed
+        hideAction.image = R.image.hideToken()
+
+        let configuration = UISwipeActionsConfiguration(actions: [hideAction])
+        configuration.performsFirstActionWithFullSwipe = true
+
+        return configuration
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Closes #5923