### PR TITLE
[Refactoring] move more code to view appropriate view model

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -626,6 +626,7 @@
 		8769888D24C6ED04002BF62B /* TransactionInProgressCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8769888C24C6ED04002BF62B /* TransactionInProgressCoordinator.swift */; };
 		8769BCA8256D15BF0095EA5B /* BlockieImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8769BCA7256D15BF0095EA5B /* BlockieImageView.swift */; };
 		876C25E429CAF91A009A5396 /* PublisherToAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C25E329CAF91A009A5396 /* PublisherToAsyncTests.swift */; };
+		876C25E629CC92AF009A5396 /* ConfirmButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C25E529CC92AF009A5396 /* ConfirmButtonViewModel.swift */; };
 		876C80CD2673940B00B16595 /* SwitchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876C80CC2673940B00B16595 /* SwitchView.swift */; };
 		87713EB0264BAB2500B1B9CB /* TokenPagesContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87713EAF264BAB2500B1B9CB /* TokenPagesContainerView.swift */; };
 		87713EB4264BAB5A00B1B9CB /* ActivityPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87713EB3264BAB5A00B1B9CB /* ActivityPageView.swift */; };
@@ -1518,6 +1519,7 @@
 		8769888C24C6ED04002BF62B /* TransactionInProgressCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionInProgressCoordinator.swift; sourceTree = "<group>"; };
 		8769BCA7256D15BF0095EA5B /* BlockieImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockieImageView.swift; sourceTree = "<group>"; };
 		876C25E329CAF91A009A5396 /* PublisherToAsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherToAsyncTests.swift; sourceTree = "<group>"; };
+		876C25E529CC92AF009A5396 /* ConfirmButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmButtonViewModel.swift; sourceTree = "<group>"; };
 		876C80CC2673940B00B16595 /* SwitchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchView.swift; sourceTree = "<group>"; };
 		87713EAF264BAB2500B1B9CB /* TokenPagesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenPagesContainerView.swift; sourceTree = "<group>"; };
 		87713EB3264BAB5A00B1B9CB /* ActivityPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityPageView.swift; sourceTree = "<group>"; };
@@ -2486,6 +2488,7 @@
 				874D098F25EE32EF00A58EF2 /* SignatureConfirmationDetailsViewModel.swift */,
 				874D099125EE336E00A58EF2 /* TypedDataViewModel.swift */,
 				5E7C7BB7DBFDF5A5E4F2DDC0 /* SendTransactionErrorViewModel.swift */,
+				876C25E529CC92AF009A5396 /* ConfirmButtonViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -5199,6 +5202,7 @@
 				73ED85A72034BFEF00593BF3 /* UITextFieldAdditions.swift in Sources */,
 				022CED80277B01E10043287F /* ScrollableSegmentedControlCell.swift in Sources */,
 				87E2555224F52E5700F025F7 /* SlidableTextFieldViewModel.swift in Sources */,
+				876C25E629CC92AF009A5396 /* ConfirmButtonViewModel.swift in Sources */,
 				73C41C73201B5EFF00243C6C /* LockCreatePasscodeViewModel.swift in Sources */,
 				87AA49E629ACEF89007C5D63 /* EnterAssetAmountView.swift in Sources */,
 				02220CFC273A9A02006A09BF /* SaveCustomRpcCoordinator.swift in Sources */,

--- a/AlphaWallet/Common/ViewModels/AcceptDeepLinkViewModel.swift
+++ b/AlphaWallet/Common/ViewModels/AcceptDeepLinkViewModel.swift
@@ -57,15 +57,26 @@ final class AcceptDeepLinkViewModel: ExpandableSection {
         for section in sections.indices {
             switch sections[section] {
             case .name:
-                let viewModel = TransactionConfirmationHeaderViewModel(title: .normal(metadata.name), headerName: sections[section].title, configuration: .init(section: section))
+                let viewModel = TransactionConfirmationHeaderViewModel(
+                    title: .normal(metadata.name),
+                    headerName: sections[section].title,
+                    viewState: .init(section: section))
+
                 viewModels += [.header(viewModel: viewModel, editButtonEnabled: false)]
             case .url:
                 let appUrl = metadata.appUrl?.absoluteString ?? ""
-                let viewModel = TransactionConfirmationHeaderViewModel(title: .normal(appUrl), headerName: sections[section].title, configuration: .init(section: section))
+                let viewModel = TransactionConfirmationHeaderViewModel(
+                    title: .normal(appUrl),
+                    headerName: sections[section].title,
+                    viewState: .init(section: section))
+
                 viewModels += [.header(viewModel: viewModel, editButtonEnabled: false)]
             case .note:
                 let note = R.string.localizable.acceptDeepLinkFieldNote(address.eip55String)
-                let viewModel = TransactionConfirmationHeaderViewModel(title: .normal(note), headerName: sections[section].title, configuration: .init(section: section))
+                let viewModel = TransactionConfirmationHeaderViewModel(
+                    title: .normal(note),
+                    headerName: sections[section].title,
+                    viewState: .init(section: section))
 
                 viewModels += [.header(viewModel: viewModel, editButtonEnabled: false)]
             }

--- a/AlphaWallet/Common/ViewModels/AcceptWalletConnectSessionViewModel.swift
+++ b/AlphaWallet/Common/ViewModels/AcceptWalletConnectSessionViewModel.swift
@@ -108,24 +108,28 @@ final class AcceptWalletConnectSessionViewModel: ExpandableSection {
 
         switch sections[section] {
         case .name:
-            return .init(title: .normal(proposal.name), headerName: sections[section].title, configuration: .init(section: section))
+            return .init(title: .normal(proposal.name), headerName: sections[section].title, viewState: .init(section: section))
         case .networks:
             let servers = serversToConnect.map { $0.displayName }.joined(separator: ", ")
             let shouldHideChevron = proposal.serverEditing == .notSupporting || serversToConnect.count == 1
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
                 isOpened: isOpened,
                 section: section,
                 shouldHideChevron: shouldHideChevron)
             let serverIcon = serversToConnect.first?.walletConnectIconImage ?? .just(nil)
 
-            return .init(title: .normal(servers), headerName: serversSectionTitle, titleIcon: serverIcon, configuration: configuration)
+            return .init(title: .normal(servers), headerName: serversSectionTitle, titleIcon: serverIcon, viewState: viewState)
         case .url:
             let dappUrl = proposal.dappUrl.absoluteString
-            return .init(title: .normal(dappUrl), headerName: sections[section].title, configuration: .init(section: section))
+            return .init(title: .normal(dappUrl), headerName: sections[section].title, viewState: .init(section: section))
         case .methods:
             let methods = methods.joined(separator: ", ")
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(isOpened: isOpened, section: section, shouldHideChevron: !sections[section].isExpandable)
-            return .init(title: .normal(methods), headerName: sections[section].title, configuration: configuration)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: isOpened,
+                section: section,
+                shouldHideChevron: !sections[section].isExpandable)
+
+            return .init(title: .normal(methods), headerName: sections[section].title, viewState: viewState)
         }
     }
 

