### PR TITLE
Fix: ERC1155 is not detected automatically. Manually adding it also wouldn't show the correct token IDs and balance. More obvious on Polygon since Ethereum mainnet uses OpenSea API

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/CallSmartContractFunction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/CallSmartContractFunction.swift
@@ -139,7 +139,8 @@ final class GetEventLogs {
         firstly {
             .value(contractAddress)
         }.then(on: queue, { [weak self, queue] contractAddress -> Promise<[EventParserResultProtocol]> in
-            let key = "\(contractAddress.eip55String)-\(server.chainID)-\(eventName)-\(abiString)-\(try JSONEncoder().encode(filter.rpcPreEncode()).hashValue)"
+            //It is fine to use the default String representation of `EventFilter` in the cache key. But it is crucial to include it, because the actual variables of the event log fetching are in there. For example ERC1155's `TransferSingle` event is used for fetching both send and receive single token ID events. We can ony tell based on the arguments in `EventFilter` whether it is a send or receive
+            let key = "\(contractAddress.eip55String)-\(server.chainID)-\(eventName)-\(abiString)-\(filter)"
 
             if let promise = self?.inFlightPromises[key] {
                 return promise

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/Erc1155TokenIdsFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/Erc1155TokenIdsFetcher.swift
@@ -91,7 +91,6 @@ public class Erc1155TokenIdsFetcher {
         let address = self.address
         let server = self.server
         let config = self.config
-        let maximumBlockRangeWindow: UInt64? = server.maximumBlockRangeForEvents
 
         let promise = firstly {
             Promise<Int>.value(session.chainState.latestBlock)


### PR DESCRIPTION
Fixes #5989

Because the caching key was incomplete