### PR TITLE
[Refactor] Semantic renaming of variable Colors.appRed to various Configuration.Color.Semantic values. No change in actual colour.

### DIFF
--- a/AlphaWallet/Accounts/ViewModels/AccountsViewModel.swift
+++ b/AlphaWallet/Accounts/ViewModels/AccountsViewModel.swift
@@ -178,7 +178,7 @@ final class AccountsViewModel {
             }
 
             deleteAction.image = R.image.close()?.withRenderingMode(.alwaysTemplate)
-            deleteAction.backgroundColor = Colors.appRed
+            deleteAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
 
             actions += [deleteAction]
         }

--- a/AlphaWallet/Alerts/ViewControllers/PriceAlertsViewController.swift
+++ b/AlphaWallet/Alerts/ViewControllers/PriceAlertsViewController.swift
@@ -158,7 +158,7 @@ extension PriceAlertsViewController: UITableViewDelegate {
             completion(true)
         }
 
-        hideAction.backgroundColor = Colors.appRed 
+        hideAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         hideAction.image = R.image.hideToken()
         let configuration = UISwipeActionsConfiguration(actions: [hideAction])
         configuration.performsFirstActionWithFullSwipe = true

--- a/AlphaWallet/Browser/ViewControllers/BookmarksViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BookmarksViewController.swift
@@ -188,7 +188,7 @@ extension BookmarksViewController: UITableViewDelegate {
             }
         }
 
-        deleteAction.backgroundColor = Colors.appRed
+        deleteAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         deleteAction.image = R.image.hideToken()
 
         let configuration = UISwipeActionsConfiguration(actions: [deleteAction])

--- a/AlphaWallet/Browser/ViewControllers/BrowserHistoryViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserHistoryViewController.swift
@@ -149,7 +149,7 @@ extension BrowserHistoryViewController: UITableViewDelegate {
             }
         }
 
-        deleteAction.backgroundColor = Colors.appRed
+        deleteAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         deleteAction.image = R.image.hideToken()
 
         let configuration = UISwipeActionsConfiguration(actions: [deleteAction])

--- a/AlphaWallet/Browser/Views/DappViewCell.swift
+++ b/AlphaWallet/Browser/Views/DappViewCell.swift
@@ -116,8 +116,8 @@ class DappViewCell: UICollectionViewCell {
         imageView.clipsToBounds = true
         imageView.kf.setImage(with: viewModel.imageUrl, placeholder: viewModel.fallbackImage)
 
-        deleteButton.tintColor = Colors.appRed
-        deleteButton.imageView?.tintColor = Colors.appRed
+        deleteButton.tintColor = Configuration.Color.Semantic.deleteButtonTitle
+        deleteButton.imageView?.tintColor = Configuration.Color.Semantic.deleteButtonTitle
         deleteButton.setImage(R.image.onboarding_failed(), for: .normal)
 
         titleLabel.textAlignment = .center

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appRed = R.color.danger()!
     static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)
     static let appText = R.color.black()!
     static let appTint = R.color.azure()!

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -113,6 +113,9 @@ struct Configuration {
             static let defaultButtonBorder = R.color.alabaster()!
             static let actionButtonBackground = UIColor(red: 105, green: 200, blue: 0)
             static let actionButtonShadow = UIColor.clear
+            static let cancelButtonTitle = R.color.danger()!
+            static let deleteButtonTitle = R.color.danger()!
+            static let defaultNote = R.color.danger()!
 
             static let labelTextActive = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.mine()!, darkColor: R.color.white()!)
@@ -281,15 +284,17 @@ struct Configuration {
                 return colorFrom(trait: trait, lightColor: R.color.alabaster()!, darkColor: R.color.venus()!)
             }
 
+            static let dangerBackground = R.color.danger()!
             static let appreciation = UIColor(red: 117, green: 185, blue: 67)
-            static let depreciation = UIColor(hex: "ff3b30")
+            static let depreciation = R.color.danger()!
+            static let pass = appreciation
+            static let fail = depreciation
 
             static let border = UIColor(red: 194, green: 194, blue: 194)
             static let text = Colors.appText
             static let textFieldStatus = Configuration.Color.Semantic.defaultErrorText
             static let icon = Colors.appTint
             static let secondary = UIColor(red: 155, green: 155, blue: 155)
-            static let textFieldError = Colors.appRed
             static let textFieldShadowWhileEditing = Colors.appTint
             static let placeholder = UIColor(hex: "919191")
             static let ensText = UIColor(red: 117, green: 185, blue: 67)

--- a/AlphaWallet/Common/Views/TextField.swift
+++ b/AlphaWallet/Common/Views/TextField.swift
@@ -33,7 +33,7 @@ class TextField: UIControl {
             case .none:
                 return whileEditing ? Configuration.Color.Semantic.textFieldShadowWhileEditing : Configuration.Color.Semantic.border
             case .error:
-                return Configuration.Color.Semantic.textFieldError
+                return Configuration.Color.Semantic.defaultErrorText
             }
         }
 
@@ -51,7 +51,7 @@ class TextField: UIControl {
             case .none:
                 return Configuration.Color.Semantic.defaultForegroundText
             case .error:
-                return Configuration.Color.Semantic.textFieldError
+                return Configuration.Color.Semantic.defaultErrorText
             }
         }
     }

--- a/AlphaWallet/Common/Views/WhereIsWalletAddressFoundOverlayView.swift
+++ b/AlphaWallet/Common/Views/WhereIsWalletAddressFoundOverlayView.swift
@@ -48,7 +48,7 @@ class WhereIsWalletAddressFoundOverlayView: UIView {
             let maskPath = UIBezierPath(rect: UIScreen.main.bounds)
             maskPath.append(clipPath.reversing())
             let mask = CAShapeLayer()
-            mask.backgroundColor = Colors.appRed.cgColor
+            mask.backgroundColor = Configuration.Color.Semantic.dangerBackground.cgColor
             mask.path = maskPath.cgPath
             layer.mask = mask
         }

--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
@@ -192,9 +192,9 @@ struct ImportMagicTokenViewControllerViewModel {
 
     var statusColor: UIColor {
         if case .failed = state {
-            return Colors.appRed
+            return Configuration.Color.Semantic.fail
         } else {
-            return Configuration.Color.Semantic.alternativeText
+            return Configuration.Color.Semantic.pass
         }
     }
 

--- a/AlphaWallet/Sell/ViewControllers/SetSellTokensCardExpiryDateViewController.swift
+++ b/AlphaWallet/Sell/ViewControllers/SetSellTokensCardExpiryDateViewController.swift
@@ -72,7 +72,7 @@ class SetSellTokensCardExpiryDateViewController: UIViewController, TokenVerifiab
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
-        label.textColor = Colors.appRed
+        label.textColor = Configuration.Color.Semantic.defaultNote
         label.font = Fonts.semibold(size: 21)
 
         return label
@@ -81,7 +81,7 @@ class SetSellTokensCardExpiryDateViewController: UIViewController, TokenVerifiab
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
-        label.textColor = Colors.appRed
+        label.textColor = Configuration.Color.Semantic.defaultNote
         label.font = Fonts.semibold(size: 21)
         label.numberOfLines = 0
 
@@ -90,7 +90,7 @@ class SetSellTokensCardExpiryDateViewController: UIViewController, TokenVerifiab
     private let noteBorderView: UIView = {
         let view = UIView()
         view.layer.cornerRadius = DataEntry.Metric.CornerRadius.box
-        view.layer.borderColor = Colors.appRed.cgColor
+        view.layer.borderColor = Configuration.Color.Semantic.defaultNote.cgColor
         view.layer.borderWidth = 1
 
         return view

--- a/AlphaWallet/Sell/ViewModels/GenerateSellMagicLinkViewModel.swift
+++ b/AlphaWallet/Sell/ViewModels/GenerateSellMagicLinkViewModel.swift
@@ -37,7 +37,7 @@ struct GenerateSellMagicLinkViewModel {
         return Fonts.regular(size: 20)
     }
     var cancelButtonTitleColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.cancelButtonTitle
     }
     var cancelButtonBackgroundColor: UIColor {
         return .clear

--- a/AlphaWallet/Sell/ViewModels/GenerateTransferMagicLinkViewModel.swift
+++ b/AlphaWallet/Sell/ViewModels/GenerateTransferMagicLinkViewModel.swift
@@ -35,7 +35,7 @@ struct GenerateTransferMagicLinkViewModel {
         return Fonts.regular(size: 20)
     }
     var cancelButtonTitleColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.cancelButtonTitle
     }
     var cancelButtonBackgroundColor: UIColor {
         return .clear

--- a/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/EnabledServersViewController.swift
@@ -143,7 +143,7 @@ extension EnabledServersViewController: UITableViewDelegate, UITableViewDataSour
         }
 
         deleteAction.image = R.image.close()?.withRenderingMode(.alwaysTemplate)
-        deleteAction.backgroundColor = Colors.appRed
+        deleteAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
 
         let editAction = UIContextualAction(style: .normal, title: R.string.localizable.editButtonTitle()) { _, _, complete in
             self.edit(server: server)

--- a/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
+++ b/AlphaWallet/TokenScript/ViewControllers/AssetDefinitionsOverridesViewController.swift
@@ -101,7 +101,7 @@ extension AssetDefinitionsOverridesViewController: UITableViewDelegate {
             completionHandler(true)
         }
 
-        hideAction.backgroundColor = Colors.appRed
+        hideAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         hideAction.image = R.image.hideToken()
 
         let configuration = UISwipeActionsConfiguration(actions: [hideAction])

--- a/AlphaWallet/Tokens/ViewControllers/AddHideTokensViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/AddHideTokensViewController.swift
@@ -221,7 +221,7 @@ extension AddHideTokensViewController: UITableViewDataSource {
             }
         }
 
-        hideAction.backgroundColor = Colors.appRed
+        hideAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         hideAction.image = R.image.hideToken()
 
         let configuration = UISwipeActionsConfiguration(actions: [hideAction])

--- a/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/VerifiableStatusViewController.swift
@@ -125,7 +125,7 @@ func createTokenScriptFileStatusButton(withStatus status: TokenLevelTokenScriptD
             title = error.localizedDescription
         }
         image = R.image.unverified()
-        tintColor = Colors.appRed
+        tintColor = Configuration.Color.Semantic.defaultErrorText
     }
     button.setTitle(title, for: .normal)
     button.setImage(image?.withRenderingMode(.alwaysOriginal), for: .normal)

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenDetailsViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenDetailsViewModel.swift
@@ -267,12 +267,12 @@ final class FungibleTokenDetailsViewModel {
                 let p = NumberFormatter.percent.string(double: percentage) ?? "-"
                 let v = NumberFormatter.fiat(currency: history.currency).string(double: value) ?? "-"
 
-                return ("\(v) (\(p)%)", Colors.green)
+                return ("\(v) (\(p)%)", Configuration.Color.Semantic.appreciation)
             case .depreciate(let percentage, let value):
                 let p = NumberFormatter.percent.string(double: percentage) ?? "-"
                 let v = NumberFormatter.fiat(currency: history.currency).string(double: value) ?? "-"
 
-                return ("\(v) (\(p)%)", Colors.appRed)
+                return ("\(v) (\(p)%)", Configuration.Color.Semantic.depreciation)
             case .none:
                 return ("-", Colors.black)
             }

--- a/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokenHistoryChartViewModel.swift
@@ -88,9 +88,9 @@ class TokenHistoryChartViewModel {
     private func gradientColorForTicker(ticker: CoinTicker?) -> UIColor {
         switch TickerHelper(ticker: ticker).change24h {
         case .appreciate, .none:
-            return Configuration.Color.Semantic.actionButtonBackground
+            return Configuration.Color.Semantic.appreciation
         case .depreciate:
-            return Colors.appRed
+            return  Configuration.Color.Semantic.depreciation
         }
     }
 }

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -337,7 +337,7 @@ final class TokensViewModel {
                     completion(true)
                 }
 
-                hideAction.backgroundColor = Colors.appRed
+                hideAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
                 hideAction.image = R.image.hideToken()
                 let configuration = UISwipeActionsConfiguration(actions: [hideAction])
                 configuration.performsFirstActionWithFullSwipe = true

--- a/AlphaWallet/Transactions/ViewModels/TransactionRowViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionRowViewModel.swift
@@ -33,7 +33,7 @@ struct TransactionRowViewModel {
     var amountTextColor: UIColor {
         switch direction {
         case .incoming: return Configuration.Color.Semantic.appreciation
-        case .outgoing: return Colors.appRed
+        case .outgoing: return Configuration.Color.Semantic.depreciation
         }
     }
 

--- a/AlphaWallet/Transactions/ViewModels/TransactionViewModel.swift
+++ b/AlphaWallet/Transactions/ViewModels/TransactionViewModel.swift
@@ -36,7 +36,7 @@ struct TransactionViewModel {
     var amountTextColor: UIColor {
         switch direction {
         case .incoming: return Configuration.Color.Semantic.appreciation
-        case .outgoing: return Colors.appRed
+        case .outgoing: return Configuration.Color.Semantic.depreciation
         }
     }
 

--- a/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/ConfigureTransactionViewController.swift
@@ -208,7 +208,7 @@ class ConfigureTransactionViewController: UIViewController {
         let titleLabel = UILabel()
         titleLabel.textAlignment = .center
         titleLabel.font = Fonts.semibold(size: 20)
-        titleLabel.textColor = Colors.appRed
+        titleLabel.textColor = Configuration.Color.Semantic.defaultErrorText
         titleLabel.text = gasPriceWarning.longTitle
 
         let descriptionLabel = UITextView()

--- a/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SetTransferTokensCardExpiryDateViewController.swift
@@ -46,7 +46,7 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
-        label.textColor = Colors.appRed
+        label.textColor = Configuration.Color.Semantic.defaultNote
         label.font = Fonts.semibold(size: 21)
 
         return label
@@ -55,7 +55,7 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
-        label.textColor = Colors.appRed
+        label.textColor = Configuration.Color.Semantic.defaultNote
         label.font = Fonts.regular(size: 21)
         label.numberOfLines = 0
 
@@ -65,7 +65,7 @@ class SetTransferTokensCardExpiryDateViewController: UIViewController, TokenVeri
         let noteBorderView = UIView()
         noteBorderView.translatesAutoresizingMaskIntoConstraints = false
         noteBorderView.layer.cornerRadius = DataEntry.Metric.CornerRadius.box
-        noteBorderView.layer.borderColor = Colors.appRed.cgColor
+        noteBorderView.layer.borderColor = Configuration.Color.Semantic.defaultNote.cgColor
         noteBorderView.layer.borderWidth = 1
 
         return noteBorderView

--- a/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ElevateWalletSecurityViewModel.swift
@@ -78,6 +78,6 @@ struct ElevateWalletSecurityViewModel {
     }
 
     var cancelLockingButtonTitleColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.cancelButtonTitle
     }
 }

--- a/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/ShowSeedPhraseViewModel.swift
@@ -21,7 +21,7 @@ struct ShowSeedPhraseViewModel {
     }
 
     var errorColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.defaultErrorText
     }
 
     var errorFont: UIFont {

--- a/AlphaWallet/Wallet/ViewModels/VerifySeedPhraseViewModel.swift
+++ b/AlphaWallet/Wallet/ViewModels/VerifySeedPhraseViewModel.swift
@@ -14,7 +14,7 @@ struct VerifySeedPhraseViewModel {
     }
 
     var seedPhraseTextViewBorderErrorColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.defaultErrorText
     }
 
     var seedPhraseTextViewBorderWidth: CGFloat {
@@ -34,7 +34,7 @@ struct VerifySeedPhraseViewModel {
     }
 
     var errorColor: UIColor {
-        return Colors.appRed
+        return Configuration.Color.Semantic.defaultErrorText
     }
 
     //Make it the same as the background. Trick to maintain the height of the error label even when there's no error by putting some dummy text. The dummy text must still make sense for accessibility

--- a/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionsViewController.swift
+++ b/AlphaWallet/WalletConnect/ViewController/WalletConnectSessionsViewController.swift
@@ -131,7 +131,7 @@ extension WalletConnectSessionsViewController: UITableViewDelegate {
             completion(true)
         }
 
-        hideAction.backgroundColor = Colors.appRed
+        hideAction.backgroundColor = Configuration.Color.Semantic.dangerBackground
         hideAction.image = R.image.hideToken()
         let configuration = UISwipeActionsConfiguration(actions: [hideAction])
         configuration.performsFirstActionWithFullSwipe = true

--- a/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionDetailsViewModel.swift
+++ b/AlphaWallet/WalletConnect/ViewModel/WalletConnectSessionDetailsViewModel.swift
@@ -109,7 +109,7 @@ class WalletConnectSessionDetailsViewModel {
     private func statusFieldAttributedString(session: AlphaWallet.WalletConnect.Session) -> NSAttributedString {
         NSAttributedString(string: walletConnectProvider.isConnected(session.topicOrUrl) ? R.string.localizable.walletConnectStatusOnline() : R.string.localizable.walletConnectStatusOffline(), attributes: [
             .font: Fonts.semibold(size: 17),
-            .foregroundColor: walletConnectProvider.isConnected(session.topicOrUrl) ? Colors.green : Colors.appRed
+            .foregroundColor: walletConnectProvider.isConnected(session.topicOrUrl) ? Configuration.Color.Semantic.pass : Configuration.Color.Semantic.fail
         ])
     }
 


### PR DESCRIPTION
The only two types of actual change here is from `Configuration.Color.Semantic.fail` and `Configuration.Color.Semantic.depreciation` to `UIColor(hex: "ff3b30")`. The rest of the changes are just renaming `Colors.appRed` to their equivilant semantic counter part.

| Name | Value |
-|-
Colors.appRed | R.color.danger
Configuration.Color.Semantic.dangerBackground | R.color.danger
Configuration.Color.Semantic.deleteButtonTitle | R.color.danger
Configuration.Color.Semantic.textFieldError | R.color.danger
Configuration.Color.Semantic.defaultNote | R.color.danger
Configuration.Color.Semantic.defaultErrorText | R.color.danger
Configuration.Color.Semantic.fail | UIColor(hex: "ff3b30")
Configuration.Color.Semantic.depreciation | UIColor(hex: "ff3b30")

Turns out R.color.danger is also ff3b30. So there is no change in color.