--- a/AlphaWallet/Common/ViewModels/DappRequesterViewModel.swift
+++ b/AlphaWallet/Common/ViewModels/DappRequesterViewModel.swift
@@ -16,20 +16,20 @@ struct DappRequesterViewModel: RequesterViewModel {
 
         var dappNameHeader: String { R.string.localizable.walletConnectDappName() }
         viewModels += [
-            .header(.init(title: .normal(requester.shortName), headerName: dappNameHeader, configuration: .init(section: 0)))
+            .header(.init(title: .normal(requester.shortName), headerName: dappNameHeader, viewState: .init(section: 0)))
         ]
 
         if let dappUrl = requester.url {
             var dappWebsiteHeader: String { R.string.localizable.walletConnectDappWebsite() }
             viewModels += [
-                .header(.init(title: .normal(dappUrl.absoluteString), headerName: dappWebsiteHeader, configuration: .init(section: 0))),
+                .header(.init(title: .normal(dappUrl.absoluteString), headerName: dappWebsiteHeader, viewState: .init(section: 0))),
             ]
         }
 
         if let server = requester.server {
             var dappServerHeader: String { R.string.localizable.settingsNetworkButtonTitle() }
             viewModels += [
-                .header(.init(title: .normal(server.name), headerName: dappServerHeader, configuration: .init(section: 0)))
+                .header(.init(title: .normal(server.name), headerName: dappServerHeader, viewState: .init(section: 0)))
             ]
         }
 

--- a/AlphaWallet/Common/ViewModels/DeepLinkRequesterViewModel.swift
+++ b/AlphaWallet/Common/ViewModels/DeepLinkRequesterViewModel.swift
@@ -16,20 +16,20 @@ struct DeepLinkRequesterViewModel: RequesterViewModel {
 
         var dappNameHeader: String { R.string.localizable.walletConnectDappName() }
         viewModels += [
-            .header(.init(title: .normal(requester.shortName), headerName: dappNameHeader, configuration: .init(section: 0)))
+            .header(.init(title: .normal(requester.shortName), headerName: dappNameHeader, viewState: .init(section: 0)))
         ]
 
         if let dappUrl = requester.url {
             var dappWebsiteHeader: String { R.string.localizable.requesterFieldUrl() }
             viewModels += [
-                .header(.init(title: .normal(dappUrl.absoluteString), headerName: dappWebsiteHeader, configuration: .init(section: 0))),
+                .header(.init(title: .normal(dappUrl.absoluteString), headerName: dappWebsiteHeader, viewState: .init(section: 0))),
             ]
         }
 
         if let server = requester.server {
             var dappServerHeader: String { R.string.localizable.settingsNetworkButtonTitle() }
             viewModels += [
-                .header(.init(title: .normal(server.name), headerName: dappServerHeader, configuration: .init(section: 0)))
+                .header(.init(title: .normal(server.name), headerName: dappServerHeader, viewState: .init(section: 0)))
             ]
         }
 

--- a/AlphaWallet/Common/Views/ImageView.swift
+++ b/AlphaWallet/Common/Views/ImageView.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AlphaWalletFoundation
 import Combine
+import Kingfisher
 
 class ImageView: UIImageView {
     private let subject: PassthroughSubject<ImagePublisher, Never> = .init()
@@ -28,7 +29,15 @@ class ImageView: UIImageView {
     private func bind() {
         subject.flatMapLatest { $0 }
             .sink { [weak self] image in
-                self?.image = image
+                switch image {
+                case .url(let url):
+                    self?.setImage(url: url.url, placeholder: R.image.iconsTokensPlaceholder())
+                case .image(let image):
+                    self?.image = image
+                case .none:
+                    break
+                }
+
                 if self?.hideWhenImageIsNil ?? false {
                     self?.isHidden = image == nil
                 }

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Amount";
 "transactionConfirmation.Send.Section.Recipient.title" = "Recipient";
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
 "transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Amount";
 "transactionConfirmation.Send.Section.Recipient.title" = "Recipient";
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
 "transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/fi.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/fi.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Summa";
 "transactionConfirmation.Send.Section.Recipient.title" = "Vastaanottaja";
 "transactionConfirmation.Send.Section.TokenId.title" = "Rahake";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Aktorisoi vahvistaaksesi tilitapahtuman";
 "transactionConfirmation.keystore.accessKey.sign" = "Salaista avainta käsitellään siirron suorittamiseksi";
 "transactionConfirmation.fee.footerText" = "Mitä korkeampi kulujen yksikköhinta (Gas Fee) on, sitä suuremmalla todennäköisyydellä tilitapahtumasi vahvistetaan nopeasti. Sovelluksen arvioimat yksikköhinnat perustuvat lohkoketjun ajantasaiseen kuormitustietoon.";

--- a/AlphaWallet/Localization/ja.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ja.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Amount";
 "transactionConfirmation.Send.Section.Recipient.title" = "Recipient";
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
 "transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/ko.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/ko.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Amount";
 "transactionConfirmation.Send.Section.Recipient.title" = "Recipient";
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
 "transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "transactionConfirmation.Send.Section.Amount.title" = "Amount";
 "transactionConfirmation.Send.Section.Recipient.title" = "Recipient";
 "transactionConfirmation.Send.Section.TokenId.title" = "Token";
+"transactionConfirmation.Send.Section.Requester.title" = "Dapp";
 "transactionConfirmation.authorisation.reason" = "Authorize to confirm transaction";
 "transactionConfirmation.keystore.accessKey.sign" = "Accessing to perform transfer";
 "transactionConfirmation.fee.footerText" = "The higher the fee, the better chances and faster your transaction will go through. Fees are based on current Ethereum blockchain network load.";

--- a/AlphaWallet/Settings/ViewModels/CheckTransactionStateViewModel.swift
+++ b/AlphaWallet/Settings/ViewModels/CheckTransactionStateViewModel.swift
@@ -12,12 +12,12 @@ import AlphaWalletWeb3
 
 struct CheckTransactionStateViewModel {
     private let serverSelection: ServerSelection
-    private let configuration = TransactionConfirmationHeaderView.Configuration(section: 0)
+    private let viewState = TransactionConfirmationHeaderViewModel.ViewState(section: 0)
 
     let textFieldPlaceholder: String = R.string.localizable.checkTransactionStateFieldHashPlaceholder()
 
     var serverSelectionViewModel: TransactionConfirmationHeaderViewModel {
-        return .init(title: .normal(selectedServerString), headerName: serverViewTitle, configuration: configuration)
+        return .init(title: .normal(selectedServerString), headerName: serverViewTitle, viewState: viewState)
     }
 
     let title: String = R.string.localizable.checkTransactionStateTitle()

--- a/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransactionConfirmationViewController.swift
@@ -13,9 +13,9 @@ protocol TransactionConfirmationViewControllerDelegate: AnyObject {
 }
 
 class TransactionConfirmationViewController: UIViewController {
-    private lazy var headerView = ConfirmationHeaderView(viewModel: .init(title: viewModel.title))
+    private lazy var headerView = ConfirmationHeaderView(viewModel: .init(title: ""))
     private let buttonsBar = HorizontalButtonsBar(configuration: .primary(buttons: 1))
-    let viewModel: TransactionConfirmationViewModel
+    let viewModel: TransactionConfirmationViewModelType
     private let separatorLine: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -37,11 +37,11 @@ class TransactionConfirmationViewController: UIViewController {
         return view.heightAnchor.constraint(equalToConstant: preferredContentSize.height)
     }()
 
-    private var cancelable = Set<AnyCancellable>()
+    private var cancellable = Set<AnyCancellable>()
 
     weak var delegate: TransactionConfirmationViewControllerDelegate?
 
-    init(viewModel: TransactionConfirmationViewModel) {
+    init(viewModel: TransactionConfirmationViewModelType) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
 
@@ -100,19 +100,15 @@ class TransactionConfirmationViewController: UIViewController {
                 } else {
                     strongSelf.heightConstraint.constant = newHeight
                 }
-            }.store(in: &cancelable)
+            }.store(in: &cancellable)
     } 
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        separatorLine.isHidden = !viewModel.hasSeparatorAboveConfirmButton
-
         buttonsBar.configure()
         let button = buttonsBar.buttons[0]
         button.shrinkBorderColor = Configuration.Color.Semantic.loadingIndicatorBorder
-        button.setTitle(viewModel.confirmationButtonTitle, for: .normal)
-        button.addTarget(self, action: #selector(confirmButtonSelected), for: .touchUpInside)
 
         containerView.scrollView.backgroundColor = Configuration.Color.Semantic.backgroundClear
         view.backgroundColor = Configuration.Color.Semantic.backgroundClear
@@ -155,19 +151,33 @@ class TransactionConfirmationViewController: UIViewController {
         delegate?.didClose(in: self)
     }
 
-    private func bind(viewModel: TransactionConfirmationViewModel) {
+    private func bind(viewModel: TransactionConfirmationViewModelType) {
         let input = TransactionConfirmationViewModelInput()
+
         let output = viewModel.transform(input: input)
         output.viewState
             .sink { [weak self, headerView] viewState in
                 headerView.configure(viewModel: .init(title: viewState.title))
                 self?.generateSubviews(for: viewState.views)
-            }.store(in: &cancelable)
-    }
+                self?.separatorLine.isHidden = viewState.isSeparatorHidden
+            }.store(in: &cancellable)
 
-    @objc func confirmButtonSelected(_ sender: UIButton) {
-        guard viewModel.canBeConfirmed else { return }
-        delegate?.controller(self, continueButtonTapped: sender)
+        let continueButton = buttonsBar.buttons[0]
+        let confirmButtonViewModelInput = ConfirmButtonViewModelInput(
+            trigger: continueButton.publisher(forEvent: .touchUpInside).eraseToAnyPublisher())
+
+        let confirmButtonViewModelOutput = viewModel.confirmButtonViewModel.transform(input: confirmButtonViewModelInput)
+        confirmButtonViewModelOutput.viewState
+            .sink { viewState in
+                continueButton.setTitle(viewState.title, for: .normal)
+                continueButton.isEnabled = viewState.isEnabled
+            }.store(in: &cancellable)
+
+        confirmButtonViewModelOutput.confirmSelected
+            .sink { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.delegate?.controller(strongSelf, continueButtonTapped: strongSelf.buttonsBar.buttons[0])
+            }.store(in: &cancellable)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -186,6 +196,11 @@ extension TransactionConfirmationViewController {
             switch each {
             case .view(let viewModel, let isHidden):
                 let view = TransactionConfirmationRowInfoView(viewModel: viewModel)
+                view.isHidden = isHidden
+
+                activeHeaderView?.childrenStackView.addArrangedSubview(view)
+            case .recipient(let viewModel, let isHidden):
+                let view = TransactionConfirmationRecipientRowInfoView(viewModel: viewModel)
                 view.isHidden = isHidden
 
                 activeHeaderView?.childrenStackView.addArrangedSubview(view)

--- a/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfigureTransactionViewModel.swift
@@ -11,7 +11,7 @@ struct ConfigureTransactionViewModel {
     }
     private let service: TokenViewModelState
     private let transactionType: TransactionType
-    private let configurator: TransactionConfigurator
+    let configurator: TransactionConfigurator
     private let fullFormatter = EtherNumberFormatter.full
     private var totalFee: BigUInt {
         return configurationToEdit.gasPrice * configurationToEdit.gasLimit
@@ -135,7 +135,10 @@ struct ConfigureTransactionViewModel {
         return R.string.localizable.configureTransactionHeaderGasLimit()
     }
 
-    init(configurator: TransactionConfigurator, recoveryMode: ConfigureTransactionViewModel.RecoveryMode, service: TokenViewModelState) {
+    init(configurator: TransactionConfigurator,
+         recoveryMode: ConfigureTransactionViewModel.RecoveryMode,
+         service: TokenViewModelState) {
+        
         let configurations = configurator.configurations
         self.configurationTypes = ConfigureTransactionViewModel.sortedConfigurationTypes(fromConfigurations: configurations)
         self.configurator = configurator

--- a/AlphaWallet/Transfer/ViewModels/ConfirmButtonViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/ConfirmButtonViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  ConfirmButtonViewModel.swift
+//  AlphaWallet
+//
+//  Created by Vladyslav Shepitko on 23.03.2023.
+//
+
+import Foundation
+import UIKit
+import Combine
+import AlphaWalletFoundation
+
+struct ConfirmButtonViewModelInput {
+    let trigger: AnyPublisher<Void, Never>
+}
+
+struct ConfirmButtonViewModelOutput {
+    let viewState: AnyPublisher<ConfirmButtonViewModel.ViewState, Never>
+    let confirmSelected: AnyPublisher<Void, Never>
+}
+
+class ConfirmButtonViewModel {
+    @Published private var isButtonEnabled: Bool = true
+    private let title: String
+    private let configurator: TransactionConfigurator
+    private var cancellable = Set<AnyCancellable>()
+
+    init(configurator: TransactionConfigurator, title: String) {
+        self.configurator = configurator
+        self.title = title
+        
+        //NOTE: prev impl wanted some delay after changing transaction configuration
+        Publishers.Merge(configurator.gasLimit.mapToVoid(), configurator.gasPrice.mapToVoid())
+            .handleEvents(receiveOutput: { [weak self] _ in self?.isButtonEnabled = false })
+            .delay(for: .milliseconds(300), scheduler: RunLoop.main)
+            .handleEvents(receiveOutput: { [weak self] _ in self?.isButtonEnabled = true })
+            .sink { _ in }
+            .store(in: &cancellable)
+    }
+
+    func transform(input: ConfirmButtonViewModelInput) -> ConfirmButtonViewModelOutput {
+        let confirmSelected = input.trigger
+            .filter { _ in self.isButtonEnabled }
+
+        let viewState = $isButtonEnabled
+            .map { [title] in ConfirmButtonViewModel.ViewState(title: title, isEnabled: $0) }
+
+        return .init(
+            viewState: viewState.eraseToAnyPublisher(),
+            confirmSelected: confirmSelected.eraseToAnyPublisher())
+    }
+}
+
+extension ConfirmButtonViewModel {
+    struct ViewState {
+        let title: String
+        let isEnabled: Bool
+    }
+}

--- a/AlphaWallet/Transfer/ViewModels/SignatureConfirmationConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SignatureConfirmationConfirmationViewModel.swift
@@ -98,7 +98,7 @@ extension SignatureConfirmationViewModel {
             values = (requester?.viewModels ?? []).compactMap { $0 as? SignatureConfirmationViewModel.ViewType }
 
             return values + [
-                .headerWithShowButton(.init(title: .normal(messagePrefix), headerName: header, configuration: .init(section: values.count)), availableToShowFullMessage)
+                .headerWithShowButton(.init(title: .normal(messagePrefix), headerName: header, viewState: .init(section: values.count)), availableToShowFullMessage)
             ]
         }
     }
@@ -136,7 +136,7 @@ extension SignatureConfirmationViewModel {
                 let string = data.value.shortStringRepresentation
                 values += [
                     .headerWithShowButton(
-                        .init(title: .normal(string), headerName: data.key, configuration: .init(section: Int(sectionIndex))),
+                        .init(title: .normal(string), headerName: data.key, viewState: .init(section: Int(sectionIndex))),
                         true
                     )
                 ]
@@ -162,7 +162,7 @@ extension SignatureConfirmationViewModel {
                 let string = typedMessage.value.string
                 values += [
                     .headerWithShowButton(
-                        .init(title: .normal(string), headerName: typedMessage.name, configuration: .init(section: Int(sectionIndex))),
+                        .init(title: .normal(string), headerName: typedMessage.name, viewState: .init(section: Int(sectionIndex))),
                         true
                     )
                 ]

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/CancelTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/CancelTransactionViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import BigInt
 import AlphaWalletFoundation
+import Combine
 
 struct CurrencyRate {
     let currency: Currency
@@ -15,32 +16,56 @@ struct CurrencyRate {
 }
 
 extension TransactionConfirmationViewModel {
-    class CancelTransactionViewModel: ExpandableSection, RateUpdatable, BalanceUpdatable {
+    class CancelTransactionViewModel: TransactionConfirmationViewModelType {
+        @Published private var etherCurrencyRate: Loadable<CurrencyRate, Error> = .loading
+
         private let configurator: TransactionConfigurator
         private let session: WalletSession
-        
-        var rate: CurrencyRate?
+        private var cancellable = Set<AnyCancellable>()
+        private let tokensService: TokenViewModelState
+        private var sections: [Section] { [.gas, .network, .description] }
+
+        let confirmButtonViewModel: ConfirmButtonViewModel
         var openedSections = Set<Int>()
 
-        var sections: [Section] {
-            [.gas, .network, .description]
+        init(configurator: TransactionConfigurator, tokensService: TokenViewModelState) {
+            self.configurator = configurator
+            self.tokensService = tokensService
+            self.session = configurator.session
+            self.confirmButtonViewModel = ConfirmButtonViewModel(
+                configurator: configurator,
+                title: R.string.localizable.tokenTransactionCancelConfirmationTitle())
         }
 
-        init(configurator: TransactionConfigurator) {
-            self.configurator = configurator
-            self.session = configurator.session
+        func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
+            let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: configurator.session.server)
+            tokensService.tokenViewModelPublisher(for: etherToken)
+                .map { $0?.balance.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) } }
+                .map { $0.flatMap { Loadable<CurrencyRate, Error>.done($0) } ?? .failure(SendFungiblesTransactionViewModel.NoCurrencyRateError()) }
+                .assign(to: \.etherCurrencyRate, on: self)
+                .store(in: &cancellable)
+
+            let viewState = Publishers.Merge($etherCurrencyRate.mapToVoid(), configurator.objectChanges)
+                .map { _ in
+                    TransactionConfirmationViewModel.ViewState(
+                        title: R.string.localizable.tokenTransactionSpeedupConfirmationTitle(),
+                        views: self.buildTypedViews(),
+                        isSeparatorHidden: true)
+                }
+
+            return TransactionConfirmationViewModelOutput(viewState: viewState.eraseToAnyPublisher())
         }
 
         func shouldShowChildren(for section: Int, index: Int) -> Bool {
             return true
         }
 
-        func generateViews() -> [ViewType] {
+        private func buildTypedViews() -> [ViewType] {
             var views: [ViewType] = []
             for (sectionIndex, section) in sections.enumerated() {
                 switch section {
                 case .gas:
-                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: configurator.session.server.canUserChangeGas)]
+                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: session.server.canUserChangeGas)]
                 case .description:
                     let vm = TransactionRowDescriptionTableViewCellViewModel(title: section.title)
                     views += [.details(viewModel: vm)]
@@ -52,25 +77,26 @@ extension TransactionConfirmationViewModel {
         }
 
         private func buildHeaderViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(isOpened: openedSections.contains(section), section: section, shouldHideChevron: !sections[section].isExpandable)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: openedSections.contains(section),
+                section: section,
+                shouldHideChevron: !sections[section].isExpandable)
+
             let headerName = sections[section].title
+
             switch sections[section] {
             case .gas:
-                let gasFee = gasFeeString(for: configurator, rate: rate)
+                let gasFee = gasFeeString(for: configurator, rate: etherCurrencyRate.value)
                 if let warning = configurator.gasPriceWarning {
-                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, viewState: viewState)
                 } else {
-                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, viewState: viewState)
                 }
             case .description:
-                return .init(title: .normal(sections[section].title), headerName: nil, configuration: configuration)
+                return .init(title: .normal(sections[section].title), headerName: nil, viewState: viewState)
             case .network:
-                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, configuration: configuration)
+                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, viewState: viewState)
             }
-        }
-
-        func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-            //no-op
         }
     }
 }

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/ClaimPaidErc875MagicLinkViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/ClaimPaidErc875MagicLinkViewModel.swift
@@ -8,59 +8,68 @@
 import Foundation
 import BigInt
 import AlphaWalletFoundation
+import Combine
 
 extension TransactionConfirmationViewModel {
-    class ClaimPaidErc875MagicLinkViewModel: ExpandableSection, RateUpdatable, BalanceUpdatable {
+    class ClaimPaidErc875MagicLinkViewModel: TransactionConfirmationViewModelType {
+        @Published private var etherCurrencyRate: Loadable<CurrencyRate, Error> = .loading
+
         private let configurator: TransactionConfigurator
         private let price: BigUInt
         private let numberOfTokens: UInt
         private let session: WalletSession
+        private var cancellable = Set<AnyCancellable>()
+        private let tokensService: TokenViewModelState
+        private var sections: [Section] { Section.allCases }
 
-        private var formattedAmountValue: String {
-            //NOTE: what actual token can be here? or its always native crypto, need to firegu out right `decimals` value, better to pass here actual NSDecimalNumber value
-            let amountToSend = (Decimal(bigUInt: price, decimals: configurator.session.server.decimals) ?? .zero).doubleValue
-            let amount = NumberFormatter.shortCrypto.string(double: amountToSend) ?? "-"
-
-            if let rate = rate {
-                let amountInFiat = NumberFormatter.fiat(currency: rate.currency).string(double: amountToSend * rate.value) ?? "-"
-
-                return "\(amount) \(configurator.session.server.symbol) ≈ \(amountInFiat)"
-            } else {
-                return "\(amount) \(configurator.session.server.symbol)"
-            }
-        }
-
+        let confirmButtonViewModel: ConfirmButtonViewModel
         var openedSections = Set<Int>()
-        var rate: CurrencyRate?
-
-        var sections: [Section] {
-            return Section.allCases
-        }
 
         init(configurator: TransactionConfigurator,
              price: BigUInt,
-             numberOfTokens: UInt) {
+             numberOfTokens: UInt,
+             tokensService: TokenViewModelState) {
             
             self.configurator = configurator
             self.price = price
             self.numberOfTokens = numberOfTokens
             self.session = configurator.session
+            self.tokensService = tokensService
+
+            self.confirmButtonViewModel = ConfirmButtonViewModel(
+                configurator: configurator,
+                title: R.string.localizable.confirmPaymentConfirmButtonTitle())
         }
 
-        func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-            //no-op
+        func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
+            let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: configurator.session.server)
+            tokensService.tokenViewModelPublisher(for: etherToken)
+                .map { $0?.balance.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) } }
+                .map { $0.flatMap { Loadable<CurrencyRate, Error>.done($0) } ?? .failure(SendFungiblesTransactionViewModel.NoCurrencyRateError()) }
+                .assign(to: \.etherCurrencyRate, on: self)
+                .store(in: &cancellable)
+
+            let viewState = Publishers.Merge($etherCurrencyRate.mapToVoid(), configurator.objectChanges)
+                .map { _ in
+                    TransactionConfirmationViewModel.ViewState(
+                        title: R.string.localizable.tokenTransactionPurchaseConfirmationTitle(),
+                        views: self.buildTypedViews(),
+                        isSeparatorHidden: false)
+                }
+
+            return TransactionConfirmationViewModelOutput(viewState: viewState.eraseToAnyPublisher())
         }
 
         func shouldShowChildren(for section: Int, index: Int) -> Bool {
             return true
         }
 
-        func generateViews() -> [ViewType] {
+        private func buildTypedViews() -> [ViewType] {
             var views: [ViewType] = []
             for (sectionIndex, section) in sections.enumerated() {
                 switch section {
                 case .gas:
-                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: configurator.session.server.canUserChangeGas)]
+                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: session.server.canUserChangeGas)]
                 case .amount, .numberOfTokens, .network:
                     views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: false)]
                 }
@@ -69,25 +78,39 @@ extension TransactionConfirmationViewModel {
         }
 
         private func buildHeaderViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(
-                    isOpened: openedSections.contains(section),
-                    section: section,
-                    shouldHideChevron: true)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: openedSections.contains(section),
+                section: section,
+                shouldHideChevron: true)
 
             let headerName = sections[section].title
             switch sections[section] {
             case .network:
-                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, configuration: configuration)
+                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, viewState: viewState)
             case .gas:
                 if let warning = configurator.gasPriceWarning {
-                    return .init(title: .warning(warning.shortTitle), headerName: headerName, configuration: configuration)
+                    return .init(title: .warning(warning.shortTitle), headerName: headerName, viewState: viewState)
                 } else {
-                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, configuration: configuration)
+                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, viewState: viewState)
                 }
             case .amount:
