### PR TITLE
[RPC] Fix: gas price for chains with sub-gwei gas prices like Arbitrum (0.1 gwei) should not be padded with +1 gwei. It becomes more than 10x more gas fees than necessary #6547

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/BlockchainProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/RPC/BlockchainProvider.swift
@@ -125,8 +125,8 @@ public final class RpcBlockchainProvider: BlockchainProvider {
                     // Guard against really high prices
                     return GasEstimates(standard: params.maxPrice)
                 } else {
-                    if params.canUserChangeGas && params.shouldAddBufferWhenEstimatingGasPrice {
-                        //Add an extra gwei because the estimate is sometimes too low
+                    if params.canUserChangeGas && params.shouldAddBufferWhenEstimatingGasPrice, gasPrice > GasPriceConfiguration.oneGwei {
+                        //Add an extra gwei because the estimate is sometimes too low. We mustn't do this if the gas price estimated is lower than 1gwei since chains like Arbitrum is cheap (0.1gwei as of 20230320)
                         return GasEstimates(standard: gasPrice + GasPriceConfiguration.oneGwei)
                     } else {
                         return GasEstimates(standard: gasPrice)


### PR DESCRIPTION
Fixes #6547 