### PR TITLE
Removed background color from AccountViewTableSectionHeader label (default is clear)

### DIFF
--- a/AlphaWallet/Accounts/Views/AccountViewTableSectionHeader.swift
+++ b/AlphaWallet/Accounts/Views/AccountViewTableSectionHeader.swift
@@ -56,7 +56,6 @@ class AccountViewTableSectionHeader: UIView {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: Fonts.semibold(size: 15),
             .paragraphStyle: paragraphStyle,
-            .backgroundColor: Configuration.Color.Semantic.defaultViewBackground,
             .foregroundColor: Configuration.Color.Semantic.defaultForegroundText]
         let attrString = NSAttributedString(string: type.title, attributes: attributes)
         label.attributedText = attrString


### PR DESCRIPTION
Closes #6502

Light | Dark
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 16 34 35](https://user-images.githubusercontent.com/1050309/224943110-ee92369f-3e8f-4b6b-86e5-b0677fbfd983.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-14 at 16 34 33](https://user-images.githubusercontent.com/1050309/224943121-f1bb91b8-88ef-45e3-a36e-dc81bf76c8d7.png)
