### PR TITLE
[Sign] Fix: signing pre-EIP-1559 transactions always fails with `SignerError.rplEncodeFailure` #6655

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/RLP.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/EtherClient/RLP.swift
@@ -22,6 +22,8 @@ public struct RLP {
             return encodeBigInt(bigint)
         case let biguint as BigUInt:
             return encodeBigUInt(biguint)
+        case let number as UInt8:
+            return encodeUInt(UInt(number))
         case let data as Data:
             return encodeData(data)
         default:


### PR DESCRIPTION
Fixes: #6655

@oa-s would you help to add a test case? Maybe just need to pass some hardcoded to `EIP155Signer.rlpEncoded(transaction:, with:)` and verify output? No signing involved.