### PR TITLE
Make Buy Crypto button's button bar in wallet tab have a transparent background color so list of tokens scroll behind it

### DIFF
--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -1,8 +1,8 @@
 // Copyright © 2018 Stormbird PTE. LTD.
 
-import UIKit 
+import UIKit
 import Combine
-import AlphaWalletFoundation 
+import AlphaWalletFoundation
 
 protocol TokensViewControllerDelegate: AnyObject {
     func viewWillAppear(in viewController: UIViewController)
@@ -114,7 +114,7 @@ final class TokensViewController: UIViewController {
             adjustTableViewHeaderHeightToFitContents()
         }
     }
-    
+
     private var isPromptBackupWalletViewHolderHidden: Bool {
         get { promptBackupWalletViewHolder.isHidden }
         set {
@@ -125,7 +125,7 @@ final class TokensViewController: UIViewController {
     }
 
     weak var delegate: TokensViewControllerDelegate?
-    
+
     var promptBackupWalletView: UIView? {
         didSet {
             oldValue?.removeFromSuperview()
@@ -501,7 +501,7 @@ fileprivate extension TokensViewController {
         for each in viewModels {
             snapshot.appendItems(each.views, toSection: each.section)
         }
-        
+
         dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
     }
 }

--- a/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensViewController.swift
@@ -152,7 +152,11 @@ final class TokensViewController: UIViewController {
     }()
     private lazy var dataSource = makeDataSource()
     private let buttonsBar = HorizontalButtonsBar(configuration: .primary(buttons: 1))
-    private lazy var footerBar = ButtonsBarBackgroundView(buttonsBar: buttonsBar, separatorHeight: 0)
+    private lazy var footerBar: ButtonsBarBackgroundView = {
+        let result = ButtonsBarBackgroundView(buttonsBar: buttonsBar, separatorHeight: 0)
+        result.backgroundColor = viewModel.buyButtonFooterBarBackgroundColor
+        return result
+    }()
 
     init(viewModel: TokensViewModel) {
         self.viewModel = viewModel

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -54,7 +54,7 @@ final class TokensViewModel {
     private let deletionSubject = PassthroughSubject<[IndexPath], Never>()
     private let wallet: Wallet
     private let assetDefinitionStore: AssetDefinitionStore
-    
+
     let config: Config
     let largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode = .never
     var filterViewModel: (cells: [ScrollableSegmentedControlCell], configuration: ScrollableSegmentedControlConfiguration) {
@@ -161,7 +161,7 @@ final class TokensViewModel {
             }
         }
     }
-    
+
     init(wallet: Wallet, tokenCollection: TokenCollection, tokensFilter: TokensFilter, walletConnectCoordinator: WalletConnectCoordinator, walletBalanceService: WalletBalanceService, config: Config, domainResolutionService: DomainResolutionServiceType, blockiesGenerator: BlockiesGenerator, assetDefinitionStore: AssetDefinitionStore) {
         self.wallet = wallet
         self.tokenCollection = tokenCollection
@@ -296,7 +296,7 @@ final class TokensViewModel {
 
     func set(isSearchActive: Bool) {
         self.isSearchActive = isSearchActive
-        
+
         reloadData()
     }
 
@@ -531,7 +531,7 @@ extension TokensViewModel {
         case success(indexPaths: [IndexPath])
         case failure
     }
-    
+
     enum TokenOrRpcServer {
         case token(TokenViewModel)
         case rpcServer(RPCServer)
@@ -699,7 +699,7 @@ extension TokensViewModel.functional {
         }
 
         return results
-    } 
+    }
 }
 
 fileprivate extension IndexPath {

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -115,6 +115,10 @@ final class TokensViewModel {
         return Configuration.Color.Semantic.searchbarBackground
     }
 
+    var buyButtonFooterBarBackgroundColor: UIColor {
+        return .clear
+    }
+
     var shouldShowBackupPromptViewHolder: Bool {
             //TODO show the prompt in both ASSETS and COLLECTIBLES tab too
         switch filter {


### PR DESCRIPTION
Before PR when near the bottom|After PR
-|-
<img width="200" alt="Screenshot 2022-12-30 at 12 27 36 PM" src="https://user-images.githubusercontent.com/56189/210034613-bb92b93e-3d5a-4f30-80d1-cea0c2144229.png">|<img width="200" alt="Screenshot 2022-12-30 at 12 01 57 PM" src="https://user-images.githubusercontent.com/56189/210034606-f12549ea-a0ad-4cf0-a49b-316376546a87.png">

This remains unchanged when scrolled to the bottom:

<img width="200" alt="Screenshot 2022-12-30 at 12 02 00 PM" src="https://user-images.githubusercontent.com/56189/210034614-21191429-8481-440f-bf55-d2e1804922c5.png">