### PR TITLE
Fix: remove spurious +27 to v since it's done in WalletConnectSwiftV2.EthereumSignature.serialized

### DIFF
--- a/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Client.swift
+++ b/AlphaWallet/WalletConnect/Providers/v2/WalletConnectV2Client.swift
@@ -33,9 +33,7 @@ struct Web3Signer: WalletConnectSwiftV2.EthereumSigner {
 
     func sign(message: Data, with key: Data) throws -> EthereumSignature {
         let hash = message.sha3(.keccak256)
-        var signature = try EthereumSigner().sign(hash: hash, withPrivateKey: key)
-        signature[64] += EthereumSigner.vitaliklizeConstant
-
+        let signature = try EthereumSigner().sign(hash: hash, withPrivateKey: key)
         return EthereumSignature(v: signature[64], r: signature[0 ..< 32].bytes, s: signature[32 ..< 64].bytes)
     }
 


### PR DESCRIPTION
Because:

```
public struct EthereumSignature {
    public let v: UInt8
    public let r: [UInt8]
    public let s: [UInt8]

    public init(v: UInt8, r: [UInt8], s: [UInt8]) {
        self.v = v
        self.r = r
        self.s = s
    }

   //...
    public var serialized: Data {
        return Data(r + s + [UInt8(v + 27)])
    }
```