### PR TITLE
Removed all direct references and definition of `Colors.appBackground`

### DIFF
--- a/AlphaWallet/Settings/ViewModels/LocaleViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/LocaleViewModel.swift
@@ -22,7 +22,7 @@ struct LocaleViewModel {
     }
 
     var backgroundColor: UIColor {
-        return Colors.appBackground
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 
     var localeFont: UIFont {

--- a/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokenInstanceActionViewController.swift
@@ -80,7 +80,7 @@ class TokenInstanceActionViewController: UIViewController, TokenVerifiableStatus
 
         updateNavigationRightBarButtons(withTokenScriptFileStatus: nil)
 
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         roundedBackground.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(roundedBackground)

--- a/AlphaWallet/Wallet/ViewControllers/ElevateWalletSecurityViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ElevateWalletSecurityViewController.swift
@@ -91,7 +91,7 @@ class ElevateWalletSecurityViewController: UIViewController {
     }
 
     func configure() {
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         title = viewModel.title
 

--- a/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/SeedPhraseBackupIntroductionViewController.swift
@@ -90,7 +90,7 @@ class SeedPhraseBackupIntroductionViewController: UIViewController {
     }
 
     func configure() {
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         subtitleLabel.numberOfLines = 0
         subtitleLabel.attributedText = viewModel.attributedSubtitle

--- a/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ShowSeedPhraseViewController.swift
@@ -179,7 +179,7 @@ class ShowSeedPhraseViewController: UIViewController {
     }
 
     func configure() {
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         subtitleLabel.textAlignment = .center
         subtitleLabel.textColor = viewModel.subtitleColor

--- a/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/VerifySeedPhraseViewController.swift
@@ -218,7 +218,7 @@ class VerifySeedPhraseViewController: UIViewController {
     }
 
     func configure() {
-        view.backgroundColor = Colors.appBackground
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         subtitleLabel.textAlignment = .center
         subtitleLabel.textColor = viewModel.subtitleColor

--- a/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
@@ -59,7 +59,7 @@ struct ElevateWalletSecurityViewModel {
         attributeString.addAttributes([
             .paragraphStyle: style,
             .font: descriptionFont,
-            .foregroundColor: Colors.appText
+            .foregroundColor: Configuration.Color.Semantic.defaultForegroundText
         ], range: NSRange(location: 0, length: description.count))
 
         return attributeString


### PR DESCRIPTION
# Colors.appBackground

There is nothing in this wallet.

## backgroundColor/LocalViewModel

1. Tap settings
2. Tap Advanced
3. Tap Features
4. Enable "Is language switcher enabled"
5. Tap back arrow
6. Tap Change Language

Light mode (before/after) | Dark mode
-|-
![locale-original](https://user-images.githubusercontent.com/1050309/211943487-1aff79bf-6404-43fa-b791-581c849ea371.png)|![locale-dark](https://user-images.githubusercontent.com/1050309/211943329-5fcba934-fa45-44a0-9d62-3995a7b50200.png)

## view.background/TokenInstanceActionViewController

This view is totally obscured by an instance of RoundedBackground so it's colour doesn't matter.

## view.background/ElevateWalletSecurityViewController

[Link to instructions](https://github.com/AlphaWallet/alpha-wallet-ios/pull/5956#issuecomment-1373173201)

On a device, not simulator:

1. Settings tab
2. Back up this Wallet
3. Tap Back up my Wallet
4. OK, I wrote this down
5. Tap to enter seed phrase
6. Tap Verify Seed Phrase
7. Tap Lock Seed Phrase

Light mode (before/after) | Dark mode before | Dark mode after image
-|-|-
![elevate-original](https://user-images.githubusercontent.com/1050309/211943779-65bd5128-f2b8-47b3-b95b-20a659fc6265.png)|![elevate-dark-original](https://user-images.githubusercontent.com/1050309/211943805-9676b522-b382-4056-a97a-7e8a581e1439.png)|![elevate-dark](https://user-images.githubusercontent.com/1050309/211943813-48fd7c4a-51fe-446c-96ee-48428f6d958f.png)

## view.background/SeedPhraseBackupIntroductionViewController

1. Tap settings
2. Tap back up this wallet

Light mode (before/after) | Dark mode image
-|-
![Introduction-light](https://user-images.githubusercontent.com/1050309/211944025-67b27012-6db2-46ce-8833-06d256cf10f5.png)|![Introduction-dark](https://user-images.githubusercontent.com/1050309/211943931-227c7e1b-dac9-4a2d-9b6d-9cac7ebbf5bb.png)

## view.background/ShowSeedPhraseViewController

1. Tap settings
2. Tap show seed phrase
3. Tap Got it, show my seed phrase

Light mode (before/after) | Dark mode image
-|-
![Show-original](https://user-images.githubusercontent.com/1050309/211944168-e4ade2b8-a21d-45d8-96bc-998b1d726d66.png)|![Show-dark](https://user-images.githubusercontent.com/1050309/211944176-eda89a36-a553-4b4c-98c9-b3d47cb578ec.png)

## view.background/VerifySeedPhraseViewController

1. Tap settings
2. Tap back up this wallet
3. Tap back up my wallet
4. Tap Ok I wrote this down

Light mode (before/after) | Dark mode image
-|-
![Verify-original](https://user-images.githubusercontent.com/1050309/211944334-e97baa50-7123-4fc7-a135-3654605d0e77.png)|![Verify-dark](https://user-images.githubusercontent.com/1050309/211944352-c871b50d-0537-4c4e-8bff-447e7cf4d52c.png)
