### PR TITLE
Fixed ActiveWalletViewTests failure

### DIFF
--- a/AlphaWalletTests/Coordinators/ActiveWalletViewTests.swift
+++ b/AlphaWalletTests/Coordinators/ActiveWalletViewTests.swift
@@ -16,10 +16,8 @@ final class FakeNetworkService: NetworkService {
 
     func upload(multipartFormData: @escaping (MultipartFormData) -> Void,
                 usingThreshold: UInt64,
-                to url: URLConvertible,
-                method: HTTPMethod,
-                headers: HTTPHeaders?,
-                callbackQueue: DispatchQueue = .main) -> AnyPublisher<Alamofire.DataResponse<Any>, SessionTaskError> {
+                with request: AlphaWalletFoundation.URLRequestConvertible,
+                callbackQueue: DispatchQueue = .main) -> AnyPublisher<URLRequest.Response, SessionTaskError> {
         return .empty()
     }
 


### PR DESCRIPTION
Obsoleted by #6336.

Closes #6334

The `Network` protocol definition changed but the mock class in the tests was not updated.
