### PR TITLE
[Refactor] Removed Colors.navigationTitleColor

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -108,7 +108,6 @@ struct Colors {
     static let gray = UIColor.gray
     static let lightBlack = UIColor(hex: "313849")
     static let lightGray = UIColor.lightGray
-    static let navigationTitleColor = UIColor.black
 }
 
 struct Fonts {

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -315,7 +315,10 @@ struct Configuration {
             static let headerViewBackground = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.venus()!)
             }
-            static let symbol = UIColor { trait in
+            static let defaultIcon = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
+            }
+            static let secureIcon = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.black()!, darkColor: R.color.white()!)
             }
         }

--- a/AlphaWallet/Common/Views/TextField.swift
+++ b/AlphaWallet/Common/Views/TextField.swift
@@ -341,7 +341,7 @@ fileprivate extension TextField {
     @objc private func toggleMaskPassword(_ sender: UIButton) {
         isSecureTextEntry.toggle()
         if isSecureTextEntry {
-            sender.tintColor = Colors.navigationTitleColor
+            sender.tintColor = Configuration.Color.Semantic.secureIcon
         } else {
             sender.tintColor = .init(red: 111, green: 111, blue: 111)
         }

--- a/AlphaWallet/Common/Views/ViewModels/TokenCardRowViewModelProtocol.swift
+++ b/AlphaWallet/Common/Views/ViewModels/TokenCardRowViewModelProtocol.swift
@@ -46,7 +46,7 @@ extension TokenCardRowViewModelProtocol {
     }
 
     var iconsColor: UIColor {
-        return Configuration.Color.Semantic.defaultHeadlineText
+        return Configuration.Color.Semantic.defaultIcon
     }
 
     var tokenCountFont: UIFont {

--- a/AlphaWallet/Lock/Views/PasscodeCharacterView.swift
+++ b/AlphaWallet/Lock/Views/PasscodeCharacterView.swift
@@ -22,8 +22,8 @@ class PasscodeCharacterView: UIView {
     private func setupView() {
         backgroundColor = .clear
         translatesAutoresizingMaskIntoConstraints = false
-        filledImageView.image = filledImageView.image?.withTintColor(Configuration.Color.Semantic.symbol, renderingMode: .alwaysOriginal)
-        emptyImageView.image = emptyImageView.image?.withTintColor(Configuration.Color.Semantic.symbol, renderingMode: .alwaysOriginal)
+        filledImageView.image = filledImageView.image?.withTintColor(Configuration.Color.Semantic.defaultIcon, renderingMode: .alwaysOriginal)
+        emptyImageView.image = emptyImageView.image?.withTintColor(Configuration.Color.Semantic.defaultIcon, renderingMode: .alwaysOriginal)
         addSubview(filledImageView)
         addSubview(emptyImageView)
         NSLayoutConstraint.activate([

--- a/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
+++ b/AlphaWallet/Market/ViewModels/ImportMagicTokenViewControllerViewModel.swift
@@ -42,7 +42,7 @@ struct ImportMagicTokenViewControllerViewModel {
     }
 
     var activityIndicatorColor: UIColor {
-        return Colors.navigationTitleColor
+        return Configuration.Color.Semantic.defaultIcon
     }
     var showActivityIndicator: Bool {
         switch state {


### PR DESCRIPTION
# TextField
Light mode | Dark mode
-|-
![TextField-light](https://user-images.githubusercontent.com/1050309/215738894-7745aad5-eed7-4d2b-b2fc-ebd0fb8911bf.png)|![TextField-dark](https://user-images.githubusercontent.com/1050309/215738877-10518007-4469-4e6e-a1c4-c56a2bbcbec3.png)

# TokenCardRowViewModelProtocol
Light mode | Dark mode
-|-
![icon-light](https://user-images.githubusercontent.com/1050309/215739563-aaf3c361-d22f-46c0-87b2-7887fd59d366.png)|![icon-dark](https://user-images.githubusercontent.com/1050309/215739555-1c98e1f8-cb17-4696-95e1-14f2e24c7f5f.png)

# ImportMagicTokenViewControllerViewModel
Light mode | Dark mode
-|-
![import-light](https://user-images.githubusercontent.com/1050309/215740000-8fa188bd-d48c-4576-bded-887de32ecc77.png)|![import-dark](https://user-images.githubusercontent.com/1050309/215739993-228d4e15-57e6-4d8f-9a96-572fa79bdfb3.png)
