### PR TITLE
support token uri rewriting

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 		87300E8B2851C9FE009DE4B3 /* AcceptDeepLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87300E8A2851C9FE009DE4B3 /* AcceptDeepLinkViewModel.swift */; };
 		87300E8E28520F28009DE4B3 /* EnsRecordsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87300E8D28520F28009DE4B3 /* EnsRecordsStorageTests.swift */; };
 		8733474E24ED008A002D649D /* TransactionConfirmationRowInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8733474D24ED008A002D649D /* TransactionConfirmationRowInfoView.swift */; };
+		8733885D29C4474500BF98A2 /* HostBasedTokenUriMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8733885C29C4474500BF98A2 /* HostBasedTokenUriMapperTests.swift */; };
 		8736214D264D3B0000AAF794 /* XYMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736214B264D3AFF00AAF794 /* XYMarkerView.swift */; };
 		8736214E264D3B0000AAF794 /* BalloonMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736214C264D3AFF00AAF794 /* BalloonMarker.swift */; };
 		873784FC28DB1F8600CE836F /* SelectSwapToolViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873784FB28DB1F8600CE836F /* SelectSwapToolViewController.swift */; };
@@ -1412,6 +1413,7 @@
 		87300E8A2851C9FE009DE4B3 /* AcceptDeepLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptDeepLinkViewModel.swift; sourceTree = "<group>"; };
 		87300E8D28520F28009DE4B3 /* EnsRecordsStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnsRecordsStorageTests.swift; sourceTree = "<group>"; };
 		8733474D24ED008A002D649D /* TransactionConfirmationRowInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionConfirmationRowInfoView.swift; sourceTree = "<group>"; };
+		8733885C29C4474500BF98A2 /* HostBasedTokenUriMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostBasedTokenUriMapperTests.swift; sourceTree = "<group>"; };
 		8736214B264D3AFF00AAF794 /* XYMarkerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XYMarkerView.swift; sourceTree = "<group>"; };
 		8736214C264D3AFF00AAF794 /* BalloonMarker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BalloonMarker.swift; sourceTree = "<group>"; };
 		873784FB28DB1F8600CE836F /* SelectSwapToolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectSwapToolViewController.swift; sourceTree = "<group>"; };
@@ -4404,6 +4406,7 @@
 				5E7C76A8CADEA69A91FECFD0 /* Ethereum */,
 				5E7C7900C580D38703DEB396 /* FakeDomainResolutionService.swift */,
 				5E7C7B7607941788030CA3CE /* Helpers */,
+				8733885C29C4474500BF98A2 /* HostBasedTokenUriMapperTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -5778,6 +5781,7 @@
 				778EAF7D1FF10AF400C8E2AB /* SettingsCoordinatorTests.swift in Sources */,
 				732E0F502022716700B39C1F /* LockEnterPasscodeCoordinatorTest.swift in Sources */,
 				29F114E91FA3EC9E00114A29 /* ActiveWalletViewTests.swift in Sources */,
+				8733885D29C4474500BF98A2 /* HostBasedTokenUriMapperTests.swift in Sources */,
 				2981F4731F8303E600CA6590 /* TransactionCoordinatorTests.swift in Sources */,
 				76F1D137B10D8309E513BBDD /* OrderSigningTests.swift in Sources */,
 				0242551A28168B84009D626E /* FeaturesTestCase.swift in Sources */,

--- a/AlphaWalletTests/Core/HostBasedTokenUriMapperTests.swift
+++ b/AlphaWalletTests/Core/HostBasedTokenUriMapperTests.swift
@@ -1,0 +1,24 @@
+//
+//  HostBasedTokenUriMapperTests.swift
+//  AlphaWalletTests
+//
+//  Created by Vladyslav Shepitko on 17.03.2023.
+//
+
+import XCTest
+@testable import AlphaWallet
+import Foundation
+import AlphaWalletFoundation
+
+class HostBasedTokenUriMapperTests: XCTestCase {
+
+    func testHideContractTwiceDoesNotCrash() {
+        let x = HostBasedTokenUriMapper(host: "api.mintkudos.xyz")
+        let u = URL(string: "https://api.mintkudos.xyz/metadata/3ba0000000000000000000000000000000000000000000000000000000000000")!
+        let r = x.map(uri: u)
+        
+        XCTAssertNotNil(r)
+        XCTAssertEqual(r!.absoluteString, "https://api.mintkudos.xyz/metadata/954")
+    }
+}
+

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/JsonFromTokenUri.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Helpers/JsonFromTokenUri.swift
@@ -31,7 +31,12 @@ final class JsonFromTokenUri {
         self.networkService = networkService
         self.blockchainProvider = blockchainProvider
         self.tokensService = tokensService
-        self.getTokenUri = NonFungibleContract(blockchainProvider: blockchainProvider)
+        self.getTokenUri = NonFungibleContract(
+            blockchainProvider: blockchainProvider,
+            uriMapper: TokenUriMapper(hostMappers: [
+                HostBasedTokenUriMapper(host: "api.mintkudos.xyz"),
+                HostBasedTokenUriMapper(host: "api.walletads.io")
+            ]))
     }
 
     func clear() {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Models/NonFungibleContract.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Models/NonFungibleContract.swift
@@ -6,8 +6,12 @@ import Combine
 
 final class NonFungibleContract {
     private let blockchainProvider: BlockchainProvider
+    private let uriMapper: TokenUriMapSupportable
 
-    public init(blockchainProvider: BlockchainProvider) {
+    public init(blockchainProvider: BlockchainProvider,
+                uriMapper: TokenUriMapSupportable) {
+
+        self.uriMapper = uriMapper
         self.blockchainProvider = blockchainProvider
     }
 
@@ -17,6 +21,13 @@ final class NonFungibleContract {
             .catch { [blockchainProvider] _ -> AnyPublisher<TokenUriData, SessionTaskError> in
                 return blockchainProvider
                     .call(Erc721UriMethodCall(contract: contract, tokenId: tokenId))
+            }.map { [uriMapper] data -> TokenUriData in
+                switch data {
+                case .data, .json, .string:
+                    return data
+                case .uri(let uri):
+                    return .uri(uriMapper.map(uri: uri) ?? uri)
+                }
             }.eraseToAnyPublisher()
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/TokenUriMapSupportable.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/TokenUriMapSupportable.swift
@@ -1,0 +1,80 @@
+//
+//  TokenUriMapSupportable.swift
+//  AlphaWalletFoundation
+//
+//  Created by Vladyslav Shepitko on 16.03.2023.
+//
+
+import Foundation
+import BigInt
+
+public protocol TokenUriMapSupportable {
+    func map(uri: URL) -> URL?
+}
+
+public struct TokenUriMapper: TokenUriMapSupportable {
+    public let hostMappers: [TokenUriMapSupportable]
+
+    public init(hostMappers: [TokenUriMapSupportable]) {
+        self.hostMappers = hostMappers
+    }
+
+    public func map(uri: URL) -> URL? {
+        hostMappers.compactMap { $0.map(uri: uri) }.first
+    }
+}
+
+//e.g: need to convert https://api.mintkudos.xyz/metadata/3ba0000000000000000000000000000000000000000000000000000000000000
+// to https://api.mintkudos.xyz/metadata/954
+
+public struct HostBasedTokenUriMapper: TokenUriMapSupportable {
+    public let host: String
+
+    public init(host: String) {
+        self.host = host
+    }
+
+    public func map(uri: URL) -> URL? {
+        guard var components = URLComponents(url: uri, resolvingAgainstBaseURL: false) else { return nil }
+        guard components.host == host else { return nil }
+        let path = components.path.components(separatedBy: "/")
+
+        if let tokenIdwithTo64CharsSuffix = path.last, tokenIdwithTo64CharsSuffix.count == 64 {
+            let droppedTrailingZeros = Array(tokenIdwithTo64CharsSuffix).map { String($0) }.removing(suffix: "0").joined()
+            guard let tokenId = BigInt(droppedTrailingZeros.drop0x, radix: 16) else { return nil }
+
+            let newPath = path.dropFirst(1).map { "/" + $0 }.dropLast(1).joined()
+            components.path = newPath + "/" + tokenId.description
+
+            return components.url ?? uri
+        }
+        return nil
+    }
+}
+
+fileprivate extension Array where Element: Equatable {
+
+    ///
+    /// Removes the trailing elements that match the specified suffix.
+    ///
+    /// - parameter suffix: The suffix to remove.
+    ///
+    /// - returns: The initial array without the specified suffix.
+    ///
+    func removing(suffix: Element) -> [Element] {
+        var array = self
+        var previousValue = suffix
+
+        for i in (0..<array.endIndex).reversed() {
+            let value = array[i]
+            guard value == previousValue else {
+                break
+            }
+
+            array.remove(at: i)
+            previousValue = value
+        }
+
+        return array
+    }
+}


### PR DESCRIPTION
support token uri rewriting, some of returned token uris return uri with token id with zeros siffix to reach 64 characters, and api don't suport it such uris
such as `https://api.mintkudos.xyz/metadata/3ba0000000000000000000000000000000000000000000000000000000000000` it needs to be converted to 
`https://api.mintkudos.xyz/metadata/954`