### PR TITLE
Donate shortcut for camera

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		5E7C72A83542B1CB69E7B4B7 /* EnabledServersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B6A80324059B3EDA38C /* EnabledServersViewController.swift */; };
 		5E7C72B0A10A92E591696E48 /* ContactUsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7AE6FAE0DF969B4F52E9 /* ContactUsBannerView.swift */; };
 		5E7C72B4302A10E137EEF94A /* DappRequestSwitchCustomChainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7C11AF59E7CA26B3A2BB /* DappRequestSwitchCustomChainCoordinator.swift */; };
+		5E7C72C38C700EACD9AD9C96 /* CameraDonation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C781EC7B566DA16720207 /* CameraDonation.swift */; };
 		5E7C72C8A15397C5A40BFE76 /* WhatIsEthereumInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C774BCA281E4B077DBBFA /* WhatIsEthereumInfoViewController.swift */; };
 		5E7C72CEFE98436DB8EC0E05 /* BrowserHistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C73D55C366BCC53208686 /* BrowserHistoryCell.swift */; };
 		5E7C72CF145240C816BB12E2 /* DappsHomeViewControllerHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7375430F36C549EA8748 /* DappsHomeViewControllerHeaderViewViewModel.swift */; };
@@ -1150,6 +1151,7 @@
 		5E7C77E2559C7C9117C0F75F /* ElevateWalletSecurityViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElevateWalletSecurityViewModel.swift; sourceTree = "<group>"; };
 		5E7C77FAAB69452F5310356F /* EIP712TypedDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EIP712TypedDataTests.swift; sourceTree = "<group>"; };
 		5E7C7809B67CC2D8D6AA31C4 /* KeystoreBackupIntroductionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeystoreBackupIntroductionViewModel.swift; sourceTree = "<group>"; };
+		5E7C781EC7B566DA16720207 /* CameraDonation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraDonation.swift; sourceTree = "<group>"; };
 		5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportMagicTokenCardRowViewModel.swift; sourceTree = "<group>"; };
 		5E7C7828BD821B6F04B71C00 /* FungibleTokenHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FungibleTokenHeaderView.swift; sourceTree = "<group>"; };
 		5E7C783E3ADA4CF9554A0E7D /* NonFungibleTokenViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonFungibleTokenViewCell.swift; sourceTree = "<group>"; };
@@ -2976,6 +2978,7 @@
 			children = (
 				5E7C7F4F9F57A4B1834EB723 /* WalletQrCodeDonation.swift */,
 				5E7C7E654FD9501D83F355C1 /* Donations.swift */,
+				5E7C781EC7B566DA16720207 /* CameraDonation.swift */,
 			);
 			path = Donations;
 			sourceTree = "<group>";
@@ -5616,6 +5619,7 @@
 				5E7C79A9B4DCEB1A62D657B7 /* CrashReporterViewModel.swift in Sources */,
 				5E7C7C8C689E972389F4A564 /* CrashReporterViewController.swift in Sources */,
 				5E7C7307FAE6F7E0BC1FE6A3 /* Donations.swift in Sources */,