-                return .init(title: .normal(formattedAmountValue), headerName: headerName, configuration: configuration)
+                return .init(title: .normal(formattedAmountValue), headerName: headerName, viewState: viewState)
             case .numberOfTokens:
-                return .init(title: .normal(String(numberOfTokens)), headerName: headerName, configuration: configuration)
+                return .init(title: .normal(String(numberOfTokens)), headerName: headerName, viewState: viewState)
+            }
+        }
+
+        private var formattedAmountValue: String {
+            //NOTE: what actual token can be here? or its always native crypto, need to firegu out right `decimals` value, better to pass here actual NSDecimalNumber value
+            let amountToSend = (Decimal(bigUInt: price, decimals: session.server.decimals) ?? .zero).doubleValue
+            let amount = NumberFormatter.shortCrypto.string(double: amountToSend) ?? "-"
+
+            if let rate = etherCurrencyRate.value {
+                let amountInFiat = NumberFormatter.fiat(currency: rate.currency).string(double: amountToSend * rate.value) ?? "-"
+
+                return "\(amount) \(session.server.symbol) ≈ \(amountInFiat)"
+            } else {
+                return "\(amount) \(session.server.symbol)"
             }
         }
     }

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/SpeedupTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/SpeedupTransactionViewModel.swift
@@ -8,38 +8,59 @@
 import Foundation
 import BigInt
 import AlphaWalletFoundation
