### PR TITLE
When we sign a short message that is still long enough to be truncated, the "Show" button doesn't appear #6221

### DIFF
--- a/AlphaWallet/Transfer/ViewModels/SignatureConfirmationConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SignatureConfirmationConfirmationViewModel.swift
@@ -78,7 +78,7 @@ extension SignatureConfirmationViewModel {
             return String(message.removingPrefixWhitespacesAndNewlines.prefix(MessageConfirmationViewModel.MessagePrefixLength))
         }
         private var availableToShowFullMessage: Bool {
-            message.removingWhitespacesAndNewlines.count > messagePrefix.count
+            return true
         }
         private let requester: RequesterViewModel?
         let message: String


### PR DESCRIPTION
Closes #6221