### PR TITLE
[Refactor] Remove spurious `AlphaWallet.Address.sameContract(as: AlphaWallet.Address)` and replace with `==`

### DIFF
--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -343,7 +343,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
             domainResolutionService: domainResolutionService,
             tokensFilter: tokensFilter,
             currencyService: currencyService)
-        
+
         coordinator.rootViewController.tabBarItem = ActiveWalletViewModel.Tabs.tokens.tabBarItem
         coordinator.delegate = self
         coordinator.start()
@@ -392,7 +392,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
         coordinator.rootViewController.tabBarItem = ActiveWalletViewModel.Tabs.activities.tabBarItem
         coordinator.navigationController.configureForLargeTitles()
         addCoordinator(coordinator)
-        
+
         return coordinator
     }
 
@@ -679,7 +679,7 @@ extension ActiveWalletCoordinator {
             currentUrl: nil,
             viewController: presentationViewController,
             networkService: networkService)
-        
+
         coordinator.delegate = dappRequestHandler
         dappRequestHandler.addCoordinator(coordinator)
         coordinator.start()

--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -564,7 +564,7 @@ class ActiveWalletCoordinator: NSObject, Coordinator, DappRequestHandlerDelegate
 
     func addImported(contract: AlphaWallet.Address, forServer server: RPCServer) {
         //Useful to check because we are/might action-only TokenScripts for native crypto currency
-        guard !contract.sameContract(as: Constants.nativeCryptoAddressInDatabase) else { return }
+        guard contract != Constants.nativeCryptoAddressInDatabase else { return }
 
         importToken.importToken(for: contract, server: server, onlyIfThereIsABalance: false)
             .done { _ in }
@@ -709,7 +709,7 @@ extension ActiveWalletCoordinator: CanOpenURL {
     }
 
     func didPressViewContractWebPage(forContract contract: AlphaWallet.Address, server: RPCServer, in viewController: UIViewController) {
-        if contract.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+        if contract == Constants.nativeCryptoAddressInDatabase {
             guard let url = server.etherscanContractDetailsWebPageURL(for: wallet.address) else { return }
             logExplorerUse(type: .wallet)
             open(url: url, in: viewController)

--- a/AlphaWallet/Common/Coordinators/WalletApiCoordinator.swift
+++ b/AlphaWallet/Common/Coordinators/WalletApiCoordinator.swift
@@ -43,7 +43,7 @@ class WalletApiCoordinator: NSObject, Coordinator {
             throw WalletApiError.connectionAddressNotFound
         }
 
-        guard wallet.address.sameContract(as: address) else {
+        guard wallet.address == address else {
             throw WalletApiError.requestedWalletNonActive
         }
 

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionInfoPageViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTCollectionInfoPageViewModel.swift
@@ -97,7 +97,7 @@ final class NFTCollectionInfoPageViewModel {
     }
 
     private func buildViewTypes(helper tokenHolderHelper: TokenInstanceViewConfigurationHelper) -> [NFTCollectionInfoPageViewModel.ViewType] {
-        if Constants.ticketContractAddress.sameContract(as: token.contractAddress) {
+        if Constants.ticketContractAddress == token.contractAddress {
             return buildViewTypesForFifaToken(helper: tokenHolderHelper)
         } else {
             return buildDefaultViewTypes(helper: tokenHolderHelper)

--- a/AlphaWallet/Tokens/ViewModels/AddHideTokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/AddHideTokensViewModel.swift
@@ -78,7 +78,7 @@ final class AddHideTokensViewModel {
             .handleEvents(receiveOutput: { [weak self] _ in self?.filterTokens() })
 
         return .init(viewState: viewState.eraseToAnyPublisher())
-    } 
+    }
 
     func titleForSection(_ section: Int) -> String {
         sections[section].description
@@ -170,7 +170,7 @@ final class AddHideTokensViewModel {
 
             if let sectionIndex = sections.firstIndex(of: .hiddenTokens) {
                 mark(token: token, isHidden: true)
-                
+
                 return .value((token, IndexPath(row: 0, section: Int(sectionIndex))))
             }
         case .hiddenTokens, .availableNewTokens, .popularTokens, .sortingFilters:

--- a/AlphaWallet/Tokens/ViewModels/AddHideTokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/AddHideTokensViewModel.swift
@@ -184,7 +184,7 @@ final class AddHideTokensViewModel {
         switch sections[indexPath.section] {
         case .displayedTokens:
             let token = displayedTokens[indexPath.row]
-            guard token.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) else { return .delete }
+            guard token.contractAddress == Constants.nativeCryptoAddressInDatabase else { return .delete }
             return .none
         case .availableNewTokens, .popularTokens, .hiddenTokens:
             return .insert

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -43,7 +43,7 @@ final class TokensViewModel {
         return tokens.chunked(into: 2).compactMap { elems -> CollectiblePairs? in
             guard let left = elems.first else { return nil }
 
-            let right = (elems.last?.contractAddress.sameContract(as: left.contractAddress) ?? false) ? nil : elems.last
+            let right = elems.last?.contractAddress == left.contractAddress ? nil : elems.last
             return .init(left: left, right: right)
         }
     }
@@ -555,7 +555,7 @@ extension TokensViewModel {
             case .rpcServer:
                 return false
             case .token(let token):
-                if token.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+                if token.contractAddress == Constants.nativeCryptoAddressInDatabase {
                     return false
                 }
                 return true

--- a/AlphaWalletTests/Settings/Coordinators/SettingsCoordinatorTests.swift
+++ b/AlphaWalletTests/Settings/Coordinators/SettingsCoordinatorTests.swift
@@ -43,7 +43,7 @@ class SettingsCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 10)
 
         XCTAssertNotNil(deletedWallet)
-        XCTAssertTrue(wallet.address.sameContract(as: deletedWallet!.address))
+        XCTAssertTrue(wallet.address == deletedWallet!.address)
         XCTAssertEqual(0, walletAddressesStore.wallets.count)
         XCTAssertEqual(0, storage.transactionCount(forServer: .main))
     }
@@ -68,7 +68,7 @@ class SettingsCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 10)
 
         XCTAssertNotNil(deletedWallet)
-        XCTAssertTrue(wallet.address.sameContract(as: deletedWallet!.address))
+        XCTAssertTrue(wallet.address == deletedWallet!.address)
         XCTAssertEqual(0, walletAddressesStore.wallets.count)
     }
 
@@ -91,7 +91,7 @@ class SettingsCoordinatorTests: XCTestCase {
         waitForExpectations(timeout: 10)
 
         XCTAssertNotNil(addedAddress)
-        XCTAssertTrue(wallet.address.sameContract(as: addedAddress!.address))
+        XCTAssertTrue(wallet.address == addedAddress!.address)
         XCTAssertEqual(1, walletAddressesStore.wallets.count)
     }
 }

--- a/modules/AlphaWalletAddress/AlphaWalletAddress/AlphaWalletAddress.swift
+++ b/modules/AlphaWalletAddress/AlphaWalletAddress/AlphaWalletAddress.swift
@@ -82,10 +82,6 @@ extension AlphaWallet {
         public func sameContract(as contract: String) -> Bool {
             return eip55String.drop0x.lowercased() == contract.drop0x.lowercased()
         }
-
-        public func sameContract(as contract: AlphaWallet.Address) -> Bool {
-            return eip55String == contract.eip55String
-        }
     }
 }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Activities/ActivitiesService.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Activities/ActivitiesService.swift
@@ -196,7 +196,7 @@ public class ActivitiesService: NSObject, ActivitiesServiceType {
             return filteredActivitiesForThisCard
         case .contract(let contract), .operationTypes(_, let contract):
             return filteredActivitiesForThisCard.filter { mapped -> Bool in
-                return mapped.tokenObject.contractAddress.sameContract(as: contract)
+                return mapped.tokenObject.contractAddress == contract
             }
         case .nativeCryptocurrency(let primaryKey):
             return filteredActivitiesForThisCard.filter { mapped -> Bool in
@@ -230,7 +230,7 @@ public class ActivitiesService: NSObject, ActivitiesServiceType {
             if let h = tokensAndTokenHolders[token.addressAndRPCServer] {
                 tokenHolders = h
             } else {
-                if token.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+                if token.contractAddress == Constants.nativeCryptoAddressInDatabase {
                     let _token = TokenScript.Token(tokenIdOrEvent: .tokenId(tokenId: .init(1)), tokenType: .nativeCryptocurrency, index: 0, name: "", symbol: "", status: .available, values: .init())
 
                     tokenHolders = [TokenHolder(tokens: [_token], contractAddress: token.contractAddress, hasAssetDefinition: true)]
@@ -242,7 +242,7 @@ public class ActivitiesService: NSObject, ActivitiesServiceType {
             //NOTE: using `tokenHolders[0]` i received crash with out of range exception
             guard let tokenHolder = tokenHolders.first else { return nil }
             //TODO fix for activities: special fix to filter out the event we don't want - need to doc this and have to handle with TokenScript design
-            let isNativeCryptoAddress = token.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase)
+            let isNativeCryptoAddress = token.contractAddress == Constants.nativeCryptoAddressInDatabase
             if card.name == "aETHMinted" && isNativeCryptoAddress && cardAttributes["amount"]?.uintValue == 0 {
                 return nil
             } else {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/BuyToken/Ramp/Ramp.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/BuyToken/Ramp/Ramp.swift
@@ -58,7 +58,7 @@ public final class Ramp: SupportedTokenActionsProvider, BuyTokenURLProviderType 
         func isAssetMatchesForToken(token: TokenActionsIdentifiable, asset: Asset) -> Bool {
             return asset.symbol.lowercased() == token.symbol.trimmingCharacters(in: .controlCharacters).lowercased()
                     && asset.decimals == token.decimals
-                    && (asset.address == nil ? token.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) : asset.address!.sameContract(as: token.contractAddress))
+                    && (asset.address == nil ? token.contractAddress == Constants.nativeCryptoAddressInDatabase : asset.address! == token.contractAddress)
         }
 
         guard !token.server.isTestnet else { return nil }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/ContractAddressObject.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/ContractAddressObject.swift
@@ -39,6 +39,6 @@ class ContractAddressObject: Object {
     override func isEqual(_ object: Any?) -> Bool {
         guard let object = object as? ContractAddressObject else { return false }
         //NOTE: to improve perfomance seems like we can use check for primary key instead of checking contracts
-        return object.contractAddress.sameContract(as: contractAddress) && object.server == server
+        return object.contractAddress == contractAddress && object.server == server
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/TickerIdFilter.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/TickerIdFilter.swift
@@ -48,18 +48,18 @@ public class TickerIdFilter {
         //NOTE maybe its need to handle values like: `"0x270DE58F54649608D316fAa795a9941b355A2Bd0/token-transfers"`
 
         if let contract = tickerId.platforms.first(where: { $0.server == token.server }) {
-            if contract.address.sameContract(as: Constants.nullAddress) {
+            if contract.address == Constants.nullAddress {
                 let result = tickerId.symbol.compare(token.symbol, options: .caseInsensitive) == .orderedSame
                 if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) && result {
                     Self.matchCounts["by platform+symbol for 0x0", default: 0] += 1
                 }
                 return result
-            } else if contract.address.sameContract(as: token.contractAddress) {
+            } else if contract.address == token.contractAddress {
                 if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
                     Self.matchCounts["by platform+contract", default: 0] += 1
                 }
                 return true
-            } else if token.server == .polygon && token.contractAddress == Constants.nativeCryptoAddressInDatabase && contract.address.sameContract(as: Self.polygonMaticContract) {
+            } else if token.server == .polygon && token.contractAddress == Constants.nativeCryptoAddressInDatabase && contract.address == Self.polygonMaticContract {
                 if Features.default.isAvailable(.isLoggingEnabledForTickerMatches) {
                     Self.matchCounts["by platform + Polygon 0x0 = Matic contract", default: 0] += 1
                 }
@@ -91,11 +91,11 @@ public class TickerIdFilter {
         //NOTE maybe its need to handle values like: `"0x270DE58F54649608D316fAa795a9941b355A2Bd0/token-transfers"`
 
         if let platform = object.platforms.first(where: { $0.server == token.server }) {
-            if platform.contractAddress.sameContract(as: Constants.nullAddress) {
+            if platform.contractAddress == Constants.nullAddress {
                 return object.symbol.compare(token.symbol, options: .caseInsensitive) == .orderedSame
-            } else if platform.contractAddress.sameContract(as: token.contractAddress) {
+            } else if platform.contractAddress == token.contractAddress {
                 return true
-            } else if token.server == .polygon && token.contractAddress == Constants.nativeCryptoAddressInDatabase && platform.contractAddress.sameContract(as: Self.polygonMaticContract) {
+            } else if token.server == .polygon && token.contractAddress == Constants.nativeCryptoAddressInDatabase && platform.contractAddress == Self.polygonMaticContract {
                 return true
             } else {
                 return false

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/TokenMappedToTicker.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/CoinTicker/Types/TokenMappedToTicker.swift
@@ -56,6 +56,6 @@ extension TokenMappedToTicker: Equatable {
 
     /// Checks for matching of ticker id
     public static func == (lhs: TokenMappedToTicker, rhs: AddressAndRPCServer) -> Bool {
-        return lhs.contractAddress.sameContract(as: rhs.address) && lhs.server == rhs.server
+        return lhs.contractAddress == rhs.address && lhs.server == rhs.server
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/Types/EnsRecord.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/Types/EnsRecord.swift
@@ -45,7 +45,7 @@ extension EnsRecord.Value: Equatable {
         case (.ens(let e1), .ens(let e2)):
             return e1 == e2
         case (.address(let a1), .address(let a2)):
-            return a1.sameContract(as: a2)
+            return a1 == a2
         default:
             return false
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Models/GetErc20Allowance.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Models/GetErc20Allowance.swift
@@ -18,7 +18,7 @@ class GetErc20Allowance {
     }
 
     public func hasEnoughAllowance(tokenAddress: AlphaWallet.Address, owner: AlphaWallet.Address, spender: AlphaWallet.Address, amount: BigUInt) -> Promise<(hasEnough: Bool, shortOf: BigUInt)> {
-        if tokenAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+        if tokenAddress == Constants.nativeCryptoAddressInDatabase {
             return .value((true, 0))
         }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
@@ -187,7 +187,7 @@ open class EtherKeystore: NSObject, Keystore {
     }
 
     private func isAddressAlreadyInWalletsList(address: AlphaWallet.Address) -> Bool {
-        return wallets.map({ $0.address }).contains { $0.sameContract(as: address) }
+        return wallets.map({ $0.address }).contains(address)
     }
 
     public func importWallet(type: ImportType) -> Result<Wallet, KeystoreError> {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
@@ -155,7 +155,7 @@ open class EtherKeystore: NSObject, Keystore {
                 walletAddressesStore: WalletAddressesStore,
                 analytics: AnalyticsLogger,
                 legacyFileBasedKeystore: LegacyFileBasedKeystore) {
-        
+
         self.keychain = keychain
         self.analytics = analytics
         self.walletAddressesStore = walletAddressesStore

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/SwapOptionsConfigurator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/SwapOptionsConfigurator.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Combine 
+import Combine
 import BigInt
 import CombineExt
 
@@ -97,7 +97,7 @@ public final class SwapOptionsConfigurator {
                 swapPair: SwapPair,
                 tokenCollection: TokenCollection,
                 tokenSwapper: TokenSwapper) {
-        
+
         self.tokenSwapper = tokenSwapper
         self.sessions = sessionProvider.activeSessions.values.sorted(by: { $0.server.displayOrderPriority < $1.server.displayOrderPriority })
         self.server = swapPair.from.server
@@ -107,7 +107,7 @@ public final class SwapOptionsConfigurator {
         invalidateSessionsWhenSupportedTokensChanged()
         fetchSupportedTokensForSelectedServer()
         resetToTokenForNonSupportedSwapPair()
-    } 
+    }
 
     public func set(token: Token, selection: SwapTokens.TokenSelection) {
         var pair = swapPair

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/SwapOptionsConfigurator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/SwapOptionsConfigurator.swift
@@ -230,7 +230,7 @@ public final class SwapOptionsConfigurator {
         do {
             let tokens = try supportedTokens(forServer: server)
             let token = try firstSupportedFromToken(forServer: server, tokens: tokens)
-            if isInitialServerValidation && !swapPair.from.contractAddress.sameContract(as: token.contractAddress) {
+            if isInitialServerValidation && swapPair.from.contractAddress != token.contractAddress {
                 let _ = try firstSupportedFromToken(forServer: server, tokens: [swapPair.from])
                 //NOTE: no changes needed as current swapPair.from supports
             } else {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/SwapQuote.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/SwapQuote.swift
@@ -78,7 +78,7 @@ extension SwapQuote.Action: Decodable {
 
 extension SwapQuote.Token {
     public static func == (lhs: SwapQuote.Token, rhs: TokenToSwap) -> Bool {
-        return lhs.address.sameContract(as: rhs.address) && lhs.chainId == rhs.server.chainID
+        return lhs.address == rhs.address && lhs.chainId == rhs.server.chainID
     }
 }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/QuickSwap/QuickSwap.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/QuickSwap/QuickSwap.swift
@@ -82,7 +82,7 @@ public class QuickSwap: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
 
         class functional {
             static func rewriteContractInput(_ address: AlphaWallet.Address) -> String {
-                if address.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+                if address == Constants.nativeCryptoAddressInDatabase {
                     //QuickSwap (forked from Uniswap) likes it this way
                     return "ETH"
                 } else {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/Uniswap.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/Uniswap.swift
@@ -90,7 +90,7 @@ public struct Uniswap: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
 
         class functional {
             static func rewriteContractInput(_ address: AlphaWallet.Address) -> String {
-                if address.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+                if address == Constants.nativeCryptoAddressInDatabase {
                     //Uniswap likes it this way
                     return "ETH"
                 } else {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/Uniswap.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/Uniswap.swift
@@ -13,8 +13,8 @@ public struct Uniswap: SupportedTokenActionsProvider, SwapTokenViaUrlProvider {
         return .empty()
     }
 
-    public let action: String 
-    
+    public let action: String
+
     public func rpcServer(forToken token: TokenActionsIdentifiable) -> RPCServer? {
         return .main
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/UniswapERC20Token.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/Uniswap/UniswapERC20Token.swift
@@ -18,7 +18,7 @@ extension UniswapERC20Token {
     static func isSupport(token: TokenActionsIdentifiable) -> Bool {
         switch token.server.serverWithEnhancedSupport {
         case .main:
-            return availableTokens.contains(where: { $0.contract.sameContract(as: token.contractAddress) })
+            return availableTokens.contains(where: { $0.contract == token.contractAddress })
         case .xDai, .polygon, .binance_smart_chain, .heco, .arbitrum, .klaytnCypress, .klaytnBaobabTestnet, .rinkeby, nil:
             return false
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -66,7 +66,7 @@ public class AssetDefinitionStore: NSObject {
 
     public func assetBodyChanged(for contract: AlphaWallet.Address) -> AnyPublisher<Void, Never> {
         return bodyChangeSubject
-            .filter { $0.sameContract(as: contract) }
+            .filter { $0 == contract }
             .mapToVoid()
             .share()
             .eraseToAnyPublisher()
@@ -74,7 +74,7 @@ public class AssetDefinitionStore: NSObject {
 
     public func assetSignatureChanged(for contract: AlphaWallet.Address) -> AnyPublisher<Void, Never> {
         return signatureChangeSubject
-            .filter { $0.sameContract(as: contract) }
+            .filter { $0 == contract }
             .mapToVoid()
             .share()
             .eraseToAnyPublisher()

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetImplicitAttributes.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetImplicitAttributes.swift
@@ -25,7 +25,7 @@ public enum AssetImplicitAttributes: String, CaseIterable {
     }
 
     public func shouldInclude(forAddress address: AlphaWallet.Address, isFungible: Bool) -> Bool {
-        let isNativeCryptoCurrency = address.sameContract(as: Constants.nativeCryptoAddressInDatabase)
+        let isNativeCryptoCurrency = address == Constants.nativeCryptoAddressInDatabase
         switch self {
         case .label:
             return true

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/FunctionOrigin.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/FunctionOrigin.swift
@@ -353,7 +353,7 @@ public struct FunctionOrigin {
         let functionCall = AssetFunctionCall(server: server, contract: originContract, functionName: functionName, inputs: functionType.inputs, output: output, arguments: arguments)
 
         //ENS token is treated as ERC721 because it is picked up from OpenSea. But it doesn't respond to `name` and `symbol`. Calling them is harmless but causes node errors that can be confusing "execution reverted" when looking at logs
-        if ["name", "symbol"].contains(functionCall.functionName) && functionCall.contract.sameContract(as: Constants.ensContractOnMainnet) {
+        if ["name", "symbol"].contains(functionCall.functionName) && functionCall.contract == Constants.ensContractOnMainnet {
             return Subscribable<AssetInternalValue>(nil)
         }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
@@ -84,7 +84,7 @@ public class TokenImageFetcher {
     public static var instance = TokenImageFetcher()
 
     private static var subscribables: AtomicDictionary<String, Subscribable<TokenImage>> = .init()
-    
+
     private static func programmaticallyGenerateIcon(for contractAddress: AlphaWallet.Address, type: TokenType, server: RPCServer, symbol: String, colors: [UIColor], staticOverlayIcon: UIImage?, blockChainNameColor: UIColor) -> TokenImage? {
         guard let i = [Constants.Image.numberOfCharactersOfSymbolToShowInIcon, symbol.count].min() else { return nil }
         let symbol = symbol.substring(to: i)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
@@ -16,7 +16,7 @@ private func programmaticallyGeneratedIconImage(for contractAddress: AlphaWallet
 }
 
 private func symbolBackgroundColor(for contractAddress: AlphaWallet.Address, server: RPCServer, colors: [UIColor], blockChainNameColor: UIColor) -> UIColor {
-    if contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+    if contractAddress == Constants.nativeCryptoAddressInDatabase {
         return blockChainNameColor
     } else {
         let index: Int
@@ -142,7 +142,7 @@ public class TokenImageFetcher {
         }
 
         let generatedImage = getDefaultOrGenerateIcon(server: server, contractAddress: contractAddress, type: type, name: name, tokenImage: contractDefinedImage, colors: colors, staticOverlayIcon: staticOverlayIcon, blockChainNameColor: blockChainNameColor, serverIconImage: serverIconImage)
-        if contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) {
+        if contractAddress == Constants.nativeCryptoAddressInDatabase {
             subscribable.send(generatedImage)
             return subscribable
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokensFilter.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokensFilter.swift
@@ -157,7 +157,7 @@ public class TokensFilter {
 
     public func filterTokens(tokens: [PopularToken], walletTokens: [TokenViewModel], filter: WalletFilter) -> [PopularToken] {
         var filteredTokens: [PopularToken] = tokens.filter { token in
-            !walletTokens.contains(where: { $0.contractAddress.sameContract(as: token.contractAddress) }) && !token.name.isEmpty
+            !walletTokens.contains(where: { $0.contractAddress == token.contractAddress }) && !token.name.isEmpty
         }
 
         switch filter {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokenObject.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokenObject.swift
@@ -102,8 +102,8 @@ class TokenObject: Object {
     override func isEqual(_ object: Any?) -> Bool {
         guard let object = object as? TokenObject else { return false }
         //NOTE: to improve perfomance seems like we can use check for primary key instead of checking contracts
-        return object.contractAddress.sameContract(as: contractAddress)
-    } 
+        return object.contractAddress == contractAddress
+    }
 
     var server: RPCServer {
         return .init(chainID: chainId)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokenViewModel.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokenViewModel.swift
@@ -87,11 +87,11 @@ extension TokenViewModel: TokenBalanceSupportable { }
 
 extension TokenViewModel: Equatable {
     public static func == (lhs: TokenViewModel, rhs: TokenViewModel) -> Bool {
-        return lhs.contractAddress.sameContract(as: rhs.contractAddress) && lhs.server == rhs.server
+        return lhs.contractAddress == rhs.contractAddress && lhs.server == rhs.server
     }
 
     public static func == (lhs: TokenViewModel, rhs: Token) -> Bool {
-        return lhs.contractAddress.sameContract(as: rhs.contractAddress) && lhs.server == rhs.server
+        return lhs.contractAddress == rhs.contractAddress && lhs.server == rhs.server
     }
 }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokensDataStore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/TokensDataStore.swift
@@ -694,8 +694,8 @@ extension MultipleChainsTokensDataStore.functional {
     public static func erc20AddressForNativeTokenFilter(servers: [RPCServer], tokens: [Token]) -> [Token] {
         var result = tokens
         for server in servers {
-            if let address = server.erc20AddressForNativeToken, result.contains(where: { $0.contractAddress.sameContract(as: address) }) {
-                result = result.filter { !$0.contractAddress.sameContract(as: Constants.nativeCryptoAddressInDatabase) && $0.server == server }
+            if let address = server.erc20AddressForNativeToken, result.contains(where: { $0.contractAddress == address }) {
+                result = result.filter { $0.contractAddress != Constants.nativeCryptoAddressInDatabase && $0.server == server }
             } else {
                 continue
             }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Storage/TransactionsStorage.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Storage/TransactionsStorage.swift
@@ -302,7 +302,7 @@ extension TransactionDataStore: Erc721TokenIdsFetcher {
                     .sorted(byKeyPath: "date", ascending: true)
 
                 let operations: [LocalizedOperationObject] = transactions
-                    .flatMap { $0.localizedOperations.filter { $0.contractAddress?.sameContract(as: contract) ?? false } }
+                    .flatMap { $0.localizedOperations.filter { $0.contractAddress == contract } }
 
                 for each in operations {
                     let tokenId = each.tokenId

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/AlphaWalletAddress.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/AlphaWalletAddress.swift
@@ -12,15 +12,15 @@ extension AlphaWallet.Address {
     }
 
     public var isLegacy721Contract: Bool {
-        return Constants.legacy721Addresses.contains { sameContract(as: $0) }
+        return Constants.legacy721Addresses.contains(self)
     }
 
     //Useful for special case for FIFA tickets
     public var isFifaTicketContract: Bool {
-        return sameContract(as: Constants.ticketContractAddress) || sameContract(as: Constants.ticketContractAddressRopsten)
+        return self == Constants.ticketContractAddress || self == Constants.ticketContractAddressRopsten
     }
 
     public var isUEFATicketContract: Bool {
-        return sameContract(as: Constants.uefaMainnet.0)
+        return self == Constants.uefaMainnet.0
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
@@ -70,7 +70,7 @@ extension Balance: CustomStringConvertible {
 
 extension WalletBalance: Hashable {
     public static func == (lhs: WalletBalance, rhs: WalletBalance) -> Bool {
-        return lhs.wallet.address.sameContract(as: rhs.wallet.address) && lhs.totalAmount == rhs.totalAmount && lhs.change == rhs.change
+        return lhs.wallet.address == rhs.wallet.address && lhs.totalAmount == rhs.totalAmount && lhs.change == rhs.change
     }
 }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
@@ -45,12 +45,12 @@ public struct WalletBalance {
 
         return .init(amount: change.amount / total.amount, currency: total.currency)
     }
-    
+
     public var changePercentageString: String {
         guard let changePercentage = changePercentage else { return "-" }
         let helper = TickerHelper(ticker: nil)
         let formatter = NumberFormatter.priceChange(currency: changePercentage.currency)
-        
+
         switch helper.change24h(from: changePercentage.amount) {
         case .appreciate(let percentageChange24h):
             return "\(formatter.string(double: percentageChange24h) ?? "")%"

--- a/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSea.swift
+++ b/modules/AlphaWalletOpenSea/AlphaWalletOpenSea/OpenSea.swift
@@ -228,7 +228,7 @@ public class OpenSea {
             } else {
                 let excludeContracts = excludeContracts.map { $0.0 }
                 let assetsExcluding = assets.filter { eachAsset in
-                    !excludeContracts.contains { $0.sameContract(as: eachAsset.key) }
+                    !excludeContracts.contains(eachAsset.key)
                 }
                 return .value(.init(hasError: false, result: assetsExcluding))
             }
@@ -236,7 +236,7 @@ public class OpenSea {
             //NOTE: return some already fetched amount
             let excludeContracts = excludeContracts.map { $0.0 }
             let assetsExcluding = assets.filter { eachAsset in
-                !excludeContracts.contains { $0.sameContract(as: eachAsset.key) }
+                !excludeContracts.contains(eachAsset.key)
             }
             return .value(.init(hasError: true, result: assetsExcluding))
         }


### PR DESCRIPTION
Removes an unnecessary function.

@oa-s can you help to verify too? Have to be careful in particular for 2 types of replacements:

* When we replace !`sameContract(as:)` with `!=`
* When we replace `contains { sameContract(as:) }` with `!=`

Also, we already have `AlphaWalletAddressTests.testEquality()`