+import Combine
 
 extension TransactionConfirmationViewModel {
-    class SpeedupTransactionViewModel: ExpandableSection, RateUpdatable, BalanceUpdatable {
+    class SpeedupTransactionViewModel: TransactionConfirmationViewModelType {
+        @Published private var etherCurrencyRate: Loadable<CurrencyRate, Error> = .loading
+
         private let configurator: TransactionConfigurator
         private let session: WalletSession
-        
-        var rate: CurrencyRate?
+        private let tokensService: TokenViewModelState
+        private var cancellable = Set<AnyCancellable>()
+        private var sections: [Section] { [.gas, .network, .description] }
+
+        let confirmButtonViewModel: ConfirmButtonViewModel
         var openedSections = Set<Int>()
 
-        var sections: [Section] {
-            [.gas, .network, .description]
-        }
-
-        init(configurator: TransactionConfigurator) {
+        init(configurator: TransactionConfigurator, tokensService: TokenViewModelState) {
             self.configurator = configurator
+            self.tokensService = tokensService
             self.session = configurator.session
+            self.confirmButtonViewModel = ConfirmButtonViewModel(
+                configurator: configurator,
+                title: R.string.localizable.activitySpeedup())
         }
 
-        func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-            //no-op
+        func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
+            let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: configurator.session.server)
+            tokensService.tokenViewModelPublisher(for: etherToken)
+                .map { $0?.balance.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) } }
+                .map { $0.flatMap { Loadable<CurrencyRate, Error>.done($0) } ?? .failure(SendFungiblesTransactionViewModel.NoCurrencyRateError()) }
+                .assign(to: \.etherCurrencyRate, on: self)
+                .store(in: &cancellable)
+
+            let viewState = Publishers.Merge($etherCurrencyRate.mapToVoid(), configurator.objectChanges)
+                .map { _ in
+                    TransactionConfirmationViewModel.ViewState(
+                        title: R.string.localizable.tokenTransactionSpeedupConfirmationTitle(),
+                        views: self.buildTypedViews(),
+                        isSeparatorHidden: true)
+                }
+
+            return TransactionConfirmationViewModelOutput(viewState: viewState.eraseToAnyPublisher())
         }
 
         func shouldShowChildren(for section: Int, index: Int) -> Bool {
             return true
         }
 
-        func generateViews() -> [ViewType] {
+        private func buildTypedViews() -> [ViewType] {
             var views: [ViewType] = []
             for (sectionIndex, section) in sections.enumerated() {
                 switch section {
                 case .gas:
-                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: configurator.session.server.canUserChangeGas)]
+                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: session.server.canUserChangeGas)]
                 case .description:
                     let vm = TransactionRowDescriptionTableViewCellViewModel(title: section.title)
                     views += [.details(viewModel: vm)]
@@ -51,20 +72,25 @@ extension TransactionConfirmationViewModel {
         }
 
         private func buildHeaderViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(isOpened: openedSections.contains(section), section: section, shouldHideChevron: !sections[section].isExpandable)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: openedSections.contains(section),
+                section: section,
+                shouldHideChevron: !sections[section].isExpandable)
+
             let headerName = sections[section].title
+            
             switch sections[section] {
             case .gas:
-                let gasFee = gasFeeString(for: configurator, rate: rate)
+                let gasFee = gasFeeString(for: configurator, rate: etherCurrencyRate.value)
                 if let warning = configurator.gasPriceWarning {
-                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, viewState: viewState)
                 } else {
-                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, viewState: viewState)
                 }
             case .network:
-                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, configuration: configuration)
+                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, viewState: viewState)
             case .description:
-                return .init(title: .normal(sections[section].title), headerName: nil, configuration: configuration)
+                return .init(title: .normal(sections[section].title), headerName: nil, viewState: viewState)
             }
         }
     }

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/SwapTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/SwapTransactionViewModel.swift
@@ -8,28 +8,31 @@
 import Foundation
 import BigInt
 import AlphaWalletFoundation
+import Combine
 
 extension TransactionConfirmationViewModel {
-    class SwapTransactionViewModel: ExpandableSection, RateUpdatable, BalanceUpdatable {
+    class SwapTransactionViewModel: TransactionConfirmationViewModelType {
+        @Published private var etherCurrencyRate: Loadable<CurrencyRate, Error> = .loading
+
         private let configurator: TransactionConfigurator
         private let fromToken: TokenToSwap
         private let fromAmount: BigUInt
         private let toToken: TokenToSwap
         private let toAmount: BigUInt
         private let session: WalletSession
+        private let tokensService: TokenViewModelState
+        private var cancellable = Set<AnyCancellable>()
+        private var sections: [Section] { [.network, .gas, .from, .to] }
 
-        var rate: CurrencyRate?
+        let confirmButtonViewModel: ConfirmButtonViewModel
         var openedSections = Set<Int>()
-
-        var sections: [Section] {
-            [.network, .gas, .from, .to]
-        }
 
         init(configurator: TransactionConfigurator,
              fromToken: TokenToSwap,
              fromAmount: BigUInt,
              toToken: TokenToSwap,
-             toAmount: BigUInt) {
+             toAmount: BigUInt,
+             tokensService: TokenViewModelState) {
             
             self.configurator = configurator
             self.fromToken = fromToken
@@ -37,18 +40,41 @@ extension TransactionConfirmationViewModel {
             self.toToken = toToken
             self.toAmount = toAmount
             self.session = configurator.session
+            self.tokensService = tokensService
+            self.confirmButtonViewModel = ConfirmButtonViewModel(
+                configurator: configurator,
+                title: R.string.localizable.confirmPaymentConfirmButtonTitle())
+        }
+
+        func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
+            let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: configurator.session.server)
+            tokensService.tokenViewModelPublisher(for: etherToken)
+                .map { $0?.balance.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) } }
+                .map { $0.flatMap { Loadable<CurrencyRate, Error>.done($0) } ?? .failure(SendFungiblesTransactionViewModel.NoCurrencyRateError()) }
+                .assign(to: \.etherCurrencyRate, on: self)
+                .store(in: &cancellable)
+
+            let viewState = Publishers.Merge($etherCurrencyRate.mapToVoid(), configurator.objectChanges)
+                .map { _ in
+                    TransactionConfirmationViewModel.ViewState(
+                        title: R.string.localizable.tokenTransactionConfirmationTitle(),
+                        views: self.buildTypedViews(),
+                        isSeparatorHidden: true)
+                }
+
+            return TransactionConfirmationViewModelOutput(viewState: viewState.eraseToAnyPublisher())
         }
 
         func shouldShowChildren(for section: Int, index: Int) -> Bool {
             return true
         }
 
-        func generateViews() -> [ViewType] {
+        private func buildTypedViews() -> [ViewType] {
             var views: [ViewType] = []
             for (sectionIndex, section) in sections.enumerated() {
                 switch section {
                 case .gas:
-                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: configurator.session.server.canUserChangeGas)]
+                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: session.server.canUserChangeGas)]
                 case .network, .from, .to:
                     views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: false)]
                 }
@@ -57,33 +83,34 @@ extension TransactionConfirmationViewModel {
         }
 
         private func buildHeaderViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
