### PR TITLE
move to default comparison implementation for structs for `WalletBalance` #6247

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/WalletBalance.swift
@@ -75,11 +75,7 @@ extension Balance: CustomStringConvertible {
     }
 }
 
-extension WalletBalance: Hashable {
-    public static func == (lhs: WalletBalance, rhs: WalletBalance) -> Bool {
-        return lhs.wallet.address == rhs.wallet.address && lhs.totalAmount == rhs.totalAmount && lhs.change == rhs.change
-    }
-}
+extension WalletBalance: Hashable { }
 
 public extension WalletBalance {
     public struct ValueForCurrency: Equatable, Hashable {


### PR DESCRIPTION
Fixes #6247