### PR TITLE
[Swap] Fix: swap transaction and approve transaction confirmation for native swap should not display the sender as the recipient should display the contract instead  6057

### DIFF
--- a/AlphaWallet/Swap/Swap/SwapTokensCoordinator.swift
+++ b/AlphaWallet/Swap/Swap/SwapTokensCoordinator.swift
@@ -340,7 +340,7 @@ public extension UnconfirmedTransaction {
         let transaction = UnconfirmedTransaction(
             transactionType: transactionType,
             value: 0,
-            recipient: owner,
+            recipient: nil,
             contract: contract,
             data: data)
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
@@ -219,7 +219,7 @@ extension TokenSwapper {
 fileprivate extension TokenSwapper.functional {
     static func buildSwapTransaction(unsignedTransaction: UnsignedSwapTransaction, fromToken: TokenToSwap, fromAmount: BigUInt, toToken: TokenToSwap, toAmount: BigUInt) -> (UnconfirmedTransaction, TransactionType.Configuration) {
         let configuration: TransactionType.Configuration = .swapTransaction(fromToken: fromToken, fromAmount: fromAmount, toToken: toToken, toAmount: toAmount)
-        let transaction: UnconfirmedTransaction = .init(transactionType: .prebuilt(unsignedTransaction.server), value: unsignedTransaction.value, recipient: unsignedTransaction.from, contract: unsignedTransaction.to, data: unsignedTransaction.data, gasLimit: unsignedTransaction.gasLimit, gasPrice: unsignedTransaction.gasPrice)
+        let transaction: UnconfirmedTransaction = .init(transactionType: .prebuilt(unsignedTransaction.server), value: unsignedTransaction.value, recipient: nil, contract: unsignedTransaction.to, data: unsignedTransaction.data, gasLimit: unsignedTransaction.gasLimit, gasPrice: unsignedTransaction.gasPrice)
 
         return (transaction, configuration)
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
@@ -54,7 +54,7 @@ open class TokenSwapper: ObservableObject {
 
     public func start() {
         guard Features.default.isAvailable(.isSwapEnabled) else { return }
-        
+
         reachabilityManager.networkBecomeReachablePublisher
             .combineLatest(sessions, reloadSubject)
             .map { (_, sessions, _) in sessions }
@@ -136,7 +136,7 @@ open class TokenSwapper: ObservableObject {
             .receive(on: RunLoop.main)
             .map { swapRoutes -> String? in
                 guard !swapRoutes.isEmpty else { return nil }
-                
+
                 self.storage.addOrUpdate(swapRoutes: swapRoutes)
 
                 guard let pair = TokenSwapper.firstRouteWithExchange(from: swapRoutes) else { return nil }


### PR DESCRIPTION
Fixes #6057

Should just be a display issue.

@oa-s would you help check? Looks like it shouldn't break other transaction types

Before PR|After PR
-|-
<img width="300" alt="Screenshot 2023-01-05 at 11 50 12 AM" src="https://user-images.githubusercontent.com/56189/210697821-39ad322e-daa9-440c-8c56-c3d5210d0d22.png">|<img width="300" alt="Screenshot 2023-01-05 at 11 44 34 AM" src="https://user-images.githubusercontent.com/56189/210697856-fb19ec63-5f14-4bd3-93de-73a434f4b41b.png">