### PR TITLE
Fixed error type implementation for errors that are defined in modules which provide errorDescription in the application. 

### DIFF
--- a/AlphaWallet/Common/Views/AddressTextField.swift
+++ b/AlphaWallet/Common/Views/AddressTextField.swift
@@ -443,7 +443,7 @@ extension String {
     }
 }
 
-extension SendInputErrors {
+extension SendInputErrors: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .emptyClipBoard:

--- a/AlphaWallet/Swap/Swap/ViewModels/SwapQuoteDetailsViewModel.swift
+++ b/AlphaWallet/Swap/Swap/ViewModels/SwapQuoteDetailsViewModel.swift
@@ -127,8 +127,8 @@ final class SwapQuoteDetailsViewModel {
     }
 }
 
-extension TokenLevelTokenScriptDisplayStatus.SignatureValidationError {
-    var errorDescription: String? {
+extension TokenLevelTokenScriptDisplayStatus.SignatureValidationError: LocalizedError {
+    public var errorDescription: String? {
         switch self {
         case .tokenScriptType1SupportedNotCanonicalizedAndUnsigned:
             return R.string.localizable.tokenScriptType1SupportedNotCanonicalizedAndUnsigned()

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/CancelTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/CancelTransactionViewModel.swift
@@ -167,8 +167,8 @@ extension ConfigureTransactionError: LocalizedError {
     }
 }
 
-extension AddCustomChainError {
-    var errorDescription: String? {
+extension AddCustomChainError: LocalizedError {
+    public var errorDescription: String? {
         switch self {
         case .cancelled:
             //This is the default behavior, just keep it

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Models/AddCustomChain.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Models/AddCustomChain.swift
@@ -3,7 +3,7 @@
 import Foundation
 import Combine
 
-public enum AddCustomChainError: LocalizedError {
+public enum AddCustomChainError: Error {
     case cancelled
     case missingBlockchainExplorerUrl
     case invalidBlockchainExplorerUrl

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/SendInputErrors.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/SendInputErrors.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public enum SendInputErrors: LocalizedError {
+public enum SendInputErrors: Error {
     case emptyClipBoard
     case wrongInput
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift
@@ -94,7 +94,7 @@ public enum TokenLevelTokenScriptDisplayStatus {
         case invalidSignature
     }
 
-    public enum SignatureValidationError: LocalizedError {
+    public enum SignatureValidationError: Error {
         case tokenScriptType1SupportedNotCanonicalizedAndUnsigned
         case tokenScriptType1SupportedAndSigned
         case tokenScriptType2InvalidSignature


### PR DESCRIPTION
Closes #6541

I ran `grep -nriI "LocalizedError" . | grep -i ".swift" | grep -i "module" | sort > ~/Desktop/LocalizedErrors.txt` on the root directory of the repo to find all the instances where `LocalizedError ` occurred in swift files in the module directory. This gave me a list of 19 instances.
```text
./modules/AlphaWalletENS/AlphaWalletENS/ENSError.swift:9:struct ENSError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/CastError.swift:5:public struct CastError<ExpectedType>: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Ethereum/ABI/ABIError.swift:9:public enum ABIError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/EtherKeystore.swift:11:public enum EtherKeystoreError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/LegacyFileBasedKeystore.swift:9:public enum FileBasedKeystoreError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/KeyManagement/SecureEnclave.swift:8:    enum Error: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/NFT/Enjin/EnjinUserManagementInterceptor.swift:102:    public enum JSONResponseParsingError: Error, LocalizedError {
=> ./modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Models/AddCustomChain.swift:6:public enum AddCustomChainError: LocalizedError {
=> ./modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/SendInputErrors.swift:5:public enum SendInputErrors: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/SwapToken/NativeSwap/Types/SwapError.swift:10:public enum SwapError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/FunctionOrigin.swift:8:public enum FunctionError: LocalizedError {
=> ./modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/Models/XMLHandler.swift:97:    public enum SignatureValidationError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/TokenScriptClient/SchemaCheckError.swift:10:public struct SchemaCheckError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/GetBlockTimestamp.swift:53:extension JSONRPCKit.JSONRPCError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift:76:    enum ImageAvailabilityError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Types/Web3Error.swift:5:public struct Web3Error: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/TransactionConfigurator.swift:17:public enum TransactionConfiguratorError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/DevelopmentForcedError.swift:5:public struct DevelopmentForcedError: LocalizedError {
./modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/RpcJson/JsonRpcError.swift:38:extension JsonRpcError: LocalizedError {
```
I went through all of them and found only two instances which followed your pattern of originally being declared a `LocalizedError` and having an extension in `AlphaWallet` that specifies the `errorDescription`.

Once approved, I will squish the commits into one to merge.

Do I need to go through the `Pods` directory? I skipped it since the code is not under our control.