### PR TITLE
[Refactor] Changed Colors.appSubtitle to Configuration.Colors.Semantic.defaultSubtitleText

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appSubtitle = UIColor(red: 117, green: 117, blue: 117)
     static let appText = R.color.black()!
     static let appTint = R.color.azure()!
     static let appWhite = UIColor.white

--- a/AlphaWallet/Transactions/Views/TransactionTableViewCell.swift
+++ b/AlphaWallet/Transactions/Views/TransactionTableViewCell.swift
@@ -37,7 +37,7 @@ class TransactionTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.lineBreakMode = .byTruncatingMiddle
-        label.textColor = Colors.appSubtitle
+        label.textColor = Configuration.Color.Semantic.defaultSubtitleText
         label.font = Fonts.regular(size: ScreenChecker.size(big: 13, medium: 13, small: 12))
 
         return label


### PR DESCRIPTION
Changed Colors.appSubtitle (UIColor(red: 117, green: 117, blue: 117)) to Configuration.Colors.Semantic.defaultSubtitleText (Light mode: UIColor(red: 113, green: 113, blue: 113), Dark mode: UIColor(red: 153, green: 153, blue: 153)) or (Light mode: Dove, Dark mode: Dusty).

I changed the colors to the closest matching color in the style guide. RGB: 117/117/117 did not exist. Closest match was Dove (113/113/113). 

Light (Before) | Light (After) | Dark (After)
-|-|-
![light-before](https://user-images.githubusercontent.com/1050309/213106597-cf295e89-c1ed-4e17-9c67-7d61e67a5c36.png)|![light-after](https://user-images.githubusercontent.com/1050309/213106587-c781bce9-7209-4107-a053-660562958c7c.png)|![dark-after](https://user-images.githubusercontent.com/1050309/213106594-b60c36b5-9f3e-40ce-8dcb-4d8e17fe1cf4.png)
