### PR TITLE
Make function return type be non-optional to reflect actual return type

### DIFF
--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Transaction/EthereumTransaction.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Transaction/EthereumTransaction.swift
@@ -64,9 +64,9 @@ public struct EthereumTransaction: CustomStringConvertible {
         let defaults = Web3Options.defaultOptions()
         let merged = Web3Options.merge(defaults, with: options)
         self.nonce = BigUInt(0)
-        self.gasLimit = merged!.gasLimit!
-        self.gasPrice = merged!.gasPrice!
-        self.value = merged!.value!
+        self.gasLimit = merged.gasLimit!
+        self.gasPrice = merged.gasPrice!
+        self.value = merged.value!
         self.to = to
         self.data = data
     }

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Contract.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Contract.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2017 Bankex Foundation. All rights reserved.
 //
 
-import Foundation 
+import Foundation
 import BigInt
 
 fileprivate typealias GlobalContract = Contract
@@ -31,7 +31,7 @@ extension Web3 {
         let web3: Web3
 
         public var options: Web3Options?
-        
+
         public init(web3: Web3, abiString: String, at: EthereumAddress? = nil, options: Web3Options? = nil) throws {
             self.web3 = web3
             self.options = web3.options
@@ -49,7 +49,7 @@ extension Web3 {
             self.contract = contract
             self.options = mergedOptions
         }
-        
+
         public func deploy(bytecode: Data, parameters: [AnyObject] = [], extraData: Data = Data(), options: Web3Options? = nil) throws -> TransactionIntermediate {
             let mergedOptions = Web3Options.merge(self.options, with: options)
             var transaction = try contract.deploy(bytecode: bytecode, parameters: parameters, extraData: extraData, options: mergedOptions)
@@ -57,7 +57,7 @@ extension Web3 {
 
             return TransactionIntermediate(transaction: transaction, web3: web3, contract: contract, method: "fallback", options: mergedOptions)
         }
-        
+
         public func method(_ method: String = "fallback", parameters: [AnyObject] = [], extraData: Data = Data(), options: Web3Options? = nil) throws -> TransactionIntermediate {
             let mergedOptions = Web3Options.merge(self.options, with: options)
             var transaction = try contract.method(method, parameters: parameters, extraData: extraData, options: mergedOptions)
@@ -69,7 +69,7 @@ extension Web3 {
         public func parseEvent(_ eventLog: EventLog) -> (eventName: String, eventData: [String: Any])? {
             return contract.parseEvent(eventLog)
         }
-        
+
         public func createEventParser(_ eventName: String, filter: EventFilter?) -> EventParserProtocol? {
             return EventParser(web3: web3, eventName: eventName, contract: contract, filter: filter)
         }

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Contract.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Contract.swift
@@ -41,8 +41,8 @@ extension Web3 {
             var mergedOptions = Web3Options.merge(self.options, with: options)
             if at != nil {
                 contract.address = at
-                mergedOptions?.to = at
-            } else if let addr = mergedOptions?.to {
+                mergedOptions.to = at
+            } else if let addr = mergedOptions.to {
                 contract.address = addr
             }
 

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Options.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Options.swift
@@ -52,7 +52,7 @@ public struct Web3Options {
         return options
     }
     
-    public static func merge(_ options: Web3Options?, with other: Web3Options?) -> Web3Options? {
+    public static func merge(_ options: Web3Options?, with other: Web3Options?) -> Web3Options {
         if other == nil && options == nil {
             return Web3Options.defaultOptions()
         }
@@ -89,7 +89,7 @@ public struct Web3Options {
     }
     
     public static func smartMergeGasLimit(originalOptions: Web3Options?, extraOptions: Web3Options?, gasEstimage: BigUInt) -> BigUInt? {
-        guard let mergedOptions = Web3Options.merge(originalOptions, with: extraOptions) else { return nil } //just require any non-nils
+        let mergedOptions = Web3Options.merge(originalOptions, with: extraOptions)
         if mergedOptions.gasLimit == nil {
             return gasEstimage // for user's convenience we just use an estimate
 //            return nil // there is no opinion from user, so we can not proceed

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Options.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+Options.swift
@@ -23,7 +23,7 @@ public struct Web3Options {
 
     public init() {
     }
-    
+
     public static func defaultOptions() -> Web3Options {
         var options = Web3Options()
 //        options.gasLimit = BigUInt("90000", radix: 10)!
@@ -33,7 +33,7 @@ public struct Web3Options {
         options.value = BigUInt(0)
         return options
     }
-    
+
     public static func fromJSON(_ json: [String: Any]) -> Web3Options? {
         var options = Web3Options()
         if let gas = json["gas"] as? String, let gasBiguint = BigUInt(gas.stripHexPrefix().lowercased(), radix: 16) {
@@ -51,7 +51,7 @@ public struct Web3Options {
         }
         return options
     }
-    
+
     public static func merge(_ options: Web3Options?, with other: Web3Options?) -> Web3Options {
         if other == nil && options == nil {
             return Web3Options.defaultOptions()
@@ -87,7 +87,7 @@ public struct Web3Options {
         }
         return newOptions
     }
-    
+
     public static func smartMergeGasLimit(originalOptions: Web3Options?, extraOptions: Web3Options?, gasEstimage: BigUInt) -> BigUInt? {
         let mergedOptions = Web3Options.merge(originalOptions, with: extraOptions)
         if mergedOptions.gasLimit == nil {

--- a/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+TransactionIntermediate.swift
+++ b/modules/AlphaWalletWeb3/AlphaWalletWeb3/Web3/Web3+TransactionIntermediate.swift
@@ -37,9 +37,7 @@ extension Web3.Contract.TransactionIntermediate {
 
         let eth = Web3.Eth(web3: web3)
 
-        guard let mergedOptions = Web3Options.merge(self.options, with: options) else {
-            return .init(error: Web3Error.inputError("Provided options are invalid"))
-        }
+        let mergedOptions = Web3Options.merge(self.options, with: options)
         guard let from = mergedOptions.from else {
             return .init(error: Web3Error.inputError("No 'from' field provided"))
         }
@@ -79,10 +77,7 @@ extension Web3.Contract.TransactionIntermediate {
 
     public func callPromise(options: Web3Options? = nil, onBlock: String = "latest") -> Promise<[String: Any]> {
         let eth = Web3.Eth(web3: self.web3)
-        guard let mergedOptions = Web3Options.merge(self.options, with: options) else {
-            return .init(error: Web3Error.inputError("Provided options are invalid"))
-        }
-
+        let mergedOptions = Web3Options.merge(self.options, with: options)
         var optionsForCall = Web3Options()
         optionsForCall.from = mergedOptions.from
         optionsForCall.to = mergedOptions.to
@@ -100,9 +95,7 @@ extension Web3.Contract.TransactionIntermediate {
 
     func estimateGasPromise(options: Web3Options? = nil, onBlock: String = "latest") -> Promise<BigUInt> {
         let eth = Web3.Eth(web3: self.web3)
-        guard let mergedOptions = Web3Options.merge(self.options, with: options) else {
-            return .init(error: Web3Error.inputError("Provided options are invalid"))
-        }
+        let mergedOptions = Web3Options.merge(self.options, with: options)
         var optionsForGasEstimation = Web3Options()
         optionsForGasEstimation.from = mergedOptions.from
         optionsForGasEstimation.to = mergedOptions.to


### PR DESCRIPTION
@oa-s help check if the intention is for `merge(_:,with:)` to return an non-optional default if both the args are `nil`?