### PR TITLE
Add code that allows sorting of RPCServer enums with CustomRPC structs such that mainnets come before testnets, RPCServers come before CustomRPC, and smaller chainIds before larger ones.

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		02F4E8BE27717A1500D89C19 /* SaveCustomRpcBrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F4E8BD27717A1500D89C19 /* SaveCustomRpcBrowseViewController.swift */; };
 		02F4E8C027717A5200D89C19 /* SaveCustomRpcBrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F4E8BF27717A5200D89C19 /* SaveCustomRpcBrowseView.swift */; };
 		02F4E8C42771C07500D89C19 /* SaveCustomRpcBrowseDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F4E8C32771C07500D89C19 /* SaveCustomRpcBrowseDataController.swift */; };
+		02FB110029FA0585006538DC /* RPCServerComparableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FB10FF29FA0585006538DC /* RPCServerComparableTest.swift */; };
 		02FEA8EF280FE1B7006C3CA9 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FEA8EE280FE1B7006C3CA9 /* NSLayoutConstraintExtension.swift */; };
 		0DF46B4002E13613F768E7AE /* Pods_AlphaWalletTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E36AB2DC7832A980726A4AB1 /* Pods_AlphaWalletTests.framework */; };
 		290B2B541F8F50030053C83E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 290B2B561F8F50030053C83E /* Localizable.strings */; };
@@ -966,6 +967,7 @@
 		02F4E8BD27717A1500D89C19 /* SaveCustomRpcBrowseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveCustomRpcBrowseViewController.swift; sourceTree = "<group>"; };
 		02F4E8BF27717A5200D89C19 /* SaveCustomRpcBrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveCustomRpcBrowseView.swift; sourceTree = "<group>"; };
 		02F4E8C32771C07500D89C19 /* SaveCustomRpcBrowseDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveCustomRpcBrowseDataController.swift; sourceTree = "<group>"; };
+		02FB10FF29FA0585006538DC /* RPCServerComparableTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RPCServerComparableTest.swift; sourceTree = "<group>"; };
 		02FEA8EE280FE1B7006C3CA9 /* NSLayoutConstraintExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintExtension.swift; sourceTree = "<group>"; };
 		0B5A03D1E5E417FE79607D0F /* Pods_AlphaWallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AlphaWallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11EA2601C4D0D445D99E4B33 /* Pods_AlphaWalletShare.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AlphaWalletShare.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3193,6 +3195,7 @@
 		5E7C78E79A2C45A2124F259D /* Tokens */ = {
 			isa = PBXGroup;
 			children = (
+				02FB10FF29FA0585006538DC /* RPCServerComparableTest.swift */,
 				02D255772807E5B900B97A05 /* CachedERC1155ContractDictionaryTestCase.swift */,
 				0251BE9427ED493A00B4F328 /* TokenGroupIdentifierTest.swift */,
 				5E7C71E355BD14E975AF7491 /* TokensDataStoreTest.swift */,
@@ -5834,6 +5837,7 @@
 				29BDF1941FEE43AA0023A45F /* TransactionConfiguratorTests.swift in Sources */,
 				877581B32886E81300701808 /* FakeCoinTickersFetcher.swift in Sources */,
 				29FF13081F75F0AE00AFD326 /* AppCoordinatorTests.swift in Sources */,
+				02FB110029FA0585006538DC /* RPCServerComparableTest.swift in Sources */,
 				2923D9B71FDA5E51000CF3F8 /* PasswordGeneratorTests.swift in Sources */,
 				29F1C865200384FE003780D8 /* Wallet.swift in Sources */,
 				29FF130D1F7626E800AFD326 /* FakeNavigationController.swift in Sources */,

--- a/AlphaWallet/Extensions/RPCServer+Extensions.swift
+++ b/AlphaWallet/Extensions/RPCServer+Extensions.swift
@@ -138,3 +138,16 @@ extension RPCServer {
         }
     }
 }
+
+extension RPCServer: Comparable {
+    public static func < (lhs: RPCServer, rhs: RPCServer) -> Bool {
+        switch (lhs.isTestnet, rhs.isTestnet) {
+        case (true, false):
+            return false
+        case (false, true):
+            return true
+        default:
+            return lhs.displayOrderPriority < rhs.displayOrderPriority
+        }
+    }
+}

--- a/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
+++ b/AlphaWallet/Settings/Coordinators/ServersCoordinator.swift
@@ -11,38 +11,7 @@ protocol ServersCoordinatorDelegate: AnyObject {
 class ServersCoordinator: Coordinator {
     //Cannot be `let` as the chains can change dynamically without the app being restarted (i.e. killed). The UI can be restarted though (when switching changes)
     static var serversOrdered: [RPCServer] {
-        return [
-            .main,
-            .xDai,
-            .polygon,
-            .classic,
-            .goerli,
-            .binance_smart_chain,
-            .binance_smart_chain_testnet,
-            .callisto,
-            .heco,
-            .heco_testnet,
-            .fantom,
-            .fantom_testnet,
-            .avalanche,
-            .avalanche_testnet,
-            .mumbai_testnet,
-            .optimismGoerli,
-            .arbitrumGoerli,
-            .optimistic,
-            .cronosMainnet,
-            .cronosTestnet,
-            .arbitrum,
-            .klaytnCypress,
-            .klaytnBaobabTestnet,
-            //Need to update Covalent.NetworkProvider.isSupport() if we enable .ioTeX and/or .ioTeXTestnet
-            //.ioTeX,
-            //.ioTeXTestnet,
-            .palm,
-            .palmTestnet,
-            .okx,
-            .sepolia
-        ] + RPCServer.customServers
+        return RPCServer.availableServers.sorted()
     }
 
     let viewModel: ServersViewModel

--- a/AlphaWalletTests/Tokens/RPCServerComparableTest.swift
+++ b/AlphaWalletTests/Tokens/RPCServerComparableTest.swift
@@ -1,0 +1,35 @@
+//
+//  RPCServerComparableTest.swift
+//  AlphaWalletTests
+//
+//  Created by Jerome Chan on 25/4/23.
+//
+
+@testable import AlphaWallet
+import XCTest
+import AlphaWalletFoundation
+
+final class RPCServerComparableTest: XCTestCase {
+
+    func testRPCServerComparable() {
+        let sorted: [RPCServer] = [
+            .custom(CustomRPC.custom(chainId: 102)), // chainId 102
+            .goerli, // chainId 5 - testnet
+            .main, // chainId 1
+            .arbitrumGoerli, // chainId 421613 - testnet
+            .arbitrum, // chainId 42161
+            .binance_smart_chain_testnet, // chainId 97 - testnet
+            .binance_smart_chain, // chainId 56
+            .custom(CustomRPC.custom(chainId: 101)) // chainId 101
+        ].sorted()
+        XCTAssertTrue(sorted[0] == .main)
+        XCTAssertTrue(sorted[1] == .binance_smart_chain)
+        XCTAssertTrue(sorted[2] == .arbitrum)
+        XCTAssertTrue(sorted[3] == .custom(chainId: 101))
+        XCTAssertTrue(sorted[4] == .custom(chainId: 102))
+        XCTAssertTrue(sorted[5] == .goerli)
+        XCTAssertTrue(sorted[6] == .binance_smart_chain_testnet)
+        XCTAssertTrue(sorted[7] == .arbitrumGoerli)
+    }
+
+}


### PR DESCRIPTION
Closes #6669

Test is included.

To sort a list of RPCServers, you can just use `.sorted` to get a list of RPCServers with testnets at the end of the list.
You can use `.sorted` on CustomRPC structs too. The testnets will be at the end of the list.
You can sort a mixture of RPCServers enums and CustomRPC structs together but it's a bit more complicated. You can use the code below to sort the list of mixed data structures:
```swift
let unsorted: [isTestnetSortableEnum] = [
            a.testnetSortable,
            b.testnetSortable,
            c.testnetSortable,
            d.testnetSortable,
            e.testnetSortable,
            f.testnetSortable,
            g.testnetSortable
        ]
        let sorted: [Any] = unsorted.sorted().map { item in
            item.server
        }
```
RPCServer enums will sort before CustomRPC structs.
Mainnets will sort before testnets.
Smaller ChainIds will sort before larger ones.
