### PR TITLE
[Refactor] Changed Colors.appWhite to Configuration.Color.Semantic.defaultInverseText and Configuration.Color.Semantic.defaultButtonBackground

### DIFF
--- a/AlphaWallet/Backup/ViewModels/PromptBackupWalletViewViewModel.swift
+++ b/AlphaWallet/Backup/ViewModels/PromptBackupWalletViewViewModel.swift
@@ -34,7 +34,7 @@ extension PromptBackupWalletViewModel {
     }
 
     var titleColor: UIColor {
-        return Colors.appWhite
+        return Configuration.Color.Semantic.defaultInverseText
     }
 
     var descriptionFont: UIFont {
@@ -42,11 +42,11 @@ extension PromptBackupWalletViewModel {
     }
 
     var descriptionColor: UIColor {
-        return Colors.appWhite
+        return Configuration.Color.Semantic.defaultInverseText
     }
 
     var backupButtonTitleColor: UIColor {
-        return Colors.appWhite
+        return Configuration.Color.Semantic.defaultInverseText
     }
 
     var backupButtonTitleFont: UIFont {
@@ -66,7 +66,7 @@ extension PromptBackupWalletViewModel {
     }
 
     var moreButtonColor: UIColor {
-        return Colors.appWhite
+        return Configuration.Color.Semantic.defaultInverseText
     }
 
     var backupButtonTitle: String {

--- a/AlphaWallet/Common/Types/AppStyle.swift
+++ b/AlphaWallet/Common/Types/AppStyle.swift
@@ -100,7 +100,6 @@ extension UITabBarController {
 }
 
 struct Colors {
-    static let appWhite = UIColor.white
 }
 
 struct Fonts {

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -60,9 +60,14 @@ struct Configuration {
 
             static let disabledActionButton = UIColor(hex: "d7ebc8")
             static let specialButton = R.color.concrete()!
-            
+
             static let qrCodeRectBorders = UIColor(red: 216, green: 216, blue: 216)
-            
+            static let defaultButtonBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.white()!, darkColor: R.color.cod()!)
+            }
+            static let inverseDefaultButtonBackground = UIColor { trait in
+                return colorFrom(trait: trait, lightColor: R.color.cod()!, darkColor: R.color.white()!)
+            }
             static let primaryButtonBackground = UIColor { trait in
                 return colorFrom(trait: trait, lightColor: R.color.cod()!, darkColor: R.color.alabaster()!)
             }

--- a/AlphaWallet/Common/Views/Button.swift
+++ b/AlphaWallet/Common/Views/Button.swift
@@ -71,7 +71,7 @@ enum ButtonStyle {
 
     var textColor: UIColor {
         switch self {
-        case .solid, .squared: return Colors.appWhite
+        case .solid, .squared: return Configuration.Color.Semantic.defaultInverseText
         case .border, .borderless, .system, .special: return Configuration.Color.Semantic.defaultForegroundText
         case .green: return ButtonsBarViewModel.primaryButton.buttonTitleColor
         }
@@ -79,10 +79,10 @@ enum ButtonStyle {
 
     var textColorHighlighted: UIColor {
         switch self {
-        case .solid, .squared: return UIColor(white: 1, alpha: 0.8)
-        case .border: return Colors.appWhite
+        case .solid, .squared: return Configuration.Color.Semantic.defaultInverseText.withAlphaComponent(0.8)
+        case .border: return Configuration.Color.Semantic.defaultInverseText
         case .borderless, .system, .special: return Configuration.Color.Semantic.defaultViewBackground
-        case .green: return Colors.appWhite.withAlphaComponent(0.8)
+        case .green: return Configuration.Color.Semantic.defaultInverseText.withAlphaComponent(0.8)
         }
     }
 

--- a/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
+++ b/AlphaWallet/Common/Views/ButtonsBar/ButtonsBar.swift
@@ -360,10 +360,10 @@ struct ButtonsBarViewModel {
     )
 
     static let systemButton = ButtonsBarViewModel(
-        buttonBackgroundColor: Colors.appWhite,
-        highlightedButtonBackgroundColor: Colors.appWhite,
-        disabledButtonBackgroundColor: Colors.appWhite,
-        disabledButtonBorderColor: Colors.appWhite,
+        buttonBackgroundColor: Configuration.Color.Semantic.defaultButtonBackground,
+        highlightedButtonBackgroundColor: Configuration.Color.Semantic.defaultButtonBackground,
+        disabledButtonBackgroundColor: Configuration.Color.Semantic.defaultButtonBackground,
+        disabledButtonBorderColor: Configuration.Color.Semantic.defaultButtonBackground,
         highlightedButtonTitleColor: Configuration.Color.Semantic.appTint.withAlphaComponent(0.3),
         disabledButtonTitleColor: Configuration.Color.Semantic.appTint.withAlphaComponent(0.3),
         buttonFont: Fonts.regular(size: ScreenChecker().isNarrowScreen ? 16 : 20),
@@ -372,7 +372,7 @@ struct ButtonsBarViewModel {
 
     static let moreButton = ButtonsBarViewModel(buttonBorderWidth: 0)
 
-    var buttonBackgroundColor: UIColor = Colors.appWhite
+    var buttonBackgroundColor: UIColor = Configuration.Color.Semantic.defaultButtonBackground
 
     var highlightedButtonBackgroundColor: UIColor?
     var disabledButtonBackgroundColor: UIColor = Configuration.Color.Semantic.disabledActionButton
@@ -380,7 +380,7 @@ struct ButtonsBarViewModel {
 
     var buttonTitleColor: UIColor = Configuration.Color.Semantic.appTint
     var highlightedButtonTitleColor: UIColor?
-    var disabledButtonTitleColor: UIColor = Colors.appWhite
+    var disabledButtonTitleColor: UIColor = Configuration.Color.Semantic.defaultButtonBackground
 
     var buttonCornerRadius: CGFloat {
         return HorizontalButtonsBar.buttonsHeight / 2.0

--- a/AlphaWallet/Transfer/Views/TransitionButton.swift
+++ b/AlphaWallet/Transfer/Views/TransitionButton.swift
@@ -22,7 +22,7 @@ public enum StopAnimationStyle {
 @IBDesignable open class TransitionButton: UIButton, CAAnimationDelegate {
     var shrinkBorderColor: UIColor = .lightGray
     var shrinkBorderWidth: CGFloat = 3.0
-    var shrinkBackgroundColor: UIColor = Colors.appWhite
+    var shrinkBackgroundColor: UIColor = AlphaWallet.Configuration.Color.Semantic.defaultButtonBackground
 
     private var cachedTitle: String?
     private var cachedImage: UIImage?


### PR DESCRIPTION
# PromptBackupWalletViewModel
The text.
Light | Dark
-|-
![PromptBackupWalletViewModel-light](https://user-images.githubusercontent.com/1050309/218415527-6d088a03-668c-441f-a2f6-8c1fedbe0bf9.png)|![PromptBackupWalletViewModel-dark](https://user-images.githubusercontent.com/1050309/218415541-065c41ae-0d4f-48c5-83b8-16f57b120b00.png)

# ButtonsBar
The button background.
Light | Dark
-|-
![buttonsbar-light](https://user-images.githubusercontent.com/1050309/218415655-909b8e33-d78f-447b-82d6-998c19d37ab3.png)|![buttonsbar-dark](https://user-images.githubusercontent.com/1050309/218415665-bb5b97ac-fdb1-4c4c-8477-c96635bac741.png)

# Button
The text.
Light | Dark
-|-
![button-light](https://user-images.githubusercontent.com/1050309/218416107-8ee5e161-ad89-4413-bdbb-3fc81badf2e5.png)|![button-dark](https://user-images.githubusercontent.com/1050309/218416122-127dde3e-6a9e-4d46-8eef-215613644d80.png)

# TransitionButton
The background of the confirm button during transition (when the button shrinks).
Light | Dark
-|-
![ezgif-5-f9cf775759](https://user-images.githubusercontent.com/1050309/218494417-2312de40-17b8-4b93-b2ad-c579d3dba5e4.gif)|![ezgif-5-f8796585ee](https://user-images.githubusercontent.com/1050309/218494409-af0b0054-87e1-4556-871c-df2c1872be64.gif)
