### PR TITLE
Removed all direct references and definition of `Colors.alabaster`

### DIFF
--- a/AlphaWallet/Browser/Views/BrowserErrorView.swift
+++ b/AlphaWallet/Browser/Views/BrowserErrorView.swift
@@ -57,7 +57,7 @@ final class BrowserErrorView: UIView {
     }
 
     private func finishInit() {
-        backgroundColor = .white
+        backgroundColor = Configuration.Color.Semantic.defaultViewBackground
         addSubview(textLabel)
         addSubview(reloadButton)
         NSLayoutConstraint.activate([

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,35 +100,34 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let lightGray = UIColor.lightGray
-    static let gray = UIColor.gray
-    static let darkGray = UIColor(hex: "2f2f2f")
-    static let black = UIColor(hex: "313849")
-    static let lightBlack = UIColor(hex: "313849")
-    static let clear = UIColor.clear
-    static let appBackground = UIColor.white
-    static let appTint = R.color.azure()!
-    static let navigationTitleColor = UIColor.black
-    static let appWhite = UIColor.white
-    static let appText = R.color.black()!
-    static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)
-    static let appHighlightGreen = UIColor(red: 117, green: 185, blue: 67)
     static let appActionButtonGreen = UIColor(red: 105, green: 200, blue: 0)
-    static let disabledActionButton = UIColor(hex: "d7ebc8")
     static let appActionButtonShadow = UIColor.clear
-    static let appGreenContrastBackground = UIColor(red: 86, green: 153, blue: 8)
-    static let appRed = R.color.danger()!
-    static let green = R.color.green()!
-    static let dove = R.color.dove()!
-    static let alabaster = R.color.alabaster()!
-    static let apprecationRed = UIColor(hex: "ff3b30")
-    static let apprecationGreen = Colors.appHighlightGreen
+    static let appBackground = UIColor.white
     static let appGrayLabel = UIColor(red: 155, green: 155, blue: 155)
-    static let settingsSubtitle = UIColor(red: 141, green: 141, blue: 141)
-    static let qrCodeRectBorders = UIColor(red: 216, green: 216, blue: 216)
-    static let loadingIndicatorBorder = UIColor(red: 237, green: 237, blue: 237)
+    static let appGreenContrastBackground = UIColor(red: 86, green: 153, blue: 8)
+    static let appHighlightGreen = UIColor(red: 117, green: 185, blue: 67)
+    static let apprecationGreen = Colors.appHighlightGreen
+    static let apprecationRed = UIColor(hex: "ff3b30")
+    static let appRed = R.color.danger()!
+    static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)
+    static let appText = R.color.black()!
+    static let appTint = R.color.azure()!
+    static let appWhite = UIColor.white
+    static let black = UIColor(hex: "313849")
+    static let clear = UIColor.clear
     static let concrete = R.color.concrete()!
+    static let darkGray = UIColor(hex: "2f2f2f")
+    static let disabledActionButton = UIColor(hex: "d7ebc8")
+    static let dove = R.color.dove()!
+    static let gray = UIColor.gray
+    static let green = R.color.green()!
+    static let lightBlack = UIColor(hex: "313849")
+    static let lightGray = UIColor.lightGray
     static let loadingBackground = R.color.loadingBackground()!
+    static let loadingIndicatorBorder = UIColor(red: 237, green: 237, blue: 237)
+    static let navigationTitleColor = UIColor.black
+    static let qrCodeRectBorders = UIColor(red: 216, green: 216, blue: 216)
+    static let settingsSubtitle = UIColor(red: 141, green: 141, blue: 141)
 }
 
 struct Fonts {

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -110,6 +110,7 @@ struct Configuration {
             static let periodButtonNormalBackground = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
             }
+            static let defaultButtonBorder = R.color.alabaster()!
 
             static let labelTextActive = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.mine()!, darkColor: R.color.white()!)

--- a/AlphaWallet/Common/Views/Button.swift
+++ b/AlphaWallet/Common/Views/Button.swift
@@ -88,7 +88,7 @@ enum ButtonStyle {
 
     var borderColor: UIColor {
         switch self {
-        case .solid, .squared, .border: return Colors.alabaster
+        case .solid, .squared, .border: return Configuration.Color.Semantic.defaultButtonBorder
         case .borderless, .system, .special: return .clear
         case .green: return ButtonsBarViewModel.primaryButton.buttonBorderColor
         }


### PR DESCRIPTION
# Colors.alabaster/.white

## BrowserErrorView
1. From main wallet screen, tap browser button.
2. Enter 127.0.0.1 in address bar of browser.
3. The background has been changed to adapt to dark mode.

Before | Light After | Dark After
-|-|-
![original](https://user-images.githubusercontent.com/1050309/211228526-4050a49a-5420-4d25-8370-434d7bc215a2.png)|![light](https://user-images.githubusercontent.com/1050309/211228524-55c84aff-daff-412b-af25-2138dcf6e582.png)|![dark](https://user-images.githubusercontent.com/1050309/211228521-a5b5a408-6050-4594-95fb-1a7e053455c1.png)

## ButtonStyle.borderColor 

`.solid`, `.squared`, `.border` are not used as far as I can determine.

```swift
    var borderColor: UIColor {
        switch self {
        case .solid, .squared, .border: return Configuration.Color.Semantic.defaultButtonBorder
        case .borderless, .system, .special: return .clear
        case .green: return ButtonsBarViewModel.primaryButton.buttonBorderColor
        }
    }
```