### PR TITLE
[Refactor] Changed Colors.darkGray to Configuration.Color.Semantic.alternativeText.

### DIFF
--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -104,7 +104,6 @@ struct Colors {
     static let appTint = R.color.azure()!
     static let appWhite = UIColor.white
     static let black = UIColor(hex: "313849")
-    static let darkGray = UIColor(hex: "2f2f2f")
 }
 
 struct Fonts {

--- a/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
+++ b/AlphaWallet/Tokens/Collectibles/Views/TokenHistoryChartView.swift
@@ -12,7 +12,7 @@ import AlphaWalletFoundation
 
 class TokenHistoryChartView: UIView {
     private let marker = XYMarkerView(
-        color: Colors.darkGray,
+        color: Configuration.Color.Semantic.alternativeText,
         font: Fonts.regular(size: 12),
         textColor: Configuration.Color.Semantic.defaultInverseText,
         insets: UIEdgeInsets(top: 8, left: 8, bottom: 20, right: 8))
@@ -50,6 +50,11 @@ class TokenHistoryChartView: UIView {
         chartView.rightAxis.setLabelCount(5, force: true)
         chartView.rightAxis.valueFormatter = valueFormatter
 
+        let marker = XYMarkerView(
+            color: Configuration.Color.Semantic.alternativeText,
+            font: Fonts.regular(size: 12),
+            textColor: Configuration.Color.Semantic.defaultInverseText,
+            insets: UIEdgeInsets(top: 8, left: 8, bottom: 20, right: 8))
         marker.chartView = chartView
         marker.minimumSize = CGSize(width: 80, height: 40)
         chartView.marker = marker

--- a/AlphaWallet/WalletConnect/View/TransactionConfirmationRPCServerInfoView.swift
+++ b/AlphaWallet/WalletConnect/View/TransactionConfirmationRPCServerInfoView.swift
@@ -15,7 +15,7 @@ class TransactionConfirmationRPCServerInfoView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = Fonts.regular(size: ScreenChecker().isNarrowScreen ? 16 : 18)
         titleLabel.textAlignment = .left
-        titleLabel.textColor = Colors.darkGray
+        titleLabel.textColor = Configuration.Color.Semantic.alternativeText
 
         return titleLabel
     }()


### PR DESCRIPTION
# TokenHistoryChartView
Light mode | Dark mode
-|-
![Screen Shot 2023-02-02 at 3 51 24 PM](https://user-images.githubusercontent.com/1050309/216265327-b6876a4e-8c62-49fb-b900-a879ba7bf62f.png)|![Screen Shot 2023-02-02 at 3 51 38 PM](https://user-images.githubusercontent.com/1050309/216265340-d6a98430-3419-4743-a0c4-4648a17aa802.png)
# TransactionConfirmationRPCServerInfoView
This view was forced to appear by setting the `isHidden` field to false. I could not get it to show without intervention.
Light mode | Dark mode
-|-
![Screen Shot 2023-02-02 at 3 25 25 PM](https://user-images.githubusercontent.com/1050309/216265712-3ee2bd41-3424-4eba-a942-fcc332d43fc7.png)|![Screen Shot 2023-02-02 at 3 25 44 PM](https://user-images.githubusercontent.com/1050309/216265721-2887b417-9f18-4d7b-90c3-1b90d79dd93a.png)
