### PR TITLE
Removed all direct references and definition of `Colors.appActionButtonShadow`.

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appActionButtonShadow = UIColor.clear
     static let appBackground = UIColor.white
     static let appGrayLabel = UIColor(red: 155, green: 155, blue: 155)
     static let appGreenContrastBackground = UIColor(red: 86, green: 153, blue: 8)

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appActionButtonGreen = UIColor(red: 105, green: 200, blue: 0)
     static let appActionButtonShadow = UIColor.clear
     static let appBackground = UIColor.white
     static let appGrayLabel = UIColor(red: 155, green: 155, blue: 155)

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -112,6 +112,7 @@ struct Configuration {
             }
             static let defaultButtonBorder = R.color.alabaster()!
             static let actionButtonBackground = UIColor(red: 105, green: 200, blue: 0)
+            static let actionButtonShadow = UIColor.clear
 
             static let labelTextActive = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.mine()!, darkColor: R.color.white()!)

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -111,6 +111,7 @@ struct Configuration {
                 return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
             }
             static let defaultButtonBorder = R.color.alabaster()!
+            static let actionButtonBackground = UIColor(red: 105, green: 200, blue: 0)
 
             static let labelTextActive = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.mine()!, darkColor: R.color.white()!)

--- a/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
+++ b/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
@@ -387,7 +387,7 @@ struct ButtonsBarViewModel {
     }
 
     var buttonShadowColor: UIColor {
-        return Colors.appActionButtonShadow
+        return Configuration.Color.Semantic.actionButtonShadow
     }
 
     var buttonShadowOffset: CGSize {

--- a/AlphaWallet/Sell/ViewModels/GenerateSellMagicLinkViewModel.swift
+++ b/AlphaWallet/Sell/ViewModels/GenerateSellMagicLinkViewModel.swift
@@ -31,7 +31,7 @@ struct GenerateSellMagicLinkViewModel {
         return Configuration.Color.Semantic.defaultForegroundText
     }
     var actionButtonBackgroundColor: UIColor {
-        return Colors.appActionButtonGreen
+        return Configuration.Color.Semantic.actionButtonBackground
     }
     var actionButtonTitleFont: UIFont {
         return Fonts.regular(size: 20)

--- a/AlphaWallet/Sell/ViewModels/GenerateTransferMagicLinkViewModel.swift
+++ b/AlphaWallet/Sell/ViewModels/GenerateTransferMagicLinkViewModel.swift
@@ -29,7 +29,7 @@ struct GenerateTransferMagicLinkViewModel {
         return Configuration.Color.Semantic.defaultForegroundText
     }
     var actionButtonBackgroundColor: UIColor {
-        return Colors.appActionButtonGreen
+        return Configuration.Color.Semantic.actionButtonBackground
     }
     var actionButtonTitleFont: UIFont {
         return Fonts.regular(size: 20)

--- a/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenCardRowViewModel.swift
@@ -38,7 +38,7 @@ struct OpenSeaNonFungibleTokenCardRowViewModel {
     }
 
     var titleColor: UIColor {
-        return Colors.appText
+        return Configuration.Color.Semantic.defaultForegroundText
     }
 
     var subtitleColor: UIColor {

--- a/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
@@ -88,7 +88,7 @@ class TokenHistoryChartViewModel {
     private func gradientColorForTicker(ticker: CoinTicker?) -> UIColor {
         switch TickerHelper(ticker: ticker).change24h {
         case .appreciate, .none:
-            return Colors.appActionButtonGreen
+            return Configuration.Color.Semantic.actionButtonBackground
         case .depreciate:
             return Colors.appRed
         }


### PR DESCRIPTION
After #6100 
# Colors.appActionButtonShadow

## ButtonsBarViewModel

1. From main wallet screen, look at Buy Crypto Button.

Light | Dark After
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-11 at 09 26 32](https://user-images.githubusercontent.com/1050309/211696623-a45acc0c-5c9d-431f-8895-628470afc2b8.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-11 at 09 26 27](https://user-images.githubusercontent.com/1050309/211696629-dd91d498-e2da-4f4c-8243-f5a6e308790d.png)

