### PR TITLE
[Refactor] Changed UIColor.white to various Configuration.Color.Semantic versions

### DIFF
--- a/AlphaWallet/Activities/Views/ActivityStateView.swift
+++ b/AlphaWallet/Activities/Views/ActivityStateView.swift
@@ -25,7 +25,7 @@ class ActivityStateView: UIView {
         control.translatesAutoresizingMaskIntoConstraints = false
         control.duration = 1.1
         control.lineWidth = 3
-        control.backgroundFillColor = .white
+        control.backgroundFillColor = Configuration.Color.Semantic.activityStateViewPendingLoadingIndicatorViewBackground
         control.translatesAutoresizingMaskIntoConstraints = false
 
         return control

--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -91,7 +91,7 @@ final class BrowserViewController: UIViewController {
 
             errorView.anchorsConstraint(to: webView),
         ])
-        view.backgroundColor = .white
+        view.backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         estimatedProgressObservation = webView.observe(\.estimatedProgress) { [weak self] webView, _ in
             guard let strongSelf = self else { return }

--- a/AlphaWallet/Common/Types/Configuration.swift
+++ b/AlphaWallet/Common/Types/Configuration.swift
@@ -50,7 +50,9 @@ struct Configuration {
             }
             static let loading = R.color.loadingBackground()!
             static let loadingIndicatorBorder = UIColor(red: 237, green: 237, blue: 237)
+            static let loadingIndicatorBackground = UIColor.white
             static let circularLoadingIndicatorLine = UIColor.red
+            static let activityStateViewPendingLoadingIndicatorViewBackground = UIColor.white
             static let backgroundLine = UIColor.lightGray
             static let checkmark = UIColor.red
             static let backButtonText = UIColor.clear

--- a/AlphaWallet/Common/Views/LoadingIndicatorView.swift
+++ b/AlphaWallet/Common/Views/LoadingIndicatorView.swift
@@ -21,7 +21,7 @@ class ActivityLoadingIndicatorView: UIView {
         }
     }
 
-    var backgroundFillColor: UIColor = .white {
+    var backgroundFillColor: UIColor = Configuration.Color.Semantic.loadingIndicatorBackground {
         didSet {
             backgroundLayer.fillColor = backgroundFillColor.cgColor
         }

--- a/AlphaWallet/Common/Views/LoadingView.swift
+++ b/AlphaWallet/Common/Views/LoadingView.swift
@@ -21,7 +21,7 @@ final class LoadingView: UIView {
         self.insets = insets
         super.init(frame: frame)
 
-        backgroundColor = .white
+        backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = message

--- a/AlphaWallet/Common/Views/ScrollableSegmentedControl/ScrollableSegmentedControlCell.swift
+++ b/AlphaWallet/Common/Views/ScrollableSegmentedControl/ScrollableSegmentedControlCell.swift
@@ -72,7 +72,6 @@ class ScrollableSegmentedControlCell: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.textColor = .white
         return label
     }()
 

--- a/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/OpenSea/OpenSeaNonFungibleTokenCardRowViewModel.swift
@@ -54,7 +54,7 @@ struct OpenSeaNonFungibleTokenCardRowViewModel {
     }
 
     var stateColor: UIColor {
-        return .white
+        return Configuration.Color.Semantic.defaultForegroundText
     }
 
     var stateFont: UIFont {

--- a/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensViewModel.swift
@@ -100,7 +100,7 @@ final class TokensViewModel {
     }
 
     var headerBackgroundColor: UIColor {
-        return .white
+        return Configuration.Color.Semantic.defaultViewBackground
     }
 
     var buyCryptoTitle: String {

--- a/AlphaWallet/Tokens/Views/AddHideTokensView.swift
+++ b/AlphaWallet/Tokens/Views/AddHideTokensView.swift
@@ -30,7 +30,7 @@ class AddHideTokensView: UIView, ReusableTableHeaderViewType {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "0"
         label.textAlignment = .center
-        label.textColor = .white
+        label.textColor = Configuration.Color.Semantic.defaultInverseText
         label.font = .boldSystemFont(ofSize: 14)
 
         return label


### PR DESCRIPTION
# ActivityStateView.swift
Direct replacement of .white.

# BrowserViewController.swift
Direct replacement of .white.

# Configuration.swift
Added new definitions

# LoadingIndicatorView.swift
Direct replacement of .white.

# LoadingView.swift
Replaced .white with .defaultViewBackground

# ScrollableSegmentedControlCell.swift
Removed .white as textColor is always overridden by ScrollableSegmentedControlCellConfiguration

# OpenSeaNonFungibleTokenCardRowViewModel
Modified code to show label with string "MYTARGET".
Light | Dark
-|-
![OpenSeaNonFungibleTokenCardRowViewModel-light](https://user-images.githubusercontent.com/1050309/220510172-a35d4479-0a01-46f6-a8a3-d3b598e95d86.png)|![OpenSeaNonFungibleTokenCardRowViewModel-dark](https://user-images.githubusercontent.com/1050309/220510157-9ffd9556-fa2f-4efd-bde0-e4ada5c5cf3f.png)

# TokensViewModel.swift
Replaced .white with .defaultViewBackground

# AddHideTokensView
The red circle with the number. Modified code to display label.
Light | Dark
-|-
![AddHideTokensView-light](https://user-images.githubusercontent.com/1050309/220510431-85e70c24-74bf-48ad-a9fc-66490e30bdfd.png)|![AddHideTokensView-dark](https://user-images.githubusercontent.com/1050309/220510422-67f4e181-252a-46a1-a54d-6a3c944b1658.png)
