### PR TITLE
Validate token transfer transactions

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/UniqueNonEmptyContracts.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/UniqueNonEmptyContracts.swift
@@ -45,9 +45,9 @@ extension UniqueNonEmptyContracts {
             //NOTE: safe check to avoid incompatible contract matching with token type, blockout api returns erc20 and erc721 for same url, so we need to filter retults
             switch tokenType {
             case .erc20:
-                guard json["tokenID"].string == nil else { return nil }
+                guard json["tokenID"].stringValue.isEmpty && json["tokenValue"].stringValue.isEmpty else { return nil }
             case .erc721:
-                guard json["tokenID"].stringValue.nonEmpty else { return nil }
+                guard json["tokenID"].stringValue.nonEmpty && json["tokenValue"].stringValue.isEmpty else { return nil }
             case .erc1155:
                 guard json["tokenID"].stringValue.nonEmpty && json["tokenValue"].stringValue.nonEmpty else { return nil }
             }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
@@ -192,7 +192,7 @@ class BlockscoutApiNetworking: ApiNetworking {
         return transporter
             .dataTaskPublisher(request)
             .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
-            .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTransactions(json: JSON($0.data), server: server) }
+            .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
     }
@@ -209,7 +209,7 @@ class BlockscoutApiNetworking: ApiNetworking {
         return transporter
             .dataTaskPublisher(request)
             .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
-            .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTransactions(json: JSON($0.data), server: server) }
+            .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
     }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/RPCServers.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/RPCServers.swift
@@ -258,7 +258,7 @@ public enum RPCServer: Hashable, CaseIterable {
             return .blockscout(apiKey: etherscanApiKey, url: url)
         case .fantom_testnet:
             guard let url = etherscanApiRoot else { return .unknown }
-            return .blockscout(apiKey: etherscanApiKey, url: url)
+            return .etherscan(apiKey: etherscanApiKey, url: url)
         case .klaytnCypress, .klaytnBaobabTestnet:
             guard let url = etherscanApiRoot else { return .unknown }
             return .blockscout(apiKey: etherscanApiKey, url: url)


### PR DESCRIPTION
validate token transfer transaction, add filtering for only expected transaction types
e.g Blockscout api might return eip20 an eip721 token transfer transactions in same response