### PR TITLE
[Refactor] Changed Colors.appTint to Configuration.Color.Semantic.appTint

### DIFF
--- a/AlphaWallet/Accounts/ViewModels/AccountsViewModel.swift
+++ b/AlphaWallet/Accounts/ViewModels/AccountsViewModel.swift
@@ -336,7 +336,7 @@ extension AccountsViewModel {
 
         var backgroundColor: UIColor {
             switch self {
-            case .copyToClipboard: return Colors.appTint
+            case .copyToClipboard: return Configuration.Color.Semantic.appTint
             case .deleteWallet: return Configuration.Color.Semantic.dangerBackground
             }
         }

--- a/AlphaWallet/Activities/Views/ActivityStateView.swift
+++ b/AlphaWallet/Activities/Views/ActivityStateView.swift
@@ -20,7 +20,7 @@ class ActivityStateView: UIView {
 
     private func createPendingLoadingIndicatorView() -> ActivityLoadingIndicatorView {
         let control = ActivityLoadingIndicatorView()
-        control.lineColor = Colors.appTint
+        control.lineColor = Configuration.Color.Semantic.appTint
         control.backgroundLineColor = Configuration.Color.Semantic.loading
         control.translatesAutoresizingMaskIntoConstraints = false
         control.duration = 1.1

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -57,7 +57,7 @@ final class BrowserViewController: UIViewController {
     lazy var progressView: UIProgressView = {
         let progressView = UIProgressView(progressViewStyle: .default)
         progressView.translatesAutoresizingMaskIntoConstraints = false
-        progressView.tintColor = Colors.appTint
+        progressView.tintColor = Configuration.Color.Semantic.appTint
         progressView.trackTintColor = .clear
         return progressView
     }()

--- a/AlphaWallet/Browser/ViewModel/BrowserHistoryCellViewModel.swift
+++ b/AlphaWallet/Browser/ViewModel/BrowserHistoryCellViewModel.swift
@@ -36,7 +36,7 @@ struct BrowserHistoryCellViewModel: Hashable {
     }
 
     var urlColor: UIColor? {
-        return Colors.appTint
+        return Configuration.Color.Semantic.appTint
     }
 
     var imageViewShadowColor: UIColor {

--- a/AlphaWallet/Browser/ViewModel/MyDappCellViewModel.swift
+++ b/AlphaWallet/Browser/ViewModel/MyDappCellViewModel.swift
@@ -44,7 +44,7 @@ struct MyDappCellViewModel: Hashable {
     }
 
     var domainNameColor: UIColor? {
-        return Colors.appTint
+        return Configuration.Color.Semantic.appTint
     }
 
     var imageViewShadowColor: UIColor {

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -6,7 +6,7 @@ import AlphaWalletFoundation
 
 func applyStyle() {
     UIBarButtonItem.appearance(whenContainedInInstancesOf: [UIDocumentBrowserViewController.self]).tintColor = Configuration.Color.Semantic.navigationBarButtonItemTint
-    UIWindow.appearance().tintColor = Colors.appTint
+    UIWindow.appearance().tintColor = Configuration.Color.Semantic.appTint
 
     UINavigationBar.appearance().shadowImage = UIImage(color: Configuration.Color.Semantic.navigationBarSeparator, size: CGSize(width: 0.25, height: 0.25))
     UINavigationBar.appearance().compactAppearance = UINavigationBarAppearance.defaultAppearence
@@ -18,7 +18,7 @@ func applyStyle() {
     UIBarButtonItem.appearance().tintColor = Configuration.Color.Semantic.navigationBarButtonItemTint
     UIBarButtonItem.appearance(whenContainedInInstancesOf: [UIToolbar.self]).tintColor = Configuration.Color.Semantic.navigationBarButtonItemTint
 
-    UIToolbar.appearance().tintColor = Colors.appTint
+    UIToolbar.appearance().tintColor = Configuration.Color.Semantic.appTint
 
     //Background (not needed in iOS 12.1 on simulator)
     //Cancel button
@@ -28,7 +28,7 @@ func applyStyle() {
 
     UIRefreshControl.appearance().tintColor = Configuration.Color.Semantic.refreshControl
 
-    UISwitch.appearance().onTintColor = Colors.appTint
+    UISwitch.appearance().onTintColor = Configuration.Color.Semantic.appTint
 
     UITableView.appearance().separatorColor = Configuration.Color.Semantic.tableViewSeparator
 }
@@ -73,7 +73,7 @@ extension UITabBarAppearance {
         ]
         tabBarItemAppearance.selected.titleTextAttributes = [
             .font: Fonts.semibold(size: 13),
-            .foregroundColor: Colors.appTint
+            .foregroundColor: Configuration.Color.Semantic.appTint
         ]
 
         tabBarAppearance.stackedLayoutAppearance = tabBarItemAppearance
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appTint = R.color.azure()!
     static let appWhite = UIColor.white
 }
 

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -301,6 +301,10 @@ struct Configuration {
                 return colorFrom(trait: trait, lightColor: R.color.alabaster()!, darkColor: R.color.venus()!)
             }
 
+            static let appTint = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.azure()!, darkColor: R.color.dodge()!)
+            }
+
             static let dangerBackground = R.color.danger()!
             static let appreciation = UIColor(red: 117, green: 185, blue: 67)
             static let depreciation = R.color.danger()!
@@ -309,9 +313,9 @@ struct Configuration {
 
             static let border = UIColor(red: 194, green: 194, blue: 194)
             static let textFieldStatus = Configuration.Color.Semantic.defaultErrorText
-            static let icon = Colors.appTint
+            static let icon = Configuration.Color.Semantic.appTint
             static let secondary = UIColor(red: 155, green: 155, blue: 155)
-            static let textFieldShadowWhileEditing = Colors.appTint
+            static let textFieldShadowWhileEditing = Configuration.Color.Semantic.appTint
             static let placeholder = UIColor(hex: "919191")
             static let ensText = UIColor(red: 117, green: 185, blue: 67)
             static let searchTextFieldBackground = UIColor(red: 243, green: 244, blue: 245)

--- a/AlphaWallet/Common/Views/Button.swift
+++ b/AlphaWallet/Common/Views/Button.swift
@@ -30,7 +30,7 @@ enum ButtonStyle {
 
     var backgroundColor: UIColor {
         switch self {
-        case .solid, .squared: return Colors.appTint
+        case .solid, .squared: return Configuration.Color.Semantic.appTint
         case .border, .borderless: return Configuration.Color.Semantic.defaultViewBackground
         case .system: return .clear
         case .special: return Configuration.Color.Semantic.specialButton
@@ -40,8 +40,8 @@ enum ButtonStyle {
 
     var backgroundColorHighlighted: UIColor {
         switch self {
-        case .solid, .squared: return Colors.appTint
-        case .border: return Colors.appTint
+        case .solid, .squared: return Configuration.Color.Semantic.appTint
+        case .border: return Configuration.Color.Semantic.appTint
         case .borderless: return Configuration.Color.Semantic.defaultViewBackground
         case .system: return .clear
         case .special: return Configuration.Color.Semantic.specialButton

--- a/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
+++ b/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
@@ -364,8 +364,8 @@ struct ButtonsBarViewModel {
         highlightedButtonBackgroundColor: Colors.appWhite,
         disabledButtonBackgroundColor: Colors.appWhite,
         disabledButtonBorderColor: Colors.appWhite,
-        highlightedButtonTitleColor: Colors.appTint.withAlphaComponent(0.3),
-        disabledButtonTitleColor: Colors.appTint.withAlphaComponent(0.3),
+        highlightedButtonTitleColor: Configuration.Color.Semantic.appTint.withAlphaComponent(0.3),
+        disabledButtonTitleColor: Configuration.Color.Semantic.appTint.withAlphaComponent(0.3),
         buttonFont: Fonts.regular(size: ScreenChecker().isNarrowScreen ? 16 : 20),
         buttonBorderWidth: 0.0
     )
@@ -378,7 +378,7 @@ struct ButtonsBarViewModel {
     var disabledButtonBackgroundColor: UIColor = Configuration.Color.Semantic.disabledActionButton
     var disabledButtonBorderColor: UIColor = Configuration.Color.Semantic.disabledActionButton
 
-    var buttonTitleColor: UIColor = Colors.appTint
+    var buttonTitleColor: UIColor = Configuration.Color.Semantic.appTint
     var highlightedButtonTitleColor: UIColor?
     var disabledButtonTitleColor: UIColor = Colors.appWhite
 
@@ -404,7 +404,7 @@ struct ButtonsBarViewModel {
 
     var buttonFont: UIFont = Fonts.semibold(size: ScreenChecker().isNarrowScreen ? 16 : 20)
 
-    var buttonBorderColor: UIColor = Colors.appTint
+    var buttonBorderColor: UIColor = Configuration.Color.Semantic.appTint
 
     var buttonBorderWidth: CGFloat = 1.0
 }

--- a/AlphaWallet/Settings/Views/LocaleViewCell.swift
+++ b/AlphaWallet/Settings/Views/LocaleViewCell.swift
@@ -10,7 +10,7 @@ class LocaleViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        tintColor = Colors.appTint
+        tintColor = Configuration.Color.Semantic.appTint
 
         let stackView = [.spacerWidth(5), nameLabel].asStackView(axis: .horizontal)
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/AlphaWallet/Swap/Swap/Views/SwapQuoteDetailsView.swift
+++ b/AlphaWallet/Swap/Swap/Views/SwapQuoteDetailsView.swift
@@ -41,8 +41,8 @@ final class SwapQuoteDetailsView: UIView {
         button.setTitle("Hide", for: .selected)
         button.widthAnchor.constraint(equalToConstant: ScreenChecker.size(big: 50, medium: 50, small: 44)).isActive = true
         button.tintColor = Configuration.Color.Semantic.tableViewHeaderBackground
-        button.setTitleColor(Colors.appTint, for: .normal)
-        button.setTitleColor(Colors.appTint, for: .selected)
+        button.setTitleColor(Configuration.Color.Semantic.appTint, for: .normal)
+        button.setTitleColor(Configuration.Color.Semantic.appTint, for: .selected)
 
         return button
     }()

--- a/AlphaWallet/Swap/SwapOptions/Views/SwapOptionsHeaderView.swift
+++ b/AlphaWallet/Swap/SwapOptions/Views/SwapOptionsHeaderView.swift
@@ -73,7 +73,7 @@ extension SwapOptionsHeaderView {
 
         let attributedText = NSAttributedString(string: title, attributes: [
             .font: Fonts.bold(size: 17) as Any,
-            .foregroundColor: Colors.appTint,
+            .foregroundColor: Configuration.Color.Semantic.appTint,
             .paragraphStyle: paragraph
         ])
 

--- a/AlphaWallet/Swap/SwapRoutes/ViewModels/SelectableSwapRouteTableViewCellViewModel.swift
+++ b/AlphaWallet/Swap/SwapRoutes/ViewModels/SelectableSwapRouteTableViewCellViewModel.swift
@@ -46,7 +46,7 @@ struct SelectableSwapRouteTableViewCellViewModel: Hashable {
 
     var tagAttributedString: NSAttributedString {
         return NSAttributedString(string: tag, attributes: [
-            .foregroundColor: Colors.appTint,
+            .foregroundColor: Configuration.Color.Semantic.appTint,
             .font: Fonts.bold(size: 14)
         ])
     }

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/NonFungibleTraitViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/NonFungibleTraitViewModel.swift
@@ -21,7 +21,7 @@ struct NonFungibleTraitViewModel: Equatable {
     let count: String?
     var attributedValue: NSAttributedString?
     var attributedCountValue: NSAttributedString?
-    var borderColor: UIColor = Colors.appTint
+    var borderColor: UIColor = Configuration.Color.Semantic.appTint
     var cornerRadius: CGFloat = 10
     var borderWidth: CGFloat = 1
 

--- a/AlphaWallet/Tokens/Collectibles/ViewModels/SingleNFTAssetSelectionViewModel.swift
+++ b/AlphaWallet/Tokens/Collectibles/ViewModels/SingleNFTAssetSelectionViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 import AlphaWalletFoundation
 
 struct SingleNFTAssetSelectionViewModel {
-    var backgroundColor: UIColor = Colors.appTint
+    var backgroundColor: UIColor = Configuration.Color.Semantic.appTint
 
     var selectedAmount: Int? {
         tokenHolder.selectedCount(tokenId: tokenId).flatMap { String($0) }.flatMap { Int($0) }

--- a/AlphaWallet/Tokens/ViewModels/ShowAddHideTokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/ShowAddHideTokensViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 struct ShowAddHideTokensViewModel {
     var addHideTokensIcon: UIImage?
     var addHideTokensTitle: String? = R.string.localizable.walletsAddHideTokensTitle()
-    var addHideTokensTintColor: UIColor = Colors.appTint
+    var addHideTokensTintColor: UIColor = Configuration.Color.Semantic.appTint
     var addHideTokensTintFont: UIFont = Fonts.semibold(size: 17)
 
     var addHideTokensAttributedString: NSAttributedString? {

--- a/AlphaWallet/Transfer/ViewControllers/SendTransactionErrorViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendTransactionErrorViewController.swift
@@ -36,7 +36,7 @@ class SendTransactionErrorViewController: UIViewController {
     private var linkButton: UIButton = {
         let b = UIButton(type: .system)
         b.titleLabel?.font = Fonts.semibold(size: 17)
-        b.setTitleColor(Colors.appTint, for: .normal)
+        b.setTitleColor(Configuration.Color.Semantic.appTint, for: .normal)
         return b
     }()
 

--- a/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
@@ -223,7 +223,7 @@ extension TransactionConfirmationHeaderView {
 
         label.attributedText = NSAttributedString(string: title, attributes: [
             .font: Fonts.bold(size: 17) as Any,
-            .foregroundColor: Colors.appTint,
+            .foregroundColor: CFG.Color.Semantic.appTint,
             .paragraphStyle: paragraph
         ])
         label.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# AccountsViewModel
Light | Dark 
-|-
![accountsviewmodel-light](https://user-images.githubusercontent.com/1050309/217994756-d32667d9-602a-40c2-84cc-5e431f9be7fb.png)|![accountsviewmodel-dark](https://user-images.githubusercontent.com/1050309/217994767-e8340d99-ce17-4861-96d6-76a71cf34f6b.png)

# ActivityStateView
Light | Dark 
-|-
![activitystateview-light](https://user-images.githubusercontent.com/1050309/217994890-83a39982-7bf4-41e8-a20c-de3a9c35975e.png)|![activitystateview-dark](https://user-images.githubusercontent.com/1050309/217994897-0c5c07f7-8ec5-4474-80f6-bdd144438a63.png)

# BrowserViewController
Light | Dark 
-|-
![browserviewcontroller-light](https://user-images.githubusercontent.com/1050309/217995082-8b90fa59-d3cb-4eb9-85e4-c0dc35583b6a.png)|![browserviewcontroller-dark](https://user-images.githubusercontent.com/1050309/217995077-e1112339-d16a-4ccb-980f-02bedd523d9f.png)

# BrowserHistoryCellViewModel
Light | Dark 
-|-
![browserhistorycellviewmodel-light](https://user-images.githubusercontent.com/1050309/217995193-6be19721-fec4-42f4-9c8f-7941b787136b.png)|![browserhistorycellviewmodel-dark](https://user-images.githubusercontent.com/1050309/217995208-61a66ae3-cc3b-478f-a167-2b57522333d1.png)

# MyDappCellViewModel
Light | Dark
-|-
![MyDappCellViewModel-light](https://user-images.githubusercontent.com/1050309/217995356-770ea123-ed03-42e7-88b9-f200b12c0f63.png)|![MyDappCellViewModel-dark](https://user-images.githubusercontent.com/1050309/217995370-c068d4fc-da12-40e5-a359-972989365e71.png)

# AppStyle
Light | Dark
-|-
![switch-light](https://user-images.githubusercontent.com/1050309/217995459-fc642f31-d952-43bc-92ec-5c6ce0474079.png)|![switch-dark](https://user-images.githubusercontent.com/1050309/217995462-a89f338d-b13d-4503-8c6d-302a0285e25a.png)

# Button
Light | Dark
-|-
![button-light](https://user-images.githubusercontent.com/1050309/217995678-387bb5bd-e6ba-4a6f-88da-2f052799e99b.png)|![button-dark](https://user-images.githubusercontent.com/1050309/217995687-7df2a862-e319-4050-a62d-637a3ef4ba8d.png)
![systemButton-light](https://user-images.githubusercontent.com/1050309/217995846-010dd8cc-8794-4a58-8b4e-9e507a24d107.png)|![systemButton-dark](https://user-images.githubusercontent.com/1050309/217995855-5eb16711-ea14-48f8-8bfc-6197f6a1f5df.png)

# LocaleViewCell
Light | Dark
-|-
![localeviewcell-light](https://user-images.githubusercontent.com/1050309/217995891-d7f31e0f-d24e-4c0f-91db-b7a6fad07a9b.png)|![localeviewcell-dark](https://user-images.githubusercontent.com/1050309/217995915-c0d3bd81-5fcf-4d57-bab4-aea7f496cbfb.png)

# SwapQuoteDetailsView
Light | Dark
-|-
![SwapQuoteDetailsView-light](https://user-images.githubusercontent.com/1050309/217996115-3d71c84d-1944-4239-b581-bbc8a272f2e9.png)|![SwapQuoteDetailsView-dark](https://user-images.githubusercontent.com/1050309/217996122-f1711a10-7cf2-4f1c-9584-b06087d2ab1c.png)

# SwapOptionsHeaderView
Light | Dark
-|-
![swapoptionsheaderview-light](https://user-images.githubusercontent.com/1050309/217996287-20c9c2d6-ec8a-4df3-b00f-7277f54d9c38.png)|![swapoptionsheaderview-dark](https://user-images.githubusercontent.com/1050309/217996307-96aed604-f8b0-4188-b33f-f55e7ebe55bd.png)

# SelectableSwapRouteTableViewCellViewModel
Light | Dark
-|-
![selectableswaproutetableviewcellviewmodel-light](https://user-images.githubusercontent.com/1050309/217996424-c335835c-61f9-4ab8-88f6-4874e210c423.png)|![selectableswaproutetableviewcellviewmodel-dark](https://user-images.githubusercontent.com/1050309/217996455-58883858-920e-46f6-a848-f393f1eab78d.png)

# NonFungibleTraitViewModel
Light | Dark
-|-
![NonFungibleTraitViewModel-light](https://user-images.githubusercontent.com/1050309/217996539-5024958f-db4b-4285-8af2-be629492d39c.png)|![NonFungibleTraitViewModel-dark](https://user-images.githubusercontent.com/1050309/217996544-6c1c799c-fe12-448e-acc4-05615af3c589.png)

# SingleNFTAssetSelectionViewModel
Light | Dark
-|-
![SingleNFTAssetSelectionViewModel-light](https://user-images.githubusercontent.com/1050309/217996654-43ce19ae-1b43-4e35-b0c2-01b813f73429.png)|![SingleNFTAssetSelectionViewModel-dark](https://user-images.githubusercontent.com/1050309/217996691-43d4b30e-596d-407c-a2f9-e53bbbf6e192.png)

# ShowAddHideTokensViewModel
Light | Dark
-|-
![ShowAddHideTokensViewModel-light](https://user-images.githubusercontent.com/1050309/217996811-f1419dad-adbd-4b7f-b8eb-620fdc0a3cd0.png)|![ShowAddHideTokensViewModel-dark](https://user-images.githubusercontent.com/1050309/217996815-6155b0ac-9bb4-4e40-8bb5-5b9511fc86a6.png)

# SendTransactionErrorViewController
## Code modified to show view
Light | Dark
-|-
![SendTransactionErrorViewController-light](https://user-images.githubusercontent.com/1050309/217996998-e6da0e2e-af94-4e15-8d8a-314859f31233.png)|![SendTransactionErrorViewController-dark](https://user-images.githubusercontent.com/1050309/217997015-7d65c8b8-03f3-4d17-89da-613bcd50d8a3.png)

# TransactionConfirmationHeaderView
Light | Dark
-|-
![TransactionConfirmationHeaderView-light](https://user-images.githubusercontent.com/1050309/217997251-93f2dcaa-9b26-4583-b983-51df0d88e9a0.png)|![TransactionConfirmationHeaderView-dark](https://user-images.githubusercontent.com/1050309/217997256-741cd6ee-58e8-424c-9267-8b51ed23b5b5.png)
