### PR TITLE
Update Travis to only build the main target (AlphaWallet) and the test target (AlphaWalletTests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ jobs:
   exclude:
     - env: LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8
 script:
-  - set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination platform\=iOS\ Simulator,OS\=16.0,name\=iPhone\ 14 build test | xcpretty
+  - set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination platform\=iOS\ Simulator,OS\=16.0,name\=iPhone\ 14 build-for-testing | xcpretty
 ...


### PR DESCRIPTION
Closes #6798

# Testing basic build

## Testing

In the terminal go to the root directory of the project.

1. type `set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro" clean | ./Pods/xcbeautify/xcbeautify`
2. type `set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro" build-for-testing | ./Pods/xcbeautify/xcbeautify`

## Expects 
To see the project build succeed.

# Testing Error in Tests
1. type `set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro" clean | ./Pods/xcbeautify/xcbeautify`
2. Go to a test and type in a syntax error
3. type `set -o pipefail && xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro" build-for-testing | ./Pods/xcbeautify/xcbeautify`

## Expects
To see the project build fail.

# Problems
You might need to adjust the OS version depending on which version of Xcode you have. To find a valid 16.x version of iOS, type in `xcodebuild -showdestinations -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests | grep OS:16`.
If xcbeautify is not present, you will need to run `make bootstrap`.