### PR TITLE
Fix: .signTransaction from dapp browser web3 call should only sign not sign+send

### DIFF
--- a/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
+++ b/AlphaWallet/Browser/Coordinators/DappBrowserCoordinator.swift
@@ -499,7 +499,7 @@ extension DappBrowserCoordinator: BrowserViewControllerDelegate {
         func performDappAction(account: AlphaWallet.Address) {
             switch action {
             case .signTransaction(let unconfirmedTransaction):
-                executeTransaction(action: action, callbackID: callbackID, transaction: unconfirmedTransaction, type: .signThenSend)
+                executeTransaction(action: action, callbackID: callbackID, transaction: unconfirmedTransaction, type: .sign)
             case .sendTransaction(let unconfirmedTransaction):
                 executeTransaction(action: action, callbackID: callbackID, transaction: unconfirmedTransaction, type: .signThenSend)
             case .signMessage(let hexMessage):


### PR DESCRIPTION
Fixes #6351