### PR TITLE
Updated Makefile to move the compressed chains file into the AlphaWallet/Resources directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ update_chains_file:
 	@echo "Compressing."
 	@$(compress_cmd)
 	@echo "Moving compressed file into project."
-	@mv scripts/chains.json.zip AlphaWallet/Rpc\ Network/chains.zip
+	@mv scripts/chains.json.zip AlphaWallet/Resources/chains.zip
 	@rm -f ./scripts/chains.json
 	@echo "Update completed."
 


### PR DESCRIPTION
Fixes #6104

No change required in Swift code as the file is referenced as `R.file.chainsZip` which is taken care of by R.swift.