-            let configuration: TransactionConfirmationHeaderView.Configuration = .init(isOpened: openedSections.contains(section), section: section, shouldHideChevron: !sections[section].isExpandable)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: openedSections.contains(section),
+                section: section,
+                shouldHideChevron: !sections[section].isExpandable)
+
             let headerName = sections[section].title
+
             switch sections[section] {
             case .gas:
-                let gasFee = gasFeeString(for: configurator, rate: rate)
+                let gasFee = gasFeeString(for: configurator, rate: etherCurrencyRate.value)
                 if let warning = configurator.gasPriceWarning {
-                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, viewState: viewState)
                 } else {
-                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, viewState: viewState)
                 }
             case .from:
                 let doubleAmount = (Decimal(bigInt: BigInt(fromAmount), decimals: fromToken.decimals) ?? .zero).doubleValue
                 let amount = NumberFormatter.shortCrypto.string(double: doubleAmount, minimumFractionDigits: 4, maximumFractionDigits: 8)
 
-                return .init(title: .normal("\(amount) \(fromToken.symbol)"), headerName: headerName, configuration: configuration)
+                return .init(title: .normal("\(amount) \(fromToken.symbol)"), headerName: headerName, viewState: viewState)
             case .to:
                 let doubleAmount = (Decimal(bigInt: BigInt(toAmount), decimals: toToken.decimals) ?? .zero).doubleValue
                 let amount = NumberFormatter.shortCrypto.string(double: doubleAmount, minimumFractionDigits: 4, maximumFractionDigits: 8)
 
-                return .init(title: .normal("\(amount) \(toToken.symbol)"), headerName: headerName, configuration: configuration)
+                return .init(title: .normal("\(amount) \(toToken.symbol)"), headerName: headerName, viewState: viewState)
             case .network:
-                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, configuration: configuration)
+                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, viewState: viewState)
             }
-        }
-
-        func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-            //no-op
         }
     }
 }

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/TokenScriptTransactionViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmation/TokenScriptTransactionViewModel.swift
@@ -8,57 +8,82 @@
 import UIKit
 import BigInt
 import AlphaWalletFoundation
+import Combine
 
 extension TransactionConfirmationViewModel {
-    class TokenScriptTransactionViewModel: ExpandableSection, RateUpdatable, BalanceUpdatable {
+    class TokenScriptTransactionViewModel: TransactionConfirmationViewModelType {
+        @Published private var etherCurrencyRate: Loadable<CurrencyRate, Error> = .loading
+
+        private let tokensService: TokenViewModelState
         private let address: AlphaWallet.Address
         private let configurator: TransactionConfigurator
         private let session: WalletSession
-        private var formattedAmountValue: String {
-            //FIXME: is here ether token?
-            let amountToSend = (Decimal(bigUInt: configurator.transaction.value, decimals: configurator.session.server.decimals) ?? .zero).doubleValue
-            let amount = NumberFormatter.shortCrypto.string(double: amountToSend) ?? "-"
+        private var cancellable = Set<AnyCancellable>()
+        private let functionCallMetaData: DecodedFunctionCall
+        private var sections: [Section] { Section.allCases }
 
-            if let rate = rate {
-                let amountInFiat = NumberFormatter.fiat(currency: rate.currency).string(double: amountToSend * rate.value) ?? "-"
-
-                return "\(amount) \(configurator.session.server.symbol) ≈ \(amountInFiat)"
-            } else {
-                return "\(amount) \(configurator.session.server.symbol)"
-            }
-        }
-
-        var rate: CurrencyRate?
-        let functionCallMetaData: DecodedFunctionCall
         var openedSections = Set<Int>()
-        var sections: [Section] {
-            return Section.allCases
-        }
+        let confirmButtonViewModel: ConfirmButtonViewModel
 
         init(address: AlphaWallet.Address,
              configurator: TransactionConfigurator,
-             functionCallMetaData: DecodedFunctionCall) {
-            
+             functionCallMetaData: DecodedFunctionCall,
+             tokensService: TokenViewModelState) {
+
+            self.tokensService = tokensService
             self.address = address
             self.configurator = configurator
             self.functionCallMetaData = functionCallMetaData
             self.session = configurator.session
-        }
-
-        func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-            //no-op
+            self.confirmButtonViewModel = ConfirmButtonViewModel(
+                configurator: configurator,
+                title: R.string.localizable.confirmPaymentConfirmButtonTitle())
         }
 
         func shouldShowChildren(for section: Int, index: Int) -> Bool {
             return true
         }
 
-        func generateViews() -> [ViewType] {
+        func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
+            let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: session.server)
+            tokensService.tokenViewModelPublisher(for: etherToken)
+                .map { $0?.balance.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) } }
+                .map { $0.flatMap { Loadable<CurrencyRate, Error>.done($0) } ?? .failure(SendFungiblesTransactionViewModel.NoCurrencyRateError()) }
+                .assign(to: \.etherCurrencyRate, on: self)
+                .store(in: &cancellable)
+
+            let viewState = Publishers.Merge($etherCurrencyRate.mapToVoid(), configurator.objectChanges)
+                .map { _ in
+                    TransactionConfirmationViewModel.ViewState(
+                        title: R.string.localizable.tokenTransactionConfirmationTitle(),
+                        views: self.buildTypedViews(),
+                        isSeparatorHidden: false)
+                }
+
+            return TransactionConfirmationViewModelOutput(
+                viewState: viewState.eraseToAnyPublisher())
+        }
+
+        private var formattedAmountValue: String {
+            //FIXME: is here ether token?
+            let amountToSend = (Decimal(bigUInt: configurator.transaction.value, decimals: session.server.decimals) ?? .zero).doubleValue
+            let amount = NumberFormatter.shortCrypto.string(double: amountToSend) ?? "-"
+
+            if let rate = etherCurrencyRate.value {
+                let amountInFiat = NumberFormatter.fiat(currency: rate.currency).string(double: amountToSend * rate.value) ?? "-"
+
+                return "\(amount) \(session.server.symbol) ≈ \(amountInFiat)"
+            } else {
+                return "\(amount) \(session.server.symbol)"
+            }
+        }
+
+        private func buildTypedViews() -> [ViewType] {
             var views: [ViewType] = []
             for (sectionIndex, section) in sections.enumerated() {
                 switch section {
                 case .gas:
-                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: configurator.session.server.canUserChangeGas)]
+                    views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: session.server.canUserChangeGas)]
                 case .function:
                     views += [.header(viewModel: buildHeaderViewModel(section: sectionIndex), isEditEnabled: false)]
 
@@ -79,24 +104,29 @@ extension TransactionConfirmationViewModel {
         }
 
         private func buildHeaderViewModel(section: Int) -> TransactionConfirmationHeaderViewModel {
-            let configuration = TransactionConfirmationHeaderView.Configuration(isOpened: openedSections.contains(section), section: section, shouldHideChevron: sections[section] != .function)
+            let viewState = TransactionConfirmationHeaderViewModel.ViewState(
+                isOpened: openedSections.contains(section),
+                section: section,
+                shouldHideChevron: sections[section] != .function)
+
             let headerName = sections[section].title
+
             switch sections[section] {
             case .gas:
-                let gasFee = gasFeeString(for: configurator, rate: rate)
+                let gasFee = gasFeeString(for: configurator, rate: etherCurrencyRate.value)
                 if let warning = configurator.gasPriceWarning {
-                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .warning(warning.shortTitle), headerName: headerName, details: gasFee, viewState: viewState)
                 } else {
-                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, configuration: configuration)
+                    return .init(title: .normal(configurator.selectedConfigurationType.title), headerName: headerName, details: gasFee, viewState: viewState)
                 }
             case .contract:
-                return .init(title: .normal(address.truncateMiddle), headerName: headerName, configuration: configuration)
+                return .init(title: .normal(address.truncateMiddle), headerName: headerName, viewState: viewState)
             case .function:
-                return .init(title: .normal(functionCallMetaData.name), headerName: headerName, configuration: configuration)
+                return .init(title: .normal(functionCallMetaData.name), headerName: headerName, viewState: viewState)
             case .amount:
-                return .init(title: .normal(formattedAmountValue), headerName: headerName, configuration: configuration)
+                return .init(title: .normal(formattedAmountValue), headerName: headerName, viewState: viewState)
             case .network:
-                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, configuration: configuration)
+                return .init(title: .normal(session.server.displayName), headerName: headerName, titleIcon: session.server.walletConnectIconImage, viewState: viewState)
             }
         }
 

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationTableHeaderViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationTableHeaderViewModel.swift
@@ -10,26 +10,21 @@ import AlphaWalletFoundation
 import Combine
 
 struct TransactionConfirmationHeaderViewModel {
-    enum Title {
-        case normal(String?)
-        case warning(String)
-    }
-
     let title: String?
     let headerName: String?
     let details: String?
-    var configuration: TransactionConfirmationHeaderView.Configuration
+    var viewState: ViewState
     let titleIcon: ImagePublisher
     var chevronImage: UIImage? {
-        let image = configuration.isOpened ? R.image.expand() : R.image.not_expand()
+        let image = viewState.isOpened ? R.image.expand() : R.image.not_expand()
         return image?.withRenderingMode(.alwaysTemplate)
     }
 
     var titleAlpha: CGFloat {
-        if configuration.shouldHideChevron {
+        if viewState.shouldHideChevron {
             return 1.0
         } else {
-            return configuration.isOpened ? 0.0 : 1.0
+            return viewState.isOpened ? 0.0 : 1.0
         }
     }
 
@@ -60,26 +55,35 @@ struct TransactionConfirmationHeaderViewModel {
         ])
     }
 
-    var backgroundColor: UIColor {
-        return Configuration.Color.Semantic.defaultViewBackground
-    }
-
     init(title: Title,
          headerName: String?,
          details: String? = nil,
          titleIcon: ImagePublisher = .just(nil),
-         configuration: TransactionConfirmationHeaderView.Configuration) {
-        
+         viewState: TransactionConfirmationHeaderViewModel.ViewState) {
+
         switch title {
         case .normal(let title):
             self.title = title
             self.titleIcon = titleIcon
         case .warning(let title):
             self.title = title
-            self.titleIcon = .just(R.image.gasWarning())
+            self.titleIcon = .just(R.image.gasWarning().flatMap { ImageOrWebImageUrl<Image>.image($0) })
         }
         self.headerName = headerName
         self.details = details
-        self.configuration = configuration
+        self.viewState = viewState
+    }
+}
+
+extension TransactionConfirmationHeaderViewModel {
+    struct ViewState {
+        var isOpened: Bool = false
+        let section: Int
+        var shouldHideChevron: Bool = true
+    }
+
+    enum Title {
+        case normal(String?)
+        case warning(String)
     }
 }

--- a/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/TransactionConfirmationViewModel.swift
@@ -5,14 +5,6 @@ import BigInt
 import Combine
 import AlphaWalletFoundation
 
-protocol RateUpdatable: AnyObject {
-    var rate: CurrencyRate? { get set }
-}
-
-protocol BalanceUpdatable: AnyObject {
-    func updateBalance(_ balanceViewModel: BalanceViewModel?)
-}
-
 struct TransactionConfirmationViewModelInput {
 
 }
@@ -21,235 +13,80 @@ struct TransactionConfirmationViewModelOutput {
     let viewState: AnyPublisher<TransactionConfirmationViewModel.ViewState, Never>
 }
 
-class TransactionConfirmationViewModel {
-    private let configurationHasChangedSubject = PassthroughSubject<Void, Never>()
-    private let reloadViewSubject = PassthroughSubject<Void, Never>()
-    private let recipientResolver: RecipientResolver
-    private let configurator: TransactionConfigurator
-    private (set) var canBeConfirmed = true
-    private var timerToReenableConfirmButton: Timer?
-    private let type: ViewModelType
-    private let tokensService: TokenViewModelState
+protocol TransactionConfirmationViewModelType: ExpandableSection {
+    var confirmButtonViewModel: ConfirmButtonViewModel { get }
+    
+    func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput
+    func shouldShowChildren(for section: Int, index: Int) -> Bool
+}
 
-    init(configurator: TransactionConfigurator,
-         configuration: TransactionType.Configuration,
-         domainResolutionService: DomainResolutionServiceType,
-         tokensService: TokenViewModelState) {
+struct TransactionConfirmationViewModel {
 
-        self.tokensService = tokensService
+    static func buildViewModel(configurator: TransactionConfigurator,
+                               configuration: TransactionType.Configuration,
+                               domainResolutionService: DomainResolutionServiceType,
+                               tokensService: TokenViewModelState) -> TransactionConfirmationViewModelType {
+
         let recipientOrContract = configurator.transaction.recipient ?? configurator.transaction.contract
-        recipientResolver = RecipientResolver(address: recipientOrContract, domainResolutionService: domainResolutionService)
-        self.configurator = configurator
-
+        let recipientResolver = RecipientResolver(address: recipientOrContract, domainResolutionService: domainResolutionService)
         switch configuration {
         case .tokenScriptTransaction(_, let contract, let functionCallMetaData):
-            type = .tokenScriptTransaction(.init(address: contract, configurator: configurator, functionCallMetaData: functionCallMetaData))
+            return TokenScriptTransactionViewModel(
+                address: contract,
+                configurator: configurator,
+                functionCallMetaData: functionCallMetaData,
+                tokensService: tokensService)
         case .dappTransaction:
-            type = .dappOrWalletConnectTransaction(.init(configurator: configurator, recipientResolver: recipientResolver, requester: nil))
+            return DappOrWalletConnectTransactionViewModel(
+                configurator: configurator,
+                recipientResolver: recipientResolver,
+                requester: nil,
+                tokensService: tokensService)
         case .walletConnect(_, let requester):
-            type = .dappOrWalletConnectTransaction(.init(configurator: configurator, recipientResolver: recipientResolver, requester: requester))
+            return DappOrWalletConnectTransactionViewModel(
+                configurator: configurator,
+                recipientResolver: recipientResolver,
+                requester: requester,
+                tokensService: tokensService)
         case .sendFungiblesTransaction:
-            type = .sendFungiblesTransaction(.init(configurator: configurator, recipientResolver: recipientResolver))
+            return SendFungiblesTransactionViewModel(
+                configurator: configurator,
+                recipientResolver: recipientResolver,
+                tokensService: tokensService)
         case .sendNftTransaction:
-            type = .sendNftTransaction(.init(configurator: configurator, recipientResolver: recipientResolver))
+            return SendNftTransactionViewModel(
+                configurator: configurator,
+                recipientResolver: recipientResolver,
+                tokensService: tokensService)
         case .claimPaidErc875MagicLink(_, let price, let numberOfTokens):
-            type = .claimPaidErc875MagicLink(.init(configurator: configurator, price: price, numberOfTokens: numberOfTokens))
+            return ClaimPaidErc875MagicLinkViewModel(
+                configurator: configurator,
+                price: price,
+                numberOfTokens: numberOfTokens,
+                tokensService: tokensService)
         case .speedupTransaction:
-            type = .speedupTransaction(.init(configurator: configurator))
+            return SpeedupTransactionViewModel(
+                configurator: configurator,
+                tokensService: tokensService)
         case .cancelTransaction:
-            type = .cancelTransaction(.init(configurator: configurator))
+            return CancelTransactionViewModel(
+                configurator: configurator,
+                tokensService: tokensService)
         case .swapTransaction(let fromToken, let fromAmount, let toToken, let toAmount):
-            type = .swapTransaction(.init(configurator: configurator, fromToken: fromToken, fromAmount: fromAmount, toToken: toToken, toAmount: toAmount))
+            return SwapTransactionViewModel(
+                configurator: configurator,
+                fromToken: fromToken,
+                fromAmount: fromAmount,
+                toToken: toToken,
+                toAmount: toAmount,
+                tokensService: tokensService)
         case .approve:
             //TODO rename `.dappOrWalletConnectTransaction` so it's more general?
-            type = .dappOrWalletConnectTransaction(.init(configurator: configurator, recipientResolver: recipientResolver, requester: nil))
-        }
-    }
-
-    private lazy var resolvedRecipient: AnyPublisher<Void, Never> = {
-        return recipientResolver.resolveRecipient()
-            .receive(on: RunLoop.main)
-            .eraseToAnyPublisher()
-    }()
-
-    private lazy var tokenBalance: AnyPublisher<BalanceViewModel?, Never> = {
-        //NOTE: isn't really correctly to handle this case, need to update it
-        let forceTriggerUpdateBalance = configurationHasChangedSubject
-            .flatMap { [configurator] _ -> AnyPublisher<Token, Never> in
-                return .just(configurator.transaction.transactionType.tokenObject)
-            }.map { [tokensService] token -> TokenViewModel? in
-                switch token.type {
-                case .nativeCryptocurrency:
-                    let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: token.server)
-                    return tokensService.tokenViewModel(for: etherToken)
-                case .erc20, .erc1155, .erc721, .erc875, .erc721ForTickets:
-                    return tokensService.tokenViewModel(for: token)
-                }
-            }.map { $0?.balance }
-
-        let tokenBalance = Just(configurator.transaction.transactionType.tokenObject)
-            .flatMap { [tokensService] token -> AnyPublisher<TokenViewModel?, Never> in
-                switch token.type {
-                case .nativeCryptocurrency:
-                    let etherToken = MultipleChainsTokensDataStore.functional.etherToken(forServer: token.server)
-                    return tokensService.tokenViewModelPublisher(for: etherToken)
-                case .erc20, .erc1155, .erc721, .erc875, .erc721ForTickets:
-                    return tokensService.tokenViewModelPublisher(for: token)
-                }
-            }.map { $0?.balance }
-
-        return Publishers.Merge(tokenBalance, forceTriggerUpdateBalance)
-            .handleEvents(receiveOutput: { [weak self] balance in
-                self?.rateUpdatable.rate = balance?.ticker.flatMap { CurrencyRate(currency: $0.currency, value: $0.price_usd) }
-                self?.updateBalance(balance)
-            }).eraseToAnyPublisher()
-    }()
-
-    /// Method called when configuration has changes and we need to recalculate new balance value
-    func updateBalance() {
-        configurationHasChangedSubject.send(())
-    }
-
-    func reloadView() {
-        reloadViewSubject.send(())
-    }
-
-    func reloadViewWithGasChanges() {
-        reloadViewSubject.send(())
-        disableConfirmButtonForShortTime()
-    }
-
-    func transform(input: TransactionConfirmationViewModelInput) -> TransactionConfirmationViewModelOutput {
-        let views = Publishers.Merge4(Just<Void>(()), tokenBalance.mapToVoid(), resolvedRecipient, reloadViewSubject)
-            .map { _ in self.generateViews() }
-
-        let viewState = views.map { TransactionConfirmationViewModel.ViewState(title: self.title, views: $0) }
-            .eraseToAnyPublisher()
-
-        return .init(viewState: viewState)
-    }
-
-    func shouldShowChildren(for section: Int, index: Int) -> Bool {
-        switch type {
-        case .dappOrWalletConnectTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .tokenScriptTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .sendFungiblesTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .sendNftTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .claimPaidErc875MagicLink(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .speedupTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .cancelTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        case .swapTransaction(let viewModel):
-            return viewModel.shouldShowChildren(for: section, index: index)
-        }
-    }
-
-    var rateUpdatable: RateUpdatable {
-        switch type {
-        case .dappOrWalletConnectTransaction(let viewModel): return viewModel
-        case .tokenScriptTransaction(let viewModel): return viewModel
-        case .sendFungiblesTransaction(let viewModel): return viewModel
-        case .sendNftTransaction(let viewModel): return viewModel
-        case .claimPaidErc875MagicLink(let viewModel): return viewModel
-        case .speedupTransaction(let viewModel): return viewModel
-        case .cancelTransaction(let viewModel): return viewModel
-        case .swapTransaction(let viewModel): return viewModel
-        }
-    }
-
-    func expandOrCollapseAction(for section: Int) -> ExpandOrCollapseAction {
-        switch type {
-        case .dappOrWalletConnectTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .tokenScriptTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .sendFungiblesTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .sendNftTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .claimPaidErc875MagicLink(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .speedupTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .cancelTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        case .swapTransaction(let viewModel):
-            return viewModel.expandOrCollapseAction(for: section)
-        }
-    }
-
-    var title: String {
-        switch type {
-        case .sendFungiblesTransaction, .sendNftTransaction:
-            return R.string.localizable.tokenTransactionTransferConfirmationTitle()
-        case .dappOrWalletConnectTransaction, .tokenScriptTransaction:
-            return R.string.localizable.tokenTransactionConfirmationTitle()
-        case .claimPaidErc875MagicLink:
-            return R.string.localizable.tokenTransactionPurchaseConfirmationTitle()
-        case .speedupTransaction:
-            return R.string.localizable.tokenTransactionSpeedupConfirmationTitle()
-        case .cancelTransaction:
-            return R.string.localizable.tokenTransactionSpeedupConfirmationTitle()
-        case .swapTransaction:
-            return R.string.localizable.tokenTransactionConfirmationTitle()
-        }
-    }
-
-    var confirmationButtonTitle: String {
-        switch type {
-        case .dappOrWalletConnectTransaction, .tokenScriptTransaction, .sendFungiblesTransaction, .sendNftTransaction, .claimPaidErc875MagicLink:
-            return R.string.localizable.confirmPaymentConfirmButtonTitle()
-        case .speedupTransaction:
-            return R.string.localizable.activitySpeedup()
-        case .cancelTransaction:
-            return R.string.localizable.tokenTransactionCancelConfirmationTitle()
-        case .swapTransaction:
-            return R.string.localizable.confirmPaymentConfirmButtonTitle()
-        }
-    }
-
-    var hasSeparatorAboveConfirmButton: Bool {
-        switch type {
-        case .sendFungiblesTransaction, .sendNftTransaction, .dappOrWalletConnectTransaction, .tokenScriptTransaction, .claimPaidErc875MagicLink:
-            return true
-        case .speedupTransaction, .cancelTransaction, .swapTransaction:
-            return false
-        }
-    }
-
-    private func disableConfirmButtonForShortTime() {
-        timerToReenableConfirmButton?.invalidate()
-        let gap = TimeInterval(0.3)
-        canBeConfirmed = false
-        timerToReenableConfirmButton = Timer.scheduledTimer(withTimeInterval: gap, repeats: false) { [weak self] _ in
-            self?.canBeConfirmed = true
-        }
-    }
-
-    private func updateBalance(_ balanceViewModel: BalanceViewModel?) {
-        switch type {
-        case .dappOrWalletConnectTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .tokenScriptTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .sendFungiblesTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .sendNftTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .claimPaidErc875MagicLink(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .speedupTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .cancelTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
-        case .swapTransaction(let viewModel):
-            viewModel.updateBalance(balanceViewModel)
+            return DappOrWalletConnectTransactionViewModel(
+                configurator: configurator,
+                recipientResolver: recipientResolver,
+                requester: nil,
+                tokensService: tokensService)
         }
     }
 }
@@ -259,12 +96,14 @@ extension TransactionConfirmationViewModel {
     struct ViewState {
         let title: String
         let views: [ViewType]
+        let isSeparatorHidden: Bool
     }
 
     enum ViewType {
         case separator(height: CGFloat)
         case details(viewModel: TransactionRowDescriptionTableViewCellViewModel)
         case view(viewModel: TransactionConfirmationRowInfoViewModel, isHidden: Bool)
+        case recipient(viewModel: TransactionConfirmationRecipientRowInfoViewModel, isHidden: Bool)
         case header(viewModel: TransactionConfirmationHeaderViewModel, isEditEnabled: Bool)
     }
 
@@ -277,17 +116,6 @@ extension TransactionConfirmationViewModel {
     enum ExpandOrCollapseAction {
         case expand
         case collapse
-    }
-
-    enum ViewModelType {
-        case dappOrWalletConnectTransaction(DappOrWalletConnectTransactionViewModel)
-        case tokenScriptTransaction(TokenScriptTransactionViewModel)
-        case sendFungiblesTransaction(SendFungiblesTransactionViewModel)
-        case sendNftTransaction(SendNftTransactionViewModel)
-        case claimPaidErc875MagicLink(ClaimPaidErc875MagicLinkViewModel)
-        case speedupTransaction(SpeedupTransactionViewModel)
-        case cancelTransaction(CancelTransactionViewModel)
-        case swapTransaction(SwapTransactionViewModel)
     }
 
     static func gasFeeString(for configurator: TransactionConfigurator, rate: CurrencyRate?) -> String {
@@ -309,30 +137,5 @@ extension TransactionConfirmationViewModel {
         } else {
             return "\(costs) \(estimatedProcessingTime)"
         }
-    }
-
-    private func generateViews() -> [ViewType] {
-        var views: [ViewType] = []
-
-        switch type {
-        case .dappOrWalletConnectTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .tokenScriptTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .sendFungiblesTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .sendNftTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .claimPaidErc875MagicLink(let viewModel):
-            views = viewModel.generateViews()
-        case .speedupTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .cancelTransaction(let viewModel):
-            views = viewModel.generateViews()
-        case .swapTransaction(let viewModel):
-            views = viewModel.generateViews()
-        }
-
-        return views
     }
 }

--- a/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationHeaderView.swift
@@ -16,12 +16,6 @@ protocol TransactionConfirmationHeaderViewDelegate: AnyObject {
 
 class TransactionConfirmationHeaderView: UIView {
 
-    struct Configuration {
-        var isOpened: Bool = false
-        let section: Int
-        var shouldHideChevron: Bool = true
-    }
-
     private var isTapActionEnabled = false
 
     private let nameLabel: UILabel = {
@@ -160,9 +154,9 @@ class TransactionConfirmationHeaderView: UIView {
     }
 
     func configure(viewModel: TransactionConfirmationHeaderViewModel) {
-        backgroundColor = viewModel.backgroundColor
+        backgroundColor = Configuration.Color.Semantic.defaultViewBackground
 
-        chevronView.isHidden = viewModel.configuration.shouldHideChevron
+        chevronView.isHidden = viewModel.viewState.shouldHideChevron
         chevronImageView.image = viewModel.chevronImage
 
         titleIconImageView.set(imageSource: viewModel.titleIcon)
@@ -181,22 +175,22 @@ class TransactionConfirmationHeaderView: UIView {
 
     @objc private func didTap(_ sender: UITapGestureRecognizer) {
         if isTapActionEnabled {
-            delegate?.headerView(self, tappedSection: viewModel.configuration.section)
+            delegate?.headerView(self, tappedSection: viewModel.viewState.section)
         } else {
-            viewModel.configuration.isOpened.toggle()
+            viewModel.viewState.isOpened.toggle()
 
             chevronImageView.image = viewModel.chevronImage
             titleLabel.alpha = viewModel.titleAlpha
             titleIconImageView.alpha = viewModel.titleAlpha
 
-            delegate?.headerView(self, openStateChanged: viewModel.configuration.section)
+            delegate?.headerView(self, openStateChanged: viewModel.viewState.section)
         }
     }
 
     func expand() {
         guard let delegate = delegate else { return }
 
-        for (index, view) in childrenStackView.arrangedSubviews.enumerated() where delegate.headerView(self, shouldShowChildren: viewModel.configuration.section, index: index) {
+        for (index, view) in childrenStackView.arrangedSubviews.enumerated() where delegate.headerView(self, shouldShowChildren: viewModel.viewState.section, index: index) {
             view.isHidden = false
         }
     }
@@ -204,7 +198,7 @@ class TransactionConfirmationHeaderView: UIView {
     func collapse() {
         guard let delegate = delegate else { return }
 
-        for (index, view) in childrenStackView.arrangedSubviews.enumerated() where delegate.headerView(self, shouldHideChildren: viewModel.configuration.section, index: index) {
+        for (index, view) in childrenStackView.arrangedSubviews.enumerated() where delegate.headerView(self, shouldHideChildren: viewModel.viewState.section, index: index) {
             view.isHidden = true
         }
     }

--- a/AlphaWallet/Transfer/Views/TransactionConfirmationRowDescriptionView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationRowDescriptionView.swift
@@ -19,7 +19,11 @@ class TransactionConfirmationRowDescriptionView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
 
         let separatorLine = UIView.separator()
-        let row1 = [.spacerWidth(DataEntry.Metric.TransactionConfirmation.transactionRowInfoInsets.left), titleLabel, .spacerWidth(DataEntry.Metric.TransactionConfirmation.transactionRowInfoInsets.right)].asStackView(axis: .horizontal)
+        let row1 = [
+            .spacerWidth(DataEntry.Metric.TransactionConfirmation.transactionRowInfoInsets.left),
+            titleLabel,
+            .spacerWidth(DataEntry.Metric.TransactionConfirmation.transactionRowInfoInsets.right)
+        ].asStackView(axis: .horizontal)
 
         let stackView = [
             separatorLine,

--- a/AlphaWallet/Transfer/Views/TransactionConfirmationRowInfoView.swift
+++ b/AlphaWallet/Transfer/Views/TransactionConfirmationRowInfoView.swift
@@ -37,7 +37,7 @@ class TransactionConfirmationRowInfoView: UIView {
 
         let stackView = [
             titleLabel,
-            subTitleLabel,
+            subTitleLabel
         ].asStackView(axis: .vertical)
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -67,4 +67,74 @@ struct TransactionConfirmationRowInfoViewModel {
     let title: String
     let subtitle: String?
     var isSubtitleHidden: Bool { subtitle?.trimmed.isEmpty ?? true }
+}
+
+class TransactionConfirmationRecipientRowInfoView: UIView {
+
+    private let titleLabel: UILabel = {
+        let titleLabel = UILabel(frame: .zero)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = Fonts.regular(size: ScreenChecker().isNarrowScreen ? 16 : 18)
+        titleLabel.textAlignment = .left
+        titleLabel.textColor = Configuration.Color.Semantic.defaultSubtitleText
+
+        return titleLabel
+    }()
+
+    private let subTitleLabel: UILabel = {
+        let subTitleLabel = UILabel(frame: .zero)
+        subTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subTitleLabel.textAlignment = .left
+        subTitleLabel.textColor = Configuration.Color.Semantic.defaultForegroundText
+        subTitleLabel.font = Fonts.regular(size: ScreenChecker().isNarrowScreen ? 13 : 15)
+        subTitleLabel.numberOfLines = 0
+
+        return subTitleLabel
+    }()
+
+    private let blockieImageView: BlockieImageView = {
+        let imageView = BlockieImageView(size: .init(width: 25, height: 25))
+        imageView.hideWhenImageIsNil = true
+
+        return imageView
+    }()
+
+    init(viewModel: TransactionConfirmationRecipientRowInfoViewModel) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let stackView = [
+            titleLabel,
+            [blockieImageView, subTitleLabel].asStackView(axis: .horizontal, spacing: 5, alignment: .leading),
+        ].asStackView(axis: .vertical)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.isLayoutMarginsRelativeArrangement = true
+
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.anchorsConstraint(to: self, edgeInsets: DataEntry.Metric.TransactionConfirmation.transactionRowInfoInsets),
+        ])
+
+        configure(viewModel: viewModel)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        return nil
+    }
+
+    private func configure(viewModel: TransactionConfirmationRecipientRowInfoViewModel) {
+        titleLabel.text = viewModel.title
+        subTitleLabel.text = viewModel.subtitle
+        subTitleLabel.isHidden = viewModel.isSubtitleHidden
+        blockieImageView.set(blockieImage: viewModel.blockieImage)
+    }
+}
+
+struct TransactionConfirmationRecipientRowInfoViewModel {
+    let title: String
+    let subtitle: String?
+    var isSubtitleHidden: Bool { subtitle?.trimmed.isEmpty ?? true }
+    var blockieImage: BlockiesImage?
 }

--- a/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
+++ b/AlphaWalletTests/Transfer/Controllers/TransactionConfiguratorTests.swift
@@ -13,7 +13,9 @@ class TransactionConfiguratorTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: .make(gasPrice: gasPrice),
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
         XCTAssertEqual(gasPrice, configurator.currentConfiguration.gasPrice)
     }
 
@@ -23,7 +25,9 @@ class TransactionConfiguratorTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: .make(gasPrice: BigUInt(1000000000)),
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
         XCTAssertEqual(GasPriceConfiguration.minPrice, configurator.currentConfiguration.gasPrice)
     }
 
@@ -33,7 +37,9 @@ class TransactionConfiguratorTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: .make(gasPrice: BigUInt(990000000000)),
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
         XCTAssertEqual(GasPriceConfiguration.maxPrice, configurator.currentConfiguration.gasPrice)
     }
 
@@ -43,7 +49,9 @@ class TransactionConfiguratorTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: .make(gasLimit: nil, gasPrice: nil),
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
         XCTAssertEqual(BigUInt(GasPriceConfiguration.defaultPrice), configurator.currentConfiguration.gasPrice)
         //gas limit is always 21k for native ether transfers
         XCTAssertEqual(BigUInt(21000), configurator.currentConfiguration.gasLimit)

--- a/AlphaWalletTests/Transfer/TransactionConfiguratorTransactionsTests.swift
+++ b/AlphaWalletTests/Transfer/TransactionConfiguratorTransactionsTests.swift
@@ -23,7 +23,9 @@ class TransactionConfiguratorTransactionsTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: transaction,
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
 
         XCTAssertEqual(configurator.toAddress, address)
     }
@@ -40,7 +42,9 @@ class TransactionConfiguratorTransactionsTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: transaction,
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
 
         XCTAssertEqual(configurator.toAddress, address)
         XCTAssertNotEqual(configurator.toAddress, transaction.recipient)
@@ -57,7 +61,9 @@ class TransactionConfiguratorTransactionsTests: XCTestCase {
             session: .make(),
             analytics: analytics,
             transaction: transaction,
-            networkService: FakeNetworkService())
+            networkService: FakeNetworkService(),
+            tokensService: WalletDataProcessingPipeline.make(wallet: .make(), server: .main).pipeline,
+            configuration: .sendFungiblesTransaction(confirmType: .signThenSend))
 
         XCTAssertEqual(configurator.toAddress, address)
         XCTAssertNotEqual(configurator.toAddress, transaction.contract)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/Types/AddressOrEnsResolution.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/ENS/Types/AddressOrEnsResolution.swift
@@ -12,7 +12,7 @@ public enum AddressOrEnsResolution {
     case invalidInput
     case resolved(AddressOrEnsName?)
 
-    var value: String? {
+    public var value: String? {
         switch self {
         case .invalidInput:
             return nil

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/TokenImageFetcher.swift
@@ -13,11 +13,11 @@ public typealias Image = UIImage
 public typealias TokenImagePublisher = AnyPublisher<TokenImage?, Never>
 
 public struct TokenImage {
-    public let image: ImageOrWebImageUrl
+    public let image: ImageOrWebImageUrl<RawImage>
     public let isFinal: Bool
     public let overlayServerIcon: UIImage?
 
-    public init(image: ImageOrWebImageUrl, isFinal: Bool, overlayServerIcon: UIImage?) {
+    public init(image: ImageOrWebImageUrl<RawImage>, isFinal: Bool, overlayServerIcon: UIImage?) {
         self.image = image
         self.isFinal = isFinal
         self.overlayServerIcon = overlayServerIcon
@@ -225,7 +225,7 @@ public class TokenImageFetcherImpl: TokenImageFetcher {
     //TODO: refactor and rename
     private static func nftCollectionImageUrl(_ type: TokenType,
                                               balance: NonFungibleFromJson?,
-                                              size: GoogleContentSize) throws -> ImageOrWebImageUrl {
+                                              size: GoogleContentSize) throws -> ImageOrWebImageUrl<RawImage> {
 
         switch type {
         case .erc721, .erc1155:
@@ -271,7 +271,7 @@ class GithubAssetsURLResolver {
     }
 }
 
-public typealias ImagePublisher = AnyPublisher<Image?, Never>
+public typealias ImagePublisher = AnyPublisher<ImageOrWebImageUrl<Image>?, Never>
 
 public class RPCServerImageFetcher {
     public static var instance = RPCServerImageFetcher()
@@ -281,7 +281,7 @@ public class RPCServerImageFetcher {
         if let sub = subscribables[server.chainID] {
             return sub
         } else {
-            let sub = CurrentValueSubject<Image?, Never>(iconImage)
+            let sub = CurrentValueSubject<ImageOrWebImageUrl<Image>?, Never>(.image(iconImage))
             subscribables[server.chainID] = sub.eraseToAnyPublisher()
 
             return sub.eraseToAnyPublisher()

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/RecipientResolver.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transfer/Types/RecipientResolver.swift
@@ -9,6 +9,11 @@ import Foundation
 import Combine
 import CombineExt
 
+public struct RecipientViewModel {
+    public var address: AlphaWallet.Address?
+    public var ensName: String?
+}
+
 public class RecipientResolver {
     public enum Row: Int, CaseIterable {
         case address
@@ -16,10 +21,16 @@ public class RecipientResolver {
     }
 
     public let address: AlphaWallet.Address?
-    public var ensName: String?
+    private var resolution: BlockieAndAddressOrEnsResolution?
+    public var ensName: EnsName? {
+        resolution?.resolution.value
+    }
+    public var blockieImage: BlockiesImage? {
+        resolution?.image
+    }
 
     public var hasResolvedEnsName: Bool {
-        if let value = ensName {
+        if let value = resolution?.resolution.value {
             return !value.trimmed.isEmpty
         }
         return false
@@ -31,16 +42,15 @@ public class RecipientResolver {
         self.domainResolutionService = domainResolutionService
     } 
 
-    public func resolveRecipient() -> AnyPublisher<Void, Never> {
+    public func resolveRecipient() -> AnyPublisher<BlockieAndAddressOrEnsResolution?, Never> {
         guard let address = address else {
-            return .just(())
+            return .just((image: nil, resolution: .invalidInput))
         }
 
-        return domainResolutionService.resolveEns(address: address)
-            .map { ens -> EnsName? in return ens }
+        return domainResolutionService.resolveEnsAndBlockie(address: address)
+            .map { resolution -> BlockieAndAddressOrEnsResolution? in return resolution }
             .replaceError(with: nil)
-            .handleEvents(receiveOutput: { [weak self] in self?.ensName = $0 })
-            .mapToVoid()
+            .handleEvents(receiveOutput: { [weak self] in self?.resolution = $0 })
             .eraseToAnyPublisher()
     }
 

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/ImageOrWebImageUrl.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/ImageOrWebImageUrl.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-public enum ImageOrWebImageUrl {
+public enum ImageOrWebImageUrl<T> {
     case url(WebImageURL)
-    case image(RawImage)
+    case image(T)
 }
 
 public enum RawImage {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/Loadable.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/Loadable.swift
@@ -8,6 +8,28 @@ public enum Loadable<T, F> {
     case failure(F)
 }
 
+extension Loadable {
+    public var value: T? {
+        switch self {
+        case .loading, .failure:
+            return nil
+        case .done(let t):
+            return t
+        }
+    }
+
+    public func mapValue<T2>(_ block: (T) -> T2) -> Loadable<T2, F> {
+        switch self {
+        case .loading:
+            return .loading
+        case .done(let t):
+            return .done(block(t))
+        case .failure(let f):
+            return .failure(f)
+        }
+    }
+}
+
 extension Loadable: Equatable where T: Equatable, F: Equatable {
     public static func == (lhs: Loadable<T, F>, rhs: Loadable<T, F>) -> Bool {
         switch (lhs, rhs) {


### PR DESCRIPTION
RP refactors transaction confirmation view model with actual class for each transaction type without bridging to each type, remove TransactionTypeViewModel enum, updates way to handle updates, removes TransactionConfigurator delegate. Adds displaying blockie image for recipient, displaying dapp icon and name for Dapp/WalletConnect transaction type