### PR TITLE
Fix: Scanning a QR code containing an address with a trailing linebreak does nothing

### DIFF
--- a/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
@@ -90,6 +90,7 @@ extension ScanQRCodeCoordinator: QRCodeReaderDelegate {
 
     func reader(_ reader: QRCodeReaderViewController!, didScanResult result: String!) {
         stopScannerAndDismiss {
+            let result = result.trimmed
             infoLog("[QR Code] Scanned value: \(String(describing: result))")
             self.logCompleteScan(result: result)
             self.delegate?.didScan(result: result, in: self)


### PR DESCRIPTION
Fixes #5949