### PR TITLE
Changed Configuration.Colors.Semantic.secondary to refer to the actual color instead of Colors.appGrayLabel

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -101,7 +101,6 @@ extension UITabBarController {
 
 struct Colors {
     static let appBackground = UIColor.white
-    static let appGrayLabel = UIColor(red: 155, green: 155, blue: 155)
     static let apprecationRed = UIColor(hex: "ff3b30")
     static let appRed = R.color.danger()!
     static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -287,7 +287,7 @@ struct Configuration {
             static let text = Colors.appText
             static let textFieldStatus = Configuration.Color.Semantic.defaultErrorText
             static let icon = Colors.appTint
-            static let secondary = Colors.appGrayLabel
+            static let secondary = UIColor(red: 155, green: 155, blue: 155)
             static let textFieldError = Colors.appRed
             static let textFieldShadowWhileEditing = Colors.appTint
             static let placeholder = UIColor(hex: "919191")


### PR DESCRIPTION
This commit is temporary. A later commit will remove Configuration.Colors.Semantic.secondary.