### PR TITLE
Semantic renaming of variable `Colors.appGreenContrastBackground` to `Configuration.Color.Semantic.textFieldContrastText`. No change in actual colour.

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -102,7 +102,6 @@ extension UITabBarController {
 struct Colors {
     static let appBackground = UIColor.white
     static let appGrayLabel = UIColor(red: 155, green: 155, blue: 155)
-    static let appGreenContrastBackground = UIColor(red: 86, green: 153, blue: 8)
     static let appHighlightGreen = UIColor(red: 117, green: 185, blue: 67)
     static let apprecationGreen = Colors.appHighlightGreen
     static let apprecationRed = UIColor(hex: "ff3b30")

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -249,6 +249,8 @@ struct Configuration {
                 return colorFrom(trait: trait, lightColor: R.color.alabaster()!, darkColor: R.color.venus()!)
             }
 
+            static let textFieldContrastText = UIColor(red: 86, green: 153, blue: 8)
+            
             static let textFieldBackground = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.alabaster()!, darkColor: R.color.venus()!)
             }

--- a/AlphaWallet/Common/Views/AmountTextField.swift
+++ b/AlphaWallet/Common/Views/AmountTextField.swift
@@ -88,7 +88,7 @@ final class AmountTextField: UIControl {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .left
         label.numberOfLines = 0
-        label.textColor = Colors.appGreenContrastBackground
+        label.textColor = Configuration.Color.Semantic.textFieldContrastText
         label.font = Configuration.Font.label
 
         return label

--- a/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
@@ -102,7 +102,7 @@ func createTokenScriptFileStatusButton(withStatus status: TokenLevelTokenScriptD
             title = message
         }
         image = R.image.verified()
-        tintColor = Colors.appGreenContrastBackground
+        tintColor = Configuration.Color.Semantic.textFieldContrastText
     case .type2BadTokenScript(let isDebugMode, let error, let reason):
         switch reason {
         case .some(.oldTokenScriptVersion):


### PR DESCRIPTION
Semantic renaming of variable. No change in actual colour. 