+				5E7C72C38C700EACD9AD9C96 /* CameraDonation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -541,16 +541,26 @@ class AppCoordinator: NSObject, Coordinator {
     }
 
     private func handleIntent(userActivity: NSUserActivity) -> Bool {
-        if let type = userActivity.userInfo?[Donations.typeKey] as? String, type == WalletQrCodeDonation.userInfoTypeValue {
-            analytics.log(navigation: Analytics.Navigation.openShortcut, properties: [
-                Analytics.Properties.type.rawValue: Analytics.ShortcutType.walletQrCode.rawValue
-            ])
-            activeWalletCoordinator?.showWalletQrCode()
-            return true
-        } else {
-            return false
+        if let type = userActivity.userInfo?[Donations.typeKey] as? String {
+            infoLog("[Shortcuts] handleIntent type: \(type)")
+            if type == CameraDonation.userInfoTypeValue {
+                analytics.log(navigation: Analytics.Navigation.openShortcut, properties: [
+                    Analytics.Properties.type.rawValue: Analytics.ShortcutType.camera.rawValue
+                ])
+                self.launchUniversalScanner(fromSource: .siriShortcut)
+                return true
+            }
+            if type == WalletQrCodeDonation.userInfoTypeValue {
+                analytics.log(navigation: Analytics.Navigation.openShortcut, properties: [
+                    Analytics.Properties.type.rawValue: Analytics.ShortcutType.walletQrCode.rawValue
+                ])
+                activeWalletCoordinator?.showWalletQrCode()
+                return true
+            }
         }
+        return false
     }
+
     //NOTE: not good to pass `activeSessionsProvider` but needed to update active wallet session with right sessions in time
     private func buildDependencies(for wallet: Wallet) -> WalletDependencies {
         if let dep = dependencies[wallet] { return dep  }

--- a/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
@@ -55,6 +55,7 @@ final class ScanQRCodeCoordinator: NSObject, Coordinator {
     }
 
     func start(fromSource source: Analytics.ScanQRCodeSource, clipboardString: String? = nil) {
+        CameraDonation().donate()
         logStartScan(source: source)
         navigationController.makePresentationFullScreenForiOS13Migration()
         parentNavigationController.present(navigationController, animated: true)

--- a/AlphaWallet/Donations/CameraDonation.swift
+++ b/AlphaWallet/Donations/CameraDonation.swift
@@ -1,0 +1,49 @@
+// Copyright © 2023 Stormbird PTE. LTD.
+
+import CoreSpotlight
+import Foundation
+import AlphaWalletFoundation
+
+class CameraDonation {
+    //TODO maybe change to include wallet address
+    private static let persistentIdentifier: NSUserActivityPersistentIdentifier = activityType
+    //Matches `Info.plist` entry
+    private static let activityType = "com.alphawallet.camera"
+
+    //Because donating a shortcut is asynchronous, the NSUserActivity has to be kept alive for a bit
+    private var userActivity: NSUserActivity?
+    //Because donating a shortcut is asynchronous, the NSUserActivity has to be kept alive for a bit. We keep a strong reference to self for a short while to ensure that so client code doesn't have to
+    private var selfReference: CameraDonation?
+
+    static let userInfoTypeValue = "cameraDonation"
+
+    init() {
+        selfReference = self
+        Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
+            self.selfReference = nil
+        }
+    }
+
+    func donate() {
+        let activity = NSUserActivity(activityType: Self.activityType)
+        activity.title = R.string.localizable.donateShortcutsCamera()
+        let userInfo = [Donations.typeKey: Self.userInfoTypeValue]
+        activity.addUserInfoEntries(from: userInfo)
+        activity.requiredUserInfoKeys = [Donations.typeKey]
+        activity.isEligibleForPrediction = true
+        activity.isEligibleForSearch = true
+        activity.persistentIdentifier = Self.persistentIdentifier
+        self.userActivity = activity
+        activity.becomeCurrent()
+        infoLog("[Shortcuts] donated \(Self.persistentIdentifier) userInfo: \(userInfo)")
+    }
+
+    //For development only
+    func delete() {
+        infoLog("[Shortcuts] Deleting donated shortcut: \(Self.persistentIdentifier)…")
+        CSSearchableIndex.default().deleteSearchableItems(withDomainIdentifiers: [Self.persistentIdentifier])
+        NSUserActivity.deleteSavedUserActivities(withPersistentIdentifiers: [Self.persistentIdentifier]) {
+            infoLog("[Shortcuts] Deleted donated shortcut: \(Self.persistentIdentifier)")
+        }
+    }
+}

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -103,6 +103,7 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>com.alphawallet.ethereum-wallet-qr-code</string>
+		<string>com.alphawallet.camera</string>
 	</array>
 	<key>UIAppFonts</key>
 	<array>

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "You tried to connect with WalletConnect.\nWell.. It takes too long. Please generate\na fresh QR code and try again.";
 "walletConnect.scanQRCodeAgain" = "Scan QR Code again";
 "donate.shortcuts.walletQrCode" = "Show Wallet QR Code";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "What’s new?";
 "token.testnetWarning" = "Ropsten tokens are like ‘Monopoly’ money. They have zero financial worth but are used by developers to try out new designs without needing to spend valuable coins. ";
 "token.value.testnetWarning" = "No Value, made for tests only";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "You tried to connect with WalletConnect.\nWell.. It takes too long. Please generate\na fresh QR code and try again.";
 "walletConnect.scanQRCodeAgain" = "Scan QR Code again";
 "donate.shortcuts.walletQrCode" = "Show Wallet QR Code";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "What’s new?";
 "token.testnetWarning" = "Ropsten tokens are like ‘Monopoly’ money. They have zero financial worth but are used by developers to try out new designs without needing to spend valuable coins. ";
 "token.value.testnetWarning" = "No Value, made for tests only";

--- a/AlphaWallet/Localization/fi.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/fi.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "Yritit kytkeä WalletConnect-toiminnolla.\nValitettavasti tämä kesti liian pitkään. Luo uusi\nQR-koodi ja yritä uudestaan.";
 "walletConnect.scanQRCodeAgain" = "Lue QR-koodi uudestaan";
 "donate.shortcuts.walletQrCode" = "Näytä lompakon QR-koodi";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "Mitä uutta?";
 "token.testnetWarning" = "Ropsten-rahakkeet eivät ole vaihdettavissa keskuspankkirahaan. Niiden rahallinen arvo on nolla. Sovelluskehittäjät käyttävät niitä testatakseen uusia asioita ilman, että heidän täytyy käyttää 'oikeita' Ethereum-rahakkeita.";
 "token.value.testnetWarning" = "Ei arvoa, luotu testaustarkoituksiin";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "You tried to connect with WalletConnect.\nWell.. It takes too long. Please generate\na fresh QR code and try again.";
 "walletConnect.scanQRCodeAgain" = "Scan QR Code again";
 "donate.shortcuts.walletQrCode" = "Show Wallet QR Code";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "What’s new?";
 "token.testnetWarning" = "Ropsten tokens are like ‘Monopoly’ money. They have zero financial worth but are used by developers to try out new designs without needing to spend valuable coins. ";
 "token.value.testnetWarning" = "No Value, made for tests only";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "You tried to connect with WalletConnect.\nWell.. It takes too long. Please generate\na fresh QR code and try again.";
 "walletConnect.scanQRCodeAgain" = "Scan QR Code again";
 "donate.shortcuts.walletQrCode" = "Show Wallet QR Code";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "What’s new?";
 "token.testnetWarning" = "Ropsten tokens are like ‘Monopoly’ money. They have zero financial worth but are used by developers to try out new designs without needing to spend valuable coins. ";
 "token.value.testnetWarning" = "No Value, made for tests only";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -803,6 +803,7 @@
 "walletConnect.error.connectionTimeout.errorMessage" = "You tried to connect with WalletConnect.\nWell.. It takes too long. Please generate\na fresh QR code and try again.";
 "walletConnect.scanQRCodeAgain" = "Scan QR Code again";
 "donate.shortcuts.walletQrCode" = "Show Wallet QR Code";
+"donate.shortcuts.camera" = "Scan QR Code with Camera";
 "whats.new" = "What’s new?";
 "token.testnetWarning" = "Ropsten tokens are like ‘Monopoly’ money. They have zero financial worth but are used by developers to try out new designs without needing to spend valuable coins. ";
 "token.value.testnetWarning" = "No Value, made for tests only";

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Analytics/AnalyticsTypes.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Analytics/AnalyticsTypes.swift
@@ -160,6 +160,7 @@ public enum Analytics {
         case addCustomTokenScreen
         case walletScreen
         case quickAction
+        case siriShortcut
     }
 
     public enum ScanQRCodeResultType: String {
@@ -236,6 +237,7 @@ public enum Analytics {
 
     public enum ShortcutType: String {
         case walletQrCode
+        case camera
     }
 
     public enum HelpUrl: String {


### PR DESCRIPTION
Donates the Siri shortcut when the user starts the in-app camera (unlike the shortcut for displaying the wallet QR code which is is donated when the wallet is loaded/switched to).

Tapping the shortcut launches the in-app camera/QR code scanner.

The donated shortcut appears in search results and in the Siri suggestions widget. Looks like this in the search results:

<img width="400" alt="Screenshot 2023-01-13 at 5 20 55 PM" src="https://user-images.githubusercontent.com/56189/212284608-f359359a-4ac7-4da9-8bd6-4abd87b797db.png">