### PR TITLE
[Refactoring] Replace `import AlphaWalletFoundation` with `import AlphaWalletLogger` wherever possible and get rid of temporary `debugLog()`, etc forwarding functions defined in `RemoteLogger.swift`

### DIFF
--- a/AlphaWallet/ActiveWalletCoordinator.swift
+++ b/AlphaWallet/ActiveWalletCoordinator.swift
@@ -2,6 +2,7 @@ import UIKit
 import PromiseKit
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 // swiftlint:disable file_length
 protocol ActiveWalletCoordinatorDelegate: AnyObject {

--- a/AlphaWallet/AppCoordinator.swift
+++ b/AlphaWallet/AppCoordinator.swift
@@ -1,4 +1,4 @@
-// Copyright SIX DAY LLC. All rights reserved.
+// Copyright © 2023 Stormbird PTE. LTD.
 
 import Combine
 import UIKit
@@ -6,6 +6,7 @@ import PromiseKit
 import AlphaWalletAddress
 import AlphaWalletCore
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import AlphaWalletTrackAPICalls
 
 extension TokenScript {

--- a/AlphaWallet/Backup/Coordinators/PromptBackupCoordinator.swift
+++ b/AlphaWallet/Backup/Coordinators/PromptBackupCoordinator.swift
@@ -4,6 +4,7 @@ import UIKit
 import BigInt
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol PromptBackupCoordinatorProminentPromptDelegate: AnyObject {
     var viewControllerToShowBackupLaterAlert: UIViewController { get }

--- a/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/QRCodeResolutionCoordinator.swift
@@ -9,6 +9,7 @@ import Foundation
 import BigInt
 import PromiseKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import Combine
 
 enum QrCodeResolution {

--- a/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/ScanQRCodeCoordinator.swift
@@ -5,6 +5,7 @@ import QRCodeReaderViewController
 import BigInt
 import PromiseKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol ScanQRCodeCoordinatorDelegate: AnyObject {
     func didCancel(in coordinator: ScanQRCodeCoordinator)

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -1,10 +1,11 @@
-// Copyright DApps Platform Inc. All rights reserved.
+// Copyright © 2023 Stormbird PTE. LTD.
 
 import Foundation
 import UIKit
 import WebKit
 import JavaScriptCore
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol BrowserViewControllerDelegate: AnyObject {
     func didCall(action: DappAction, callbackID: Int, inBrowserViewController viewController: BrowserViewController)

--- a/AlphaWallet/Common/Coordinators/WalletApiCoordinator.swift
+++ b/AlphaWallet/Common/Coordinators/WalletApiCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 import Combine
 import PromiseKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol WalletApiCoordinatorDelegate: AnyObject {
     func didOpenUrl(in service: WalletApiCoordinator, redirectUrl: URL)

--- a/AlphaWallet/Common/Services/FirebaseReportService.swift
+++ b/AlphaWallet/Common/Services/FirebaseReportService.swift
@@ -7,6 +7,7 @@
 import FirebaseCore
 import FirebaseCrashlytics
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 extension AlphaWallet {
     final class FirebaseCrashlyticsReporter: CrashlyticsReporter {

--- a/AlphaWallet/Common/Views/NavigationController.swift
+++ b/AlphaWallet/Common/Views/NavigationController.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol PushNotifiable {
     func didPushViewController(animated: Bool)

--- a/AlphaWallet/Common/Views/SvgImageView.swift
+++ b/AlphaWallet/Common/Views/SvgImageView.swift
@@ -8,7 +8,7 @@
 import UIKit
 import WebKit
 import Kingfisher
-import AlphaWalletFoundation
+import AlphaWalletLogger
 
 private let svgImageViewSharedConfiguration: WKWebViewConfiguration = {
     let preferences = WKPreferences()

--- a/AlphaWallet/Donations/CameraDonation.swift
+++ b/AlphaWallet/Donations/CameraDonation.swift
@@ -2,7 +2,7 @@
 
 import CoreSpotlight
 import Foundation
-import AlphaWalletFoundation
+import AlphaWalletLogger
 
 class CameraDonation {
     //TODO maybe change to include wallet address

--- a/AlphaWallet/Donations/WalletQrCodeDonation.swift
+++ b/AlphaWallet/Donations/WalletQrCodeDonation.swift
@@ -2,7 +2,8 @@
 
 import CoreSpotlight
 import Foundation
-import AlphaWalletFoundation
+import AlphaWalletAddress
+import AlphaWalletLogger
 
 class WalletQrCodeDonation {
     //TODO maybe change to include wallet address

--- a/AlphaWallet/Market/ImportMagicLinkController.swift
+++ b/AlphaWallet/Market/ImportMagicLinkController.swift
@@ -10,6 +10,7 @@ import BigInt
 import PromiseKit
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import AlphaWalletWeb3
 
 // swiftlint:disable type_body_length

--- a/AlphaWallet/Settings/ViewControllers/SaveCustomRpcBrowseViewController.swift
+++ b/AlphaWallet/Settings/ViewControllers/SaveCustomRpcBrowseViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol SaveCustomRpcBrowseViewControllerDataDelegate: AnyObject {
     func didFinish(in viewController: SaveCustomRpcBrowseViewController, customRpcArray: [CustomRPC])

--- a/AlphaWallet/Settings/ViewModels/SupportViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/SupportViewModel.swift
@@ -6,8 +6,8 @@
 //
 
 import UIKit
-import AlphaWalletLogger
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import Combine
 
 struct SupportViewModelInput {

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NFTAssetViewModel.swift
@@ -9,6 +9,7 @@ import UIKit
 import BigInt
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 struct AttributeCollectionViewModel {
     let traits: [NonFungibleTraitViewModel]

--- a/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/NewTokenCoordinator.swift
@@ -8,6 +8,7 @@
 import UIKit
 import PromiseKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 private struct NoContractDetailsDetected: Error {
 }

--- a/AlphaWallet/Tokens/ViewModels/FungibleTokenDetailsViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/FungibleTokenDetailsViewModel.swift
@@ -3,6 +3,7 @@
 import UIKit
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 struct FungibleTokenDetailsViewModelInput {
     let willAppear: AnyPublisher<Void, Never>

--- a/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
+++ b/AlphaWallet/Transfer/Coordinators/TransactionConfirmationCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 import BigInt
 import PromiseKit
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol TransactionConfirmationCoordinatorDelegate: CanOpenURL, SendTransactionDelegate, BuyCryptoDelegate {
     func didFinish(_ result: ConfirmResult, in coordinator: TransactionConfirmationCoordinator)

--- a/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
+++ b/AlphaWallet/WalletConnect/Coordinator/WalletConnectCoordinator.swift
@@ -11,6 +11,7 @@ import WalletConnectSwift
 import PromiseKit
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import AlphaWalletCore
 
 protocol RequestAddCustomChainProvider: NSObjectProtocol {

--- a/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Client.swift
+++ b/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Client.swift
@@ -8,6 +8,7 @@
 import Foundation
 import WalletConnectSwift
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 protocol WalletConnectV1ClientDelegate: AnyObject {
     func server(_ server: Server, didReceiveRequest: Request)

--- a/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Provider.swift
+++ b/AlphaWallet/WalletConnect/Providers/v1/WalletConnectV1Provider.swift
@@ -11,6 +11,7 @@ import AlphaWalletAddress
 import PromiseKit
 import Combine
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 class WalletConnectV1Provider: WalletConnectServer {
 

--- a/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Provider.swift
+++ b/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Provider.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 import WalletConnectSwiftV2
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 enum ProposalOrServer {
     case server(RPCServer)

--- a/AlphaWallet/WalletConnect/Types/WalletConnectRequestConverter.swift
+++ b/AlphaWallet/WalletConnect/Types/WalletConnectRequestConverter.swift
@@ -9,6 +9,7 @@ import Foundation
 import PromiseKit
 import WalletConnectSwift
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 struct WalletConnectRequestDecoder {
 

--- a/AlphaWallet/WalletConnect/WalletConnectProvider.swift
+++ b/AlphaWallet/WalletConnect/WalletConnectProvider.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 import CombineExt
 import AlphaWalletFoundation
+import AlphaWalletLogger
 import PromiseKit
 import AlphaWalletCore
 

--- a/AlphaWalletTests/Core/Types/RetryPublisherTests.swift
+++ b/AlphaWalletTests/Core/Types/RetryPublisherTests.swift
@@ -11,6 +11,7 @@ import AlphaWalletAddress
 import AlphaWalletCore
 @testable import AlphaWallet
 import AlphaWalletFoundation
+import AlphaWalletLogger
 
 class RetryPublisherTests: XCTestCase {
     private var cancelable = Set<AnyCancellable>()

--- a/AlphaWalletTests/Redeem/CreateRedeemTests.swift
+++ b/AlphaWalletTests/Redeem/CreateRedeemTests.swift
@@ -5,7 +5,7 @@ import Foundation
 @testable import AlphaWallet
 import XCTest
 import BigInt
-import AlphaWalletFoundation
+import AlphaWalletLogger
 
 class CreateRedeemTests: XCTestCase {
     let keyStore = FakeEtherKeystore()

--- a/AlphaWalletTests/modules/AlphaWalletFoundation/Oneinch/OneinchTests.swift
+++ b/AlphaWalletTests/modules/AlphaWalletFoundation/Oneinch/OneinchTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import Combine
 import CombineExt
 import AlphaWalletCore
+import AlphaWalletLogger
 
 final class OneinchTests: XCTestCase {
     private var cancelable = Set<AnyCancellable>()

--- a/AlphaWalletTests/modules/AlphaWalletFoundation/Ramp/RampTests.swift
+++ b/AlphaWalletTests/modules/AlphaWalletFoundation/Ramp/RampTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import Combine
 import CombineExt
 import AlphaWalletCore
+import AlphaWalletLogger
 
 final class RampTests: XCTestCase {
     private var cancelable = Set<AnyCancellable>()

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/BlockscanChat/BlockscanChat.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/BlockscanChat/BlockscanChat.swift
@@ -4,6 +4,7 @@ import Foundation
 import SwiftyJSON
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public class BlockscanChat {
     private var lastKnownCount: Int?

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/BlockscanChat/BlockscanChatService.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/BlockscanChat/BlockscanChatService.swift
@@ -2,6 +2,7 @@
 
 import Combine
 import Foundation
+import AlphaWalletLogger
 
 public protocol BlockscanChatServiceDelegate: AnyObject {
     func openBlockscanChat(url: URL, for: BlockscanChatService)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Browser/Types/DappAction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Browser/Types/DappAction.swift
@@ -1,8 +1,9 @@
-// Copyright DApps Platform Inc. All rights reserved.
+// Copyright © 2023 Stormbird PTE. LTD.
 
 import Foundation
 import BigInt
 import WebKit
+import AlphaWalletLogger
 
 public enum DappAction {
     case signMessage(String)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/BuyToken/Ramp/Ramp.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/BuyToken/Ramp/Ramp.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public final class Ramp: SupportedTokenActionsProvider, BuyTokenURLProviderType {
     private var objectWillChangeSubject = PassthroughSubject<Void, Never>()

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/UnstoppableDomains/UnstoppableDomainsV2NetworkProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/UnstoppableDomains/UnstoppableDomainsV2NetworkProvider.swift
@@ -9,6 +9,7 @@ import Combine
 import SwiftyJSON
 import AlphaWalletENS
 import AlphaWalletCore
+import AlphaWalletLogger
 
 struct UnstoppableDomainsV2NetworkProvider {
     private let networkService: NetworkService

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/UnstoppableDomains/UnstoppableDomainsV2Resolver.swift
@@ -10,6 +10,7 @@ import Combine
 import SwiftyJSON
 import AlphaWalletENS
 import AlphaWalletCore
+import AlphaWalletLogger
 
 struct UnstoppableDomainsV2ApiError: Error {
     var localizedDescription: String

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Requests/GetTransactionRequest.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/Requests/GetTransactionRequest.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import JSONRPCKit
+import AlphaWalletLogger
 
 struct GetTransactionRequest: JSONRPCKit.Request {
     typealias Response = PendingTransaction?

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Extensions/Session+PromiseKit.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Extensions/Session+PromiseKit.swift
@@ -1,6 +1,7 @@
 // Copyright © 2020 Stormbird PTE. LTD.
 
 import Foundation
+import AlphaWalletLogger
 import APIKit
 import JSONRPCKit
 import PromiseKit

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Features/Features.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Features/Features.swift
@@ -1,6 +1,7 @@
 // Copyright © 2020 Stormbird PTE. LTD.
 
 import Foundation
+import AlphaWalletLogger
 
 public class Features {
     public static let `default`: Features = Features()!

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/GasPriceEstimator/GasPriceEstimator.swift
@@ -9,6 +9,7 @@ import Foundation
 import BigInt
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public protocol GasPriceEstimator {
     func estimateGasPrice() -> AnyPublisher<GasEstimates, PromiseError>

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Helpers/RemoteLogger.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Helpers/RemoteLogger.swift
@@ -4,26 +4,6 @@ import Foundation
 import AlphaWalletLogger
 import PaperTrailLumberjack
 
-public func debugLog(_ message: Any, _ logger: Logger = DDLogger.instance, callerFunctionName: String = #function) {
-    AlphaWalletLogger.debugLog(message, logger, callerFunctionName: callerFunctionName)
-}
-
-public func infoLog(_ message: Any, _ logger: Logger = DDLogger.instance, callerFunctionName: String = #function) {
-    AlphaWalletLogger.infoLog(message, logger, callerFunctionName: callerFunctionName)
-}
-
-public func warnLog(_ message: Any, _ logger: Logger = DDLogger.instance, callerFunctionName: String = #function) {
-    AlphaWalletLogger.warnLog(message, logger, callerFunctionName: callerFunctionName)
-}
-
-public func verboseLog(_ message: Any, _ logger: Logger = DDLogger.instance, callerFunctionName: String = #function) {
-    AlphaWalletLogger.verboseLog(message, logger, callerFunctionName: callerFunctionName)
-}
-
-public func errorLog(_ message: Any, _ logger: Logger = DDLogger.instance, callerFunctionName: String = #function) {
-    AlphaWalletLogger.errorLog(message, logger, callerFunctionName: callerFunctionName)
-}
-
 public typealias EmailAttachment = (data: Data, mimeType: String, fileName: String)
 extension Logger {
     public static var logFilesAttachments: [EmailAttachment] {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Initializers/DatabaseMigration.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Initializers/DatabaseMigration.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import RealmSwift
+import AlphaWalletLogger
 
 public class DatabaseMigration: Initializer {
     let account: Wallet

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/BlockchainProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/BlockchainProvider.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import AlphaWalletLogger
 import AlphaWalletWeb3
 import BigInt
 import AlphaWalletCore

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/CallSmartContractFunction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/CallSmartContractFunction.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import PromiseKit
+import AlphaWalletLogger
 import AlphaWalletWeb3
 import BigInt
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/Constants+Credentials.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/Constants+Credentials.swift
@@ -1,5 +1,6 @@
 // Copyright © 2019 Stormbird PTE. LTD.
 import Foundation
+import AlphaWalletLogger
 
 extension Constants {
     public enum Credentials {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/ApproveSwapProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Helpers/ApproveSwapProvider.swift
@@ -10,6 +10,7 @@ import PromiseKit
 import BigInt
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public protocol ApproveSwapProviderDelegate: AnyObject {
     func promptToSwap(unsignedTransaction: UnsignedSwapTransaction, fromToken: TokenToSwap, fromAmount: BigUInt, toToken: TokenToSwap, toAmount: BigUInt, in provider: ApproveSwapProvider)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/TokenSwapper.swift
@@ -5,6 +5,7 @@ import BigInt
 import Combine
 import AlphaWalletAddress
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public struct SwapSupportState {
     let server: RPCServer

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/AssetDefinitionStore.swift
@@ -1,6 +1,7 @@
 // Copyright © 2018 Stormbird PTE. LTD.
 
 import Combine
+import AlphaWalletLogger
 import PromiseKit
 
 public typealias XMLFile = String

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/TokenScriptSignatureVerifier.swift
@@ -5,6 +5,7 @@ import PromiseKit
 import SwiftyJSON
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public protocol TokenScriptSignatureVerifieble {
     func verificationType(forXml xmlString: String) -> Promise<TokenScriptSignatureVerificationType>

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/TokenScriptOverridesFileManager.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/TokenScriptOverridesFileManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public typealias ImportTokenScriptOverridesFileEvent = Result<TokenScriptOverridesForContract, OpenURLError>
 public typealias TokenScriptOverridesForContract = (contract: AlphaWallet.Address, server: RPCServer, destinationFileInUse: Bool, filename: String)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/CachedERC1155ContractDictionary.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/CachedERC1155ContractDictionary.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AlphaWalletLogger
 
 public class CachedERC1155ContractDictionary {
     private let fileUrl: URL

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/JsonFromTokenUri.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/JsonFromTokenUri.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AlphaWalletCore
+import AlphaWalletLogger
 import AlphaWalletOpenSea
 import SwiftyJSON
 import Combine

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
@@ -3,6 +3,7 @@
 import UIKit
 import PromiseKit
 import AlphaWalletCore
+import AlphaWalletLogger
 import AlphaWalletOpenSea
 
 public typealias GoogleContentSize = AlphaWalletCore.GoogleContentSize

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Storage/TransactionsStorage.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Storage/TransactionsStorage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AlphaWalletLogger
 import BigInt
 import RealmSwift
 import Combine

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/SendTransaction.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/SendTransaction.swift
@@ -1,8 +1,9 @@
-// Copyright SIX DAY LLC. All rights reserved.
+// Copyright © 2023 Stormbird PTE. LTD.
 
-import BigInt
 import Foundation
+import AlphaWalletLogger
 import APIKit
+import BigInt
 import JSONRPCKit
 import PromiseKit
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/TransactionConfigurator.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/TransactionConfigurator.swift
@@ -1,10 +1,11 @@
-// Copyright SIX DAY LLC. All rights reserved.
+// Copyright © 2023 Stormbird PTE. LTD.
 
 import Foundation
 import BigInt
 import PromiseKit
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 
 public protocol TransactionConfiguratorDelegate: AnyObject {
     func configurationChanged(in configurator: TransactionConfigurator)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GetGasLimit.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/GetGasLimit.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AlphaWalletLogger
 import APIKit
 import BigInt
 import JSONRPCKit

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/RunLoopThread.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/RunLoopThread.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AlphaWalletLogger
 
 public class RunLoopThread: Thread {
     let isRunLoopThreadLoggingEnabled: Bool = Config().development.isRunLoopThreadLoggingEnabled

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/WalletBalance/TokenBalanceFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/WalletBalance/TokenBalanceFetcher.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 import AlphaWalletCore
+import AlphaWalletLogger
 import AlphaWalletOpenSea
 import BigInt
 import PromiseKit


### PR DESCRIPTION
Finish work started in #6224. Closes #6225. Reduces dependencies on `AlphaWalletFoundation`.