### PR TITLE
[Refactor] Changed Colors.settingsSubtitle to Configuration.Color.Semantic.defaultSubtitleText

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -117,7 +117,6 @@ struct Colors {
     static let loadingIndicatorBorder = UIColor(red: 237, green: 237, blue: 237)
     static let navigationTitleColor = UIColor.black
     static let qrCodeRectBorders = UIColor(red: 216, green: 216, blue: 216)
-    static let settingsSubtitle = UIColor(red: 141, green: 141, blue: 141)
 }
 
 struct Fonts {

--- a/AlphaWallet/Settings/Views/WalletSecurityLevelIndicator.swift
+++ b/AlphaWallet/Settings/Views/WalletSecurityLevelIndicator.swift
@@ -40,7 +40,7 @@ class WalletSecurityLevelIndicator: UIView {
     private func configure() {
         label.textAlignment = .center
         label.font = Fonts.regular(size: 11)
-        label.textColor = Colors.settingsSubtitle
+        label.textColor = Configuration.Color.Semantic.defaultSubtitleText
         label.text = WalletSecurityLevelIndicator.convertLevelToTitle(level)
     }
 


### PR DESCRIPTION
Changed Colors.settingSubtitle (UIColor(red: 141, green: 141, blue: 141)) to Configuration.Color.Semantic.defaultSubtitleText (Light mode: UIColor(red: 113, green: 113, blue: 113), Dark mode: UIColor(red: 153, green: 153, blue: 153))

Light mode (before) | Light mode (after) | Dark mode (after)
-|-|-
![original](https://user-images.githubusercontent.com/1050309/213173942-2c4c66aa-8878-4f00-b73f-e56df36af7c1.png)|![light](https://user-images.githubusercontent.com/1050309/213173964-4d17c6d5-91c6-4d5e-8a0d-3206ea337cbb.png)|![dark](https://user-images.githubusercontent.com/1050309/213173971-221c85b2-8580-4c28-98c1-e1d80cc775cf.png)
