### PR TITLE
Mark Sepolia as testnet, not mainnet (close #6575)

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Settings/Types/RPCServers.swift
@@ -154,9 +154,9 @@ public enum RPCServer: Hashable, CaseIterable {
 
     public var isTestnet: Bool {
         switch self {
-        case .xDai, .classic, .main, .callisto, .binance_smart_chain, .artis_sigma1, .heco, .fantom, .avalanche, .polygon, .optimistic, .arbitrum, .palm, .klaytnCypress, .ioTeX, .cronosMainnet, .okx, .sepolia:
+        case .xDai, .classic, .main, .callisto, .binance_smart_chain, .artis_sigma1, .heco, .fantom, .avalanche, .polygon, .optimistic, .arbitrum, .palm, .klaytnCypress, .ioTeX, .cronosMainnet, .okx:
             return false
-        case .goerli, .artis_tau1, .binance_smart_chain_testnet, .heco_testnet, .fantom_testnet, .avalanche_testnet, .mumbai_testnet, .cronosTestnet, .palmTestnet, .klaytnBaobabTestnet, .ioTeXTestnet, .optimismGoerli, .arbitrumGoerli:
+        case .goerli, .artis_tau1, .binance_smart_chain_testnet, .heco_testnet, .fantom_testnet, .avalanche_testnet, .mumbai_testnet, .cronosTestnet, .palmTestnet, .klaytnBaobabTestnet, .ioTeXTestnet, .optimismGoerli, .arbitrumGoerli, .sepolia:
             return true
         case .custom(let custom):
             return custom.isTestnet


### PR DESCRIPTION
Sepolia is a testnet:
https://ethereum.org/en/developers/docs/networks/#ethereum-testnets

If bug:
Fixes #6575 

If not a bug:
Closes #

1-liner summary: Mark Sepolia as testnet, not mainnet

Details if any (this should probably be in the commit message too):

Screenshots of Before PR and After PR if it's applicable (sometimes this make it much faster/easier to review):

Anything particular to test:
