### PR TITLE
[Refactor] Changed Colors.appText to Configuration.Color.Semantic.defaultIcon and Configuration.Color.Semantic.defaultForegroundText

### DIFF
--- a/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
+++ b/AlphaWallet/AlphaWalletHelp/Views/ContactUsBannerView.swift
@@ -59,7 +59,7 @@ class ContactUsBannerView: UIView {
 
         imageView.image = R.image.onboarding_contact()
 
-        label.textColor = Colors.appText
+        label.textColor = Configuration.Color.Semantic.defaultForegroundText
         label.font = Fonts.regular(size: 18)
         label.text = R.string.localizable.aHelpContactFooterButtonTitle()
     }

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appText = R.color.black()!
     static let appTint = R.color.azure()!
     static let appWhite = UIColor.white
 }

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -308,7 +308,6 @@ struct Configuration {
             static let fail = depreciation
 
             static let border = UIColor(red: 194, green: 194, blue: 194)
-            static let text = Colors.appText
             static let textFieldStatus = Configuration.Color.Semantic.defaultErrorText
             static let icon = Colors.appTint
             static let secondary = UIColor(red: 155, green: 155, blue: 155)

--- a/AlphaWallet/Common/Views/StateViewModel.swift
+++ b/AlphaWallet/Common/Views/StateViewModel.swift
@@ -6,7 +6,7 @@ import UIKit
 struct StateViewModel {
 
     var titleTextColor: UIColor {
-        return Colors.appText
+        return Configuration.Color.Semantic.defaultForegroundText
    }
 
     var titleFont: UIFont {
@@ -14,7 +14,7 @@ struct StateViewModel {
     }
 
     var descriptionTextColor: UIColor {
-        return Colors.appText
+        return Configuration.Color.Semantic.defaultForegroundText
     }
 
     var descriptionFont: UIFont {

--- a/AlphaWallet/Tokens/Collectibles/ViewControllers/NFTAssetSelectionViewController.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewControllers/NFTAssetSelectionViewController.swift
@@ -318,10 +318,10 @@ extension NFTAssetSelectionViewController {
             placeholderLabel.textColor = Configuration.Color.Semantic.searchbarPlaceholder
         }
         if let textField = searchController.searchBar.firstSubview(ofType: UITextField.self) {
-            textField.textColor = Colors.appText
+            textField.textColor = Configuration.Color.Semantic.defaultForegroundText
             if let imageView = textField.leftView as? UIImageView {
                 imageView.image = imageView.image?.withRenderingMode(.alwaysTemplate)
-                imageView.tintColor = Colors.appText
+                imageView.tintColor = Configuration.Color.Semantic.defaultIcon
             }
         }
         //Hack to hide the horizontal separator below the search bar


### PR DESCRIPTION
# ContactUsBannerView
Light | Dark
-|-
![contact-light](https://user-images.githubusercontent.com/1050309/216947464-f4a7e184-17de-4764-8c27-6d9ea3950838.png)|![contact-dark](https://user-images.githubusercontent.com/1050309/216947400-351e7f94-e04d-4d86-9c04-7f6eab73bf27.png)

# StateViewModel
Default Colours overridden by https://github.com/AlphaWallet/alpha-wallet-ios/blob/eeea2673c9c44a9e8024f2b15d9f05285ca55bfc/AlphaWallet/Common/Views/LoadingView.swift#L66-L73

# NFTAssetSelectionViewController
Light | Dark
-|-
 ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-06 at 18 04 42](https://user-images.githubusercontent.com/1050309/216948255-10cb3a8a-0fd3-45b0-803b-28124b4a17c6.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-06 at 18 04 48](https://user-images.githubusercontent.com/1050309/216948263-384ff3de-73a0-4606-9c54-2b71b1f281b5.png)
