### PR TITLE
Make functions return type reflect actual return types

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/RLP.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/RLP.swift
@@ -56,7 +56,7 @@ public struct RLP {
         return encodeBigUInt(number.magnitude)
     }
 
-    static func encodeBigUInt(_ number: BigUInt) -> Data? {
+    static func encodeBigUInt(_ number: BigUInt) -> Data {
         let encoded = number.serialize()
         if encoded.isEmpty {
             return Data(bytes: [0x80])

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Requests/GetTransactionRequest.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Requests/GetTransactionRequest.swift
@@ -21,12 +21,9 @@ struct GetTransactionRequest: JSONRPCKit.Request {
             infoLog("[RPC] Fetch transaction by hash: \(hash) is null")
             return nil
         }
-        guard
-            let dict = resultObject as? [String: AnyObject],
-            let transaction = PendingTransaction.from(dict)
-        else {
+        guard let dict = resultObject as? [String: AnyObject] else {
             throw CastError(actualValue: resultObject, expectedType: Response.self)
         }
-        return transaction
+        return PendingTransaction.from(dict)
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Foundation/QRCodeValueParser.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Foundation/QRCodeValueParser.swift
@@ -18,7 +18,7 @@ public struct AddressOrEip681Parser {
             return .address(address)
         }
 
-        guard parts.count == 2, let address = parts.last?.slice(to: "@")?.slice(to: "/")?.slice(to: "?").flatMap({ AddressOrEnsName(string: Eip681Parser.stripOptionalPrefix(from: $0)) }) else { return nil }
+        guard parts.count == 2, let addressOrNameString = parts.last?.slice(to: "@").slice(to: "/").slice(to: "?"), let address = AddressOrEnsName(string: Eip681Parser.stripOptionalPrefix(from: addressOrNameString)) else { return nil }
         let secondHalf = parts[1]
         let uncheckedParamParts = Array(secondHalf.components(separatedBy: "?")[1...])
         let paramParts = uncheckedParamParts.isEmpty ? [] : Array(uncheckedParamParts[0].components(separatedBy: "&"))
@@ -65,7 +65,7 @@ public extension String {
         }
     }
 
-    func slice(to: String) -> String? {
+    func slice(to: String) -> String {
         if let substringTo = (range(of: to, range: startIndex..<endIndex)?.lowerBound) {
             return String(self[startIndex..<substringTo])
         } else {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Rpc Network/AvailableRpcNetwork.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Rpc Network/AvailableRpcNetwork.swift
@@ -35,7 +35,7 @@ public struct RpcNetwork: Codable {
         }
         return name.lowercased().contains("testnet")
     }
-    
+
     public var customRpc: CustomRPC {
         CustomRPC(chainID: chainId, nativeCryptoTokenName: nativeCurrency.name, chainName: name, symbol: nativeCurrency.symbol, rpcEndpoint: rpc.first ?? "", explorerEndpoint: infoURL, etherscanCompatibleType: .unknown, isTestnet: isTestNet)
     }
@@ -59,10 +59,10 @@ public struct NativeCurrency: Codable {
 }
 
 fileprivate func readFromCompressedFile(filePathUrl: URL?) -> [CustomRPC]? {
-    guard let filePathUrl = filePathUrl, let rawData = readFileIntoMemory(url: filePathUrl), let uncompressedData = uncompressData(data: rawData), let unfilteredChainArray = decodeDataToChainEntryArray(data: uncompressedData), let chainList = filterChainAndConvertToCustomRPC(chains: unfilteredChainArray) else {
+    guard let filePathUrl = filePathUrl, let rawData = readFileIntoMemory(url: filePathUrl), let uncompressedData = uncompressData(data: rawData), let unfilteredChainArray = decodeDataToChainEntryArray(data: uncompressedData) else {
         return nil
     }
-    return chainList
+    return filterChainAndConvertToCustomRPC(chains: unfilteredChainArray)
 }
 
 fileprivate func readFileIntoMemory(url: URL) -> Data? {
@@ -91,7 +91,7 @@ fileprivate func decodeDataToChainEntryArray(data: Data) -> [RpcNetwork]? {
     }
 }
 
-fileprivate func filterChainAndConvertToCustomRPC(chains: [RpcNetwork]) -> [CustomRPC]? {
+fileprivate func filterChainAndConvertToCustomRPC(chains: [RpcNetwork]) -> [CustomRPC] {
     let viewModel = SaveCustomRpcManualEntryViewModel(operation: .add)
     let filteredChain = chains.compactMap { entry -> CustomRPC? in
         switch viewModel.validate(entry: entry) {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeSyntax.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeSyntax.swift
@@ -42,7 +42,7 @@ public enum AssetAttributeSyntax: String {
         }
     }
 
-    private func coerceSubscribableToSyntax(_ subscribable: Subscribable<AssetInternalValue>) -> AssetInternalValue? {
+    private func coerceSubscribableToSyntax(_ subscribable: Subscribable<AssetInternalValue>) -> AssetInternalValue {
         let convertedSubscribable = Subscribable<AssetInternalValue>(nil)
         subscribable.subscribe { value in
             guard let value = value else { return }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeValueUsableAsFunctionArguments.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetAttributeValueUsableAsFunctionArguments.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import BigInt
-import TrustKeystore 
+import TrustKeystore
 import AlphaWalletWeb3
 
 public enum AssetAttributeValueUsableAsFunctionArguments {
@@ -42,15 +42,15 @@ public enum AssetAttributeValueUsableAsFunctionArguments {
         case .address:
             return coerceToAddress(forFunctionType: functionType)
         case .bool:
-            return coerceToBool(forFunctionType: functionType)
+            return coerceToBool(forFunctionType: functionType) as AnyObject
         case .int, .int8, .int16, .int24, .int32, .int40, .int48, .int56, .int64, .int72, .int80, .int88, .int96, .int104, .int112, .int120, .int128, .int136, .int144, .int152, .int160, .int168, .int176, .int184, .int192, .int200, .int208, .int216, .int224, .int232, .int240, .int248, .int256:
-            return coerceToInt(forFunctionType: functionType)
+            return coerceToInt(forFunctionType: functionType) as AnyObject
         case .string, .bytes:
-            return coerceToString(forFunctionType: functionType)
+            return coerceToString(forFunctionType: functionType) as AnyObject
         case .bytes1, .bytes2, .bytes3, .bytes4, .bytes5, .bytes6, .bytes7, .bytes8, .bytes9, .bytes10, .bytes11, .bytes12, .bytes13, .bytes14, .bytes15, .bytes16, .bytes17, .bytes18, .bytes19, .bytes20, .bytes21, .bytes22, .bytes23, .bytes24, .bytes25, .bytes26, .bytes27, .bytes28, .bytes29, .bytes30, .bytes31, .bytes32:
-            return coerceToBytes(forFunctionType: functionType)
+            return coerceToBytes(forFunctionType: functionType) as AnyObject
         case .uint, .uint8, .uint16, .uint24, .uint32, .uint40, .uint48, .uint56, .uint64, .uint72, .uint80, .uint88, .uint96, .uint104, .uint112, .uint120, .uint128, .uint136, .uint144, .uint152, .uint160, .uint168, .uint176, .uint184, .uint192, .uint200, .uint208, .uint216, .uint224, .uint232, .uint240, .uint248, .uint256:
-            return coerceToUInt(forFunctionType: functionType)
+            return coerceToUInt(forFunctionType: functionType) as AnyObject
         case .void:
             return nil
         }
@@ -102,34 +102,34 @@ public enum AssetAttributeValueUsableAsFunctionArguments {
         }
     }
 
-    private func coerceToBool(forFunctionType functionType: FunctionOrigin.FunctionType) -> AnyObject? {
+    private func coerceToBool(forFunctionType functionType: FunctionOrigin.FunctionType) -> Bool? {
         switch self {
         case .bool(let bool):
-            return bool as AnyObject
+            return bool
         case .string(let string):
             switch string {
             case "TRUE", "true":
-                return true as AnyObject
+                return true
             case "FALSE", "false":
-                return false as AnyObject
+                return false
             default:
                 return nil
             }
         case .int(let int):
             switch int {
             case 1:
-                return true as AnyObject
+                return true
             case 0:
-                return false as AnyObject
+                return false
             default:
                 return nil
             }
         case .uint(let uint):
             switch uint {
             case 1:
-                return true as AnyObject
+                return true
             case 0:
-                return false as AnyObject
+                return false
             default:
                 return nil
             }
@@ -137,9 +137,9 @@ public enum AssetAttributeValueUsableAsFunctionArguments {
             let dataAsBigUInt = BigUInt(data)
             switch dataAsBigUInt {
             case 1:
-                return true as AnyObject
+                return true
             case 0:
-                return false as AnyObject
+                return false
             default:
                 return nil
             }
@@ -148,67 +148,67 @@ public enum AssetAttributeValueUsableAsFunctionArguments {
         }
     }
 
-    private func coerceToInt(forFunctionType functionType: FunctionOrigin.FunctionType) -> AnyObject? {
+    private func coerceToInt(forFunctionType functionType: FunctionOrigin.FunctionType) -> BigInt? {
         switch self {
         case .int(let int):
-            return int as AnyObject
+            return int
         case .uint(let uint):
-            return BigInt(uint) as AnyObject
+            return BigInt(uint)
         case .string(let string):
-            return BigInt(string) as AnyObject
+            return BigInt(string)
         case .address, .generalisedTime, .bool, .bytes:
             return nil
         }
     }
 
-    private func coerceToString(forFunctionType functionType: FunctionOrigin.FunctionType) -> AnyObject? {
+    private func coerceToString(forFunctionType functionType: FunctionOrigin.FunctionType) -> String {
         switch self {
         case .address(let address):
-            return address.eip55String as AnyObject
+            return address.eip55String
         case .string(let string):
-            return string as AnyObject
+            return string
         case .bytes(let bytes):
-            return bytes.hexEncoded as AnyObject
+            return bytes.hexEncoded
         case .int(let int):
-            return int.description as AnyObject
+            return int.description
         case .uint(let uint):
-            return uint.description as AnyObject
+            return uint.description
         case .generalisedTime(let generalisedTime):
-            return generalisedTime.formatAsGeneralisedTime as AnyObject
+            return generalisedTime.formatAsGeneralisedTime
         case .bool(let bool):
-            return bool.description as AnyObject
+            return bool.description
         }
     }
 
-    private func coerceToUInt(forFunctionType functionType: FunctionOrigin.FunctionType) -> AnyObject? {
+    private func coerceToUInt(forFunctionType functionType: FunctionOrigin.FunctionType) -> BigUInt? {
         switch self {
         case .int(let int):
-            return BigUInt(int) as AnyObject
+            return BigUInt(int)
         case .uint(let uint):
-            return uint as AnyObject
+            return uint
         case .string(let string):
-            return BigUInt(string) as AnyObject
+            return BigUInt(string)
         case .bytes(let data):
-            return BigUInt(data) as AnyObject
+            return BigUInt(data)
         case .address, .generalisedTime, .bool:
             return nil
         }
     }
 
-    private func coerceToBytes(forFunctionType functionType: FunctionOrigin.FunctionType) -> AnyObject? {
+    private func coerceToBytes(forFunctionType functionType: FunctionOrigin.FunctionType) -> Data? {
         switch self {
         case .int(let int):
-            return BigUInt(int).serialize() as AnyObject
+            return BigUInt(int).serialize()
         case .uint(let uint):
-            return uint.serialize() as AnyObject
+            return uint.serialize()
         case .string(let string):
             if string.hasPrefix("0x"), string.count > 2, string.count % 2 == 0 {
-                return Data(_hex: string) as AnyObject
+                return Data(_hex: string)
             } else {
-                return string.data(using: .utf8) as AnyObject
+                return string.data(using: .utf8)
             }
         case .bytes(let data):
-            return data as AnyObject
+            return data
         case .address, .generalisedTime, .bool:
             return nil
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/PendingTransaction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/PendingTransaction.swift
@@ -16,7 +16,7 @@ public struct PendingTransaction {
 }
 
 extension PendingTransaction {
-    public static func from(_ transaction: [String: AnyObject]) -> PendingTransaction? {
+    public static func from(_ transaction: [String: AnyObject]) -> PendingTransaction {
         let blockHash = transaction["blockHash"] as? String ?? ""
         let blockNumber = transaction["blockNumber"] as? String ?? ""
         let gas = transaction["gas"] as? String ?? "0"
@@ -38,4 +38,4 @@ extension PendingTransaction {
             nonce: BigInt(nonce.drop0x, radix: 16)?.description ?? ""
         )
     }
-} 
+}

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Extensions/String+Extension.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Extensions/String+Extension.swift
@@ -4,7 +4,7 @@ extension String {
     var fullRange: Range<Index> {
         return startIndex..<endIndex
     }
-    
+
     var fullNSRange: NSRange {
         return NSRange(fullRange, in: self)
     }
@@ -15,7 +15,7 @@ extension String {
         }
         return range.lowerBound
     }
-    
+
     func index(of char: Character) -> Index? {
         guard let range = range(of: String(char)) else {
             return nil
@@ -33,25 +33,25 @@ extension String {
         }
         return output
     }
-    
+
     subscript (bounds: CountableClosedRange<Int>) -> String {
         let start = index(self.startIndex, offsetBy: bounds.lowerBound)
         let end = index(self.startIndex, offsetBy: bounds.upperBound)
         return String(self[start...end])
     }
-    
+
     subscript (bounds: CountableRange<Int>) -> String {
         let start = index(self.startIndex, offsetBy: bounds.lowerBound)
         let end = index(self.startIndex, offsetBy: bounds.upperBound)
         return String(self[start..<end])
     }
-    
+
     subscript (bounds: CountablePartialRangeFrom<Int>) -> String {
         let start = index(self.startIndex, offsetBy: bounds.lowerBound)
         let end = self.endIndex
         return String(self[start..<end])
     }
-    
+
     func leftPadding(toLength: Int, withPad character: Character) -> String {
         let stringLength = self.count
         if stringLength < toLength {
@@ -64,7 +64,7 @@ extension String {
     var hasHexPrefix: Bool {
         return self.hasPrefix("0x")
     }
-    
+
     func stripHexPrefix() -> String {
         if self.hasPrefix("0x") {
             let indexStart = self.index(self.startIndex, offsetBy: 2)
@@ -72,14 +72,14 @@ extension String {
         }
         return self
     }
-    
+
     func addHexPrefix() -> String {
         if !self.hasPrefix("0x") {
             return "0x" + self
         }
         return self
     }
-    
+
     func stripLeadingZeroes() -> String? {
         let hex = self.addHexPrefix()
         guard let matcher = try? NSRegularExpression(pattern: "^(?<prefix>0x)0*(?<end>[0-9a-fA-F]*)$", options: NSRegularExpression.Options.dotMatchesLineSeparators) else { return nil }
@@ -91,7 +91,7 @@ extension String {
         }
         return "0x0"
     }
-    
+
     func matchingStrings(regex: String) -> [[String]] {
         guard let regex = try? NSRegularExpression(pattern: regex, options: []) else { return [] }
         let nsString = self as NSString
@@ -103,7 +103,7 @@ extension String {
             }
         }
     }
-    
+
     func range(from nsRange: NSRange) -> Range<String.Index>? {
         guard
             let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location, limitedBy: utf16.endIndex),
@@ -113,7 +113,7 @@ extension String {
             else { return nil }
         return from ..< to
     }
-    
+
     var asciiValue: Int {
         let s = self.unicodeScalars
         return Int(s[s.startIndex].value)

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Extensions/String+Extension.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Extensions/String+Extension.swift
@@ -60,13 +60,7 @@ extension String {
             return String(self.suffix(toLength))
         }
     }
-    
-    func interpretAsBinaryData() -> Data? {
-        let padded = self.padding(toLength: ((self.count + 7) / 8) * 8, withPad: "0", startingAt: 0)
-        let byteArray = padded.split(intoChunksOf: 8).map { UInt8(strtoul($0, nil, 2)) }
-        return Data(byteArray)
-    }
-    
+
     var hasHexPrefix: Bool {
         return self.hasPrefix("0x")
     }

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Utils/Web3+Utils.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Utils/Web3+Utils.swift
@@ -22,7 +22,7 @@ extension Web3.Utils {
 
         return EthereumAddress(Data(contractAddressData))
     }
-    
+
     public enum Units {
         case eth
         case wei
@@ -31,7 +31,7 @@ extension Web3.Utils {
         case Gwei
         case Microether
         case Finney
-        
+
         var decimals: Int {
             switch self {
             case .eth:
@@ -51,18 +51,18 @@ extension Web3.Utils {
             }
         }
     }
-    
+
     public static var coldWalletABI = "[{\"payable\":true,\"type\":\"fallback\"}]"
     public static var erc20ABI = "[{\"constant\":true,\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_spender\",\"type\":\"address\"},{\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"name\":\"success\",\"type\":\"bool\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_from\",\"type\":\"address\"},{\"name\":\"_to\",\"type\":\"address\"},{\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"name\":\"success\",\"type\":\"bool\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_to\",\"type\":\"address\"},{\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"name\":\"success\",\"type\":\"bool\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_spender\",\"type\":\"address\"},{\"name\":\"_value\",\"type\":\"uint256\"},{\"name\":\"_extraData\",\"type\":\"bytes\"}],\"name\":\"approveAndCall\",\"outputs\":[{\"name\":\"success\",\"type\":\"bool\"}],\"payable\":false,\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\"},{\"name\":\"_spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"name\":\"remaining\",\"type\":\"uint256\"}],\"payable\":false,\"type\":\"function\"},{\"inputs\":[{\"name\":\"_initialAmount\",\"type\":\"uint256\"},{\"name\":\"_tokenName\",\"type\":\"string\"},{\"name\":\"_decimalUnits\",\"type\":\"uint8\"},{\"name\":\"_tokenSymbol\",\"type\":\"string\"}],\"type\":\"constructor\"},{\"payable\":false,\"type\":\"fallback\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"_to\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"_owner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"_spender\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},]"
 }
 
 extension Web3.Utils {
-    
+
     public static func privateToPublic(_ privateKey: Data, compressed: Bool = false) -> Data? {
         guard let publicKey = SECP256K1.privateToPublic(privateKey: privateKey, compressed: compressed) else { return nil }
         return publicKey
     }
-    
+
     public static func publicToAddressData(_ publicKey: Data) -> Data? {
         if publicKey.count == 33 {
             guard let decompressedKey = SECP256K1.combineSerializedPublicKeys(keys: [publicKey], outputCompressed: false) else { return nil }
@@ -82,23 +82,23 @@ extension Web3.Utils {
         let addressData = sha3[12...31]
         return addressData
     }
-    
+
     public static func publicToAddress(_ publicKey: Data) -> EthereumAddress? {
         guard let addressData = Web3.Utils.publicToAddressData(publicKey) else { return nil }
         let address = addressData.toHexString().addHexPrefix().lowercased()
         return EthereumAddress(address)
     }
-    
+
     public static func publicToAddressString(_ publicKey: Data) -> String? {
         guard let addressData = Web3.Utils.publicToAddressData(publicKey) else { return nil }
         let address = addressData.toHexString().addHexPrefix().lowercased()
         return address
     }
-    
+
     public static func addressDataToString(_ addressData: Data) -> String {
         return addressData.toHexString().addHexPrefix().lowercased()
     }
-    
+
     public static func hashPersonalMessage(_ personalMessage: Data) -> Data? {
         var prefix = "\u{19}Ethereum Signed Message:\n"
         prefix += String(personalMessage.count)
@@ -113,12 +113,12 @@ extension Web3.Utils {
         let hash = data.sha3(.keccak256)
         return hash
     }
-    
+
     public static func parseToBigUInt(_ amount: String, units: Web3.Utils.Units = .eth) -> BigUInt? {
         let unitDecimals = units.decimals
         return parseToBigUInt(amount, decimals: unitDecimals)
     }
-    
+
     public static func parseToBigUInt(_ amount: String, decimals: Int = 18) -> BigUInt? {
         let separators = CharacterSet(charactersIn: ".,")
         let components = amount.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: separators)
@@ -135,7 +135,7 @@ extension Web3.Utils {
         }
         return mainPart
     }
-    
+
     public static func formatToEthereumUnits(_ bigNumber: BigInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".") -> String? {
         let magnitude = bigNumber.magnitude
         guard let formatted = formatToEthereumUnits(magnitude, toUnits: toUnits, decimals: decimals, decimalSeparator: decimalSeparator) else { return nil }
@@ -146,8 +146,8 @@ extension Web3.Utils {
             return "-" + formatted
         }
     }
-    
     public static func formatToPrecision(_ bigNumber: BigInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
+
         let magnitude = bigNumber.magnitude
         guard let formatted = formatToPrecision(magnitude, numberDecimals: numberDecimals, formattingDecimals: formattingDecimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific) else { return nil }
         switch bigNumber.sign {
@@ -157,12 +157,12 @@ extension Web3.Utils {
             return "-" + formatted
         }
     }
-    
+
     public static func formatToEthereumUnits(_ bigNumber: BigUInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
         return formatToPrecision(bigNumber, numberDecimals: toUnits.decimals, formattingDecimals: decimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific)
     }
-    
     public static func formatToPrecision(_ bigNumber: BigUInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
+
         if bigNumber == 0 {
             return "0"
         }
@@ -197,13 +197,13 @@ extension Web3.Utils {
         }
         return String(quotient) + decimalSeparator + remainderPadded
     }
-    
+
     static public func personalECRecover(_ personalMessage: String, signature: String) -> EthereumAddress? {
         guard let data = Data.fromHex(personalMessage) else { return nil }
         guard let sig = Data.fromHex(signature) else { return nil }
         return Web3.Utils.personalECRecover(data, signature: sig)
     }
-    
+
     static public func personalECRecover(_ personalMessage: Data, signature: Data) -> EthereumAddress? {
         if signature.count != 65 { return nil }
         let rData = signature[0 ..< 32].bytes
@@ -214,7 +214,7 @@ extension Web3.Utils {
         guard let publicKey = SECP256K1.recoverPublicKey(hash: hash, signature: signatureData) else { return nil }
         return Web3.Utils.publicToAddress(publicKey)
     }
-    
+
     static public func hashECRecover(hash: Data, signature: Data) -> EthereumAddress? {
         if signature.count != 65 { return nil }
         let rData = signature[0 ..< 32].bytes
@@ -224,25 +224,25 @@ extension Web3.Utils {
         guard let publicKey = SECP256K1.recoverPublicKey(hash: hash, signature: signatureData) else { return nil }
         return Web3.Utils.publicToAddress(publicKey)
     }
-    
+
     /// returns Ethereum variant of sha3 (keccak256) of data. Returns nil is data is empty
     static public func keccak256(_ data: Data) -> Data? {
         if data.isEmpty { return nil }
         return data.sha3(.keccak256)
     }
-    
+
     /// returns Ethereum variant of sha3 (keccak256) of data. Returns nil is data is empty
     static public func sha3(_ data: Data) -> Data? {
         if data.isEmpty { return nil }
         return data.sha3(.keccak256)
     }
-    
+
     /// returns sha256 of data. Returns nil is data is empty
     static public func sha256(_ data: Data) -> Data? {
         if data.isEmpty { return nil }
         return data.sha256()
     }
-    
+
     static func unmarshalSignature(signatureData: Data) -> SECP256K1.UnmarshaledSignature? {
         if signatureData.count != 65 { return nil }
         let bytes = signatureData.bytes
@@ -250,7 +250,7 @@ extension Web3.Utils {
         let s = Array(bytes[32..<64])
         return SECP256K1.UnmarshaledSignature(v: bytes[64], r: r, s: s)
     }
-    
+
     static func marshalSignature(v: UInt8, r: [UInt8], s: [UInt8]) -> Data? {
         guard r.count == 32, s.count == 32 else { return nil }
         var completeSignature = Data(bytes: r)
@@ -258,7 +258,7 @@ extension Web3.Utils {
         completeSignature.append(Data(bytes: [v]))
         return completeSignature
     }
-    
+
     static func marshalSignature(unmarshalledSignature: SECP256K1.UnmarshaledSignature) -> Data? {
         var completeSignature = Data(bytes: unmarshalledSignature.r)
         completeSignature.append(Data(bytes: unmarshalledSignature.s))

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Utils/Web3+Utils.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Utils/Web3+Utils.swift
@@ -136,20 +136,9 @@ extension Web3.Utils {
         return mainPart
     }
 
-    public static func formatToEthereumUnits(_ bigNumber: BigInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".") -> String? {
+    public static func formatToEthereumUnits(_ bigNumber: BigInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".") -> String {
         let magnitude = bigNumber.magnitude
-        guard let formatted = formatToEthereumUnits(magnitude, toUnits: toUnits, decimals: decimals, decimalSeparator: decimalSeparator) else { return nil }
-        switch bigNumber.sign {
-        case .plus:
-            return formatted
-        case .minus:
-            return "-" + formatted
-        }
-    }
-    public static func formatToPrecision(_ bigNumber: BigInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
-
-        let magnitude = bigNumber.magnitude
-        guard let formatted = formatToPrecision(magnitude, numberDecimals: numberDecimals, formattingDecimals: formattingDecimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific) else { return nil }
+        let formatted = formatToEthereumUnits(magnitude, toUnits: toUnits, decimals: decimals, decimalSeparator: decimalSeparator)
         switch bigNumber.sign {
         case .plus:
             return formatted
@@ -158,11 +147,22 @@ extension Web3.Utils {
         }
     }
 
-    public static func formatToEthereumUnits(_ bigNumber: BigUInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
+    public static func formatToPrecision(_ bigNumber: BigInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String {
+        let magnitude = bigNumber.magnitude
+        let formatted = formatToPrecision(magnitude, numberDecimals: numberDecimals, formattingDecimals: formattingDecimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific)
+        switch bigNumber.sign {
+        case .plus:
+            return formatted
+        case .minus:
+            return "-" + formatted
+        }
+    }
+
+    public static func formatToEthereumUnits(_ bigNumber: BigUInt, toUnits: Web3.Utils.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String {
         return formatToPrecision(bigNumber, numberDecimals: toUnits.decimals, formattingDecimals: decimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific)
     }
-    public static func formatToPrecision(_ bigNumber: BigUInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
 
+    public static func formatToPrecision(_ bigNumber: BigUInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String {
         if bigNumber == 0 {
             return "0"
         }


### PR DESCRIPTION
Separate commits because they are atomic. Can merge as it is without squashing.