### PR TITLE
[Refactoring] Remove duplicate function and only call the remaining one

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift
@@ -428,7 +428,7 @@ open class EtherKeystore: NSObject, Keystore {
 
     public func signPersonalMessage(_ message: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError> {
         let prefix = "\u{19}Ethereum Signed Message:\n\(message.count)".data(using: .utf8)!
-        return signMessage(prefix + message, for: account, prompt: prompt)
+        return signMessageData(prefix + message, for: account, prompt: prompt)
     }
 
     public func signHash(_ hash: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError> {
@@ -460,10 +460,6 @@ open class EtherKeystore: NSObject, Keystore {
         let values = datas.map { $0.typedData }.reduce(Data(), { $0 + $1 }).sha3(.keccak256)
         let combined = (schemas + values).sha3(.keccak256)
         return signHash(combined, for: account, prompt: prompt)
-    }
-
-    public func signMessage(_ message: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError> {
-        return signHash(message.sha3(.keccak256), for: account, prompt: prompt)
     }
 
     public func signMessageBulk(_ data: [Data], for account: AlphaWallet.Address, prompt: String) -> Result<[Data], KeystoreError> {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/Keystore.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/Keystore.swift
@@ -31,7 +31,6 @@ public protocol Keystore: AnyObject {
     func isProtectedByUserPresence(account: AlphaWallet.Address) -> Bool
     func signPersonalMessage(_ message: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError>
     func signTypedMessage(_ datas: [EthTypedData], for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError>
-    func signMessage(_ message: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError>
     func signHash(_ hash: Data, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError>
     func signTransaction(_ transaction: UnsignedTransaction, prompt: String) -> Result<Data, KeystoreError>
     func signEip712TypedData(_ data: EIP712TypedData, for account: AlphaWallet.Address, prompt: String) -> Result<Data, KeystoreError>


### PR DESCRIPTION
More refactoring around signing to code to support hardware signing. In this PR, we remove a duplicate function and call the remaining one. They both operate on `Data`. Just the one that is removed is non-optional.