### PR TITLE
[Analytics] Log blockchain explorer API errors

### DIFF
--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Analytics/AnalyticsTypes.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Analytics/AnalyticsTypes.swift
@@ -116,6 +116,8 @@ public enum Analytics {
         case lifiFetchSupportedToolsError
         case lifiFetchSupportedChainsError
         case coinGeckoRateLimited
+        case blockchainExplorerRateLimited
+        case blockchainExplorerError
     }
 
     public enum Properties: String {
@@ -140,6 +142,7 @@ public enum Analytics {
         case reason
         case domainName
         case scheme
+        case code
     }
 
     public enum EmbeddedDeepLinkType: String {

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/EtherscanCompatibleApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/EtherscanCompatibleApiNetworking.swift
@@ -338,7 +338,10 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
             let json = try? JSON(response.data)
             infoLog("[API] request failure with status code: \(response.response.statusCode), json: \(json), server: \(server)", callerFunctionName: caller)
         case .success:
-            break
+            //Etherscan. Reproduce by curling without an API key a few times
+            if let json = try? JSON(response.data), json["result"].stringValue == "Max rate limit reached" {
+                infoLog("[API] request rate limited with status code: \(response.response.statusCode), json: \(json), server: \(server)", callerFunctionName: caller)
+            }
         }
     }
 }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/EtherscanCompatibleApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Tokens/Logic/EtherscanCompatibleApiNetworking.swift
@@ -50,7 +50,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -80,7 +80,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -110,7 +110,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -179,7 +179,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .mapError { PromiseError(error: $0) }
             .flatMap { [transactionBuilder] result -> AnyPublisher<TransactionsResponse, PromiseError> in
                 if result.response.statusCode == 404 {
@@ -255,7 +255,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -274,7 +274,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -292,7 +292,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -332,7 +332,7 @@ class EtherscanCompatibleApiNetworking: ApiNetworking {
             .eraseToAnyPublisher()
     }
 
-    static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
+    fileprivate static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
         switch URLRequest.validate(statusCode: 200..<300, response: response.response) {
         case .failure:
             let json = try? JSON(response.data)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
@@ -50,7 +50,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -79,7 +79,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -108,7 +108,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -177,7 +177,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
             .mapError { PromiseError(error: $0) }
             .flatMap { [transactionBuilder] result -> AnyPublisher<TransactionsResponse, PromiseError> in
                 if result.response.statusCode == 404 {
@@ -242,7 +242,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -261,7 +261,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -280,7 +280,7 @@ class BlockscoutApiNetworking: ApiNetworking {
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { EtherscanCompatibleApiNetworking.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -306,7 +306,7 @@ class BlockscoutApiNetworking: ApiNetworking {
             }.eraseToAnyPublisher()
     }
 
-    static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
+    fileprivate static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
         switch URLRequest.validate(statusCode: 200..<300, response: response.response) {
         case .failure:
             let json = try? JSON(response.data)

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/BlockscoutApiNetworking.swift
@@ -20,18 +20,15 @@ class BlockscoutApiNetworking: ApiNetworking {
     private let apiKey: String?
     private let baseUrl: URL
     private let defaultPagination = BlockBasedPagination(startBlock: nil, endBlock: nil)
+    private let analytics: AnalyticsLogger
 
-    init(server: RPCServer,
-         transporter: ApiTransporter,
-         transactionBuilder: TransactionBuilder,
-         apiKey: String?,
-         baseUrl: URL) {
-
+    init(server: RPCServer, transporter: ApiTransporter, transactionBuilder: TransactionBuilder, apiKey: String?, baseUrl: URL, analytics: AnalyticsLogger) {
         self.baseUrl = baseUrl
         self.apiKey = apiKey
         self.transactionBuilder = transactionBuilder
         self.transporter = transporter
         self.server = server
+        self.analytics = analytics
     }
 
     func erc20TokenInteractions(walletAddress: AlphaWallet.Address,
@@ -47,10 +44,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .tokentx)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -76,10 +75,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .txlist)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -105,10 +106,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .txlist)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { UniqueNonEmptyContracts(json: try JSON(data: $0.data), tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -174,10 +177,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .txlist)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .mapError { PromiseError(error: $0) }
             .flatMap { [transactionBuilder] result -> AnyPublisher<TransactionsResponse, PromiseError> in
                 if result.response.statusCode == 404 {
@@ -239,10 +244,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .tokentx)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc20) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -258,10 +265,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .tokentx)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc721) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -277,10 +286,12 @@ class BlockscoutApiNetworking: ApiNetworking {
             apiKey: apiKey,
             walletAddress: walletAddress,
             action: .tokentx)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter
             .dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { EtherscanCompatibleApiNetworking.functional.decodeTokenTransferTransactions(json: JSON($0.data), server: server, tokenType: .erc1155) }
             .mapError { PromiseError.some(error: $0) }
             .eraseToAnyPublisher()
@@ -306,11 +317,13 @@ class BlockscoutApiNetworking: ApiNetworking {
             }.eraseToAnyPublisher()
     }
 
-    fileprivate static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
+    fileprivate static func log(response: URLRequest.Response, server: RPCServer, analytics: AnalyticsLogger, domainName: String, caller: String = #function) {
         switch URLRequest.validate(statusCode: 200..<300, response: response.response) {
         case .failure:
             let json = try? JSON(response.data)
             infoLog("[API] request failure with status code: \(response.response.statusCode), json: \(json), server: \(server)", callerFunctionName: caller)
+            let properties: [String: AnalyticsEventPropertyValue] = [Analytics.Properties.chain.rawValue: server.chainID, Analytics.Properties.domainName.rawValue: domainName, Analytics.Properties.code.rawValue: response.response.statusCode]
+            analytics.log(error: Analytics.WebApiErrors.blockchainExplorerError, properties: properties)
         case .success:
             break
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Covalent/CovalentApiNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Covalent/CovalentApiNetworking.swift
@@ -17,16 +17,15 @@ public class CovalentApiNetworking: ApiNetworking {
     private let transporter: ApiTransporter
     private let paginationFilter = TransactionPageBasedPaginationFilter()
     private let defaultPagination = PageBasedTransactionsPagination(page: 0, lastFetched: [], limit: 500)
+    private let analytics: AnalyticsLogger
 
-    public init(server: RPCServer,
-                apiKey: String?,
-                transporter: ApiTransporter) {
-
+    public init(server: RPCServer, apiKey: String?, transporter: ApiTransporter, analytics: AnalyticsLogger) {
         self.server = server
         self.apiKey = apiKey
         self.transporter = transporter
+        self.analytics = analytics
     }
-    
+
     public func gasPriceEstimates() -> AnyPublisher<LegacyGasEstimates, PromiseError> {
         return .fail(PromiseError(error: ApiNetworkingError.methodNotSupported))
     }
@@ -38,7 +37,7 @@ public class CovalentApiNetworking: ApiNetworking {
         guard let pagination = (pagination ?? defaultPagination) as? PageBasedTransactionsPagination else {
             return .fail(PromiseError(error: ApiNetworkingError.paginationTypeNotSupported))
         }
-        
+
         let request = TransactionsRequest(
             baseUrl: baseUrl,
             walletAddress: walletAddress,
@@ -47,9 +46,11 @@ public class CovalentApiNetworking: ApiNetworking {
             pageSize: pagination.limit,
             apiKey: apiKey ?? "",
             blockSignedAtAsc: sortOrder == .asc)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter.dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { [server, paginationFilter] response -> TransactionsResponse in
                 guard let json = try? JSON(data: response.data) else { throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "")) }
 
@@ -71,7 +72,7 @@ public class CovalentApiNetworking: ApiNetworking {
 
     public func erc721TokenTransferTransactions(walletAddress: AlphaWallet.Address,
                                                 pagination: TransactionsPagination?) -> AnyPublisher<TransactionsResponse, PromiseError> {
-        
+
         return .fail(PromiseError(error: ApiNetworkingError.methodNotSupported))
     }
 
@@ -99,11 +100,13 @@ public class CovalentApiNetworking: ApiNetworking {
         return .fail(PromiseError(error: ApiNetworkingError.methodNotSupported))
     }
 
-    fileprivate static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
+    fileprivate static func log(response: URLRequest.Response, server: RPCServer, analytics: AnalyticsLogger, domainName: String, caller: String = #function) {
         switch URLRequest.validate(statusCode: 200..<300, response: response.response) {
         case .failure:
             let json = try? JSON(response.data)
             infoLog("[API] request failure with status code: \(response.response.statusCode), json: \(json), server: \(server)", callerFunctionName: caller)
+            let properties: [String: AnalyticsEventPropertyValue] = [Analytics.Properties.chain.rawValue: server.chainID, Analytics.Properties.domainName.rawValue: domainName, Analytics.Properties.code.rawValue: response.response.statusCode]
+            analytics.log(error: Analytics.WebApiErrors.blockchainExplorerError, properties: properties)
         case .success:
             break
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Oklink/OklinkNetworking.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Transactions/Oklink/OklinkNetworking.swift
@@ -27,18 +27,15 @@ public class OklinkApiNetworking: ApiNetworking {
     private let ercTokenProvider: TokenProviderType
     private let transactionBuilder: TransactionBuilder
     private let defaultPagination = PageBasedTransactionsPagination(page: 0, lastFetched: [], limit: 50)
+    private let analytics: AnalyticsLogger
 
-    public init(server: RPCServer,
-                apiKey: String?,
-                transporter: ApiTransporter,
-                ercTokenProvider: TokenProviderType,
-                transactionBuilder: TransactionBuilder) {
-
+    public init(server: RPCServer, apiKey: String?, transporter: ApiTransporter, ercTokenProvider: TokenProviderType, transactionBuilder: TransactionBuilder, analytics: AnalyticsLogger) {
         self.transactionBuilder = transactionBuilder
         self.ercTokenProvider = ercTokenProvider
         self.server = server
         self.apiKey = apiKey
         self.transporter = transporter
+        self.analytics = analytics
     }
 
     public func gasPriceEstimates() -> AnyPublisher<LegacyGasEstimates, PromiseError> {
@@ -64,9 +61,11 @@ public class OklinkApiNetworking: ApiNetworking {
             headers: OklinkApiNetworking.allHTTPHeaderFields)
 
         let decoder = NormalTransactionListDecoder(pagination: pagination, paginationFilter: paginationFilter)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter.dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { try decoder.decode(data: $0.data) }
             .mapError { PromiseError(error: $0) }
             .flatMap { response in
@@ -107,9 +106,11 @@ public class OklinkApiNetworking: ApiNetworking {
             headers: OklinkApiNetworking.allHTTPHeaderFields)
 
         let decoder = TransactionListDecoder(pagination: pagination, paginationFilter: paginationFilter)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter.dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { try decoder.decode(data: $0.data) }
             .mapError { PromiseError(error: $0) }
             .flatMap { response -> AnyPublisher<TransactionsResponse, PromiseError> in
@@ -142,9 +143,11 @@ public class OklinkApiNetworking: ApiNetworking {
             headers: OklinkApiNetworking.allHTTPHeaderFields)
 
         let decoder = TransactionListDecoder(pagination: pagination, paginationFilter: paginationFilter)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter.dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { try decoder.decode(data: $0.data) }
             .mapError { PromiseError(error: $0) }
             .flatMap { response -> AnyPublisher<TransactionsResponse, PromiseError> in
@@ -177,9 +180,11 @@ public class OklinkApiNetworking: ApiNetworking {
             headers: OklinkApiNetworking.allHTTPHeaderFields)
 
         let decoder = TransactionListDecoder(pagination: pagination, paginationFilter: paginationFilter)
+        let analytics = analytics
+        let domainName = baseUrl.host!
 
         return transporter.dataTaskPublisher(request)
-            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server) })
+            .handleEvents(receiveOutput: { [server] in Self.log(response: $0, server: server, analytics: analytics, domainName: domainName) })
             .tryMap { try decoder.decode(data: $0.data) }
             .mapError { PromiseError(error: $0) }
             .flatMap { response -> AnyPublisher<TransactionsResponse, PromiseError> in
@@ -349,11 +354,13 @@ public class OklinkApiNetworking: ApiNetworking {
             }.eraseToAnyPublisher()
     }
 
-    fileprivate static func log(response: URLRequest.Response, server: RPCServer, caller: String = #function) {
+    fileprivate static func log(response: URLRequest.Response, server: RPCServer, analytics: AnalyticsLogger, domainName: String, caller: String = #function) {
         switch URLRequest.validate(statusCode: 200..<300, response: response.response) {
         case .failure:
             let json = try? JSON(response.data)
             infoLog("[API] request failure with status code: \(response.response.statusCode), json: \(json), server: \(server)", callerFunctionName: caller)
+            let properties: [String: AnalyticsEventPropertyValue] = [Analytics.Properties.chain.rawValue: server.chainID, Analytics.Properties.domainName.rawValue: domainName, Analytics.Properties.code.rawValue: response.response.statusCode]
+            analytics.log(error: Analytics.WebApiErrors.blockchainExplorerError, properties: properties)
         case .success:
             break
         }

--- a/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/SessionsProvider.swift
+++ b/modules/AlphaWalletFoundation/AlphaWalletFoundation/Types/SessionsProvider.swift
@@ -149,47 +149,16 @@ open class BaseSessionsProvider: SessionsProvider {
 
         switch server.transactionsSource {
         case .etherscan(let apiKey, let url):
-            let transactionBuilder = TransactionBuilder(
-                tokensDataStore: tokensDataStore,
-                server: server,
-                ercTokenProvider: ercTokenProvider)
-
-            return EtherscanCompatibleApiNetworking(
-                server: server,
-                transporter: transporter,
-                transactionBuilder: transactionBuilder,
-                baseUrl: url,
-                apiKey: apiKey)
+            let transactionBuilder = TransactionBuilder(tokensDataStore: tokensDataStore, server: server, ercTokenProvider: ercTokenProvider)
+            return EtherscanCompatibleApiNetworking(server: server, transporter: transporter, transactionBuilder: transactionBuilder, baseUrl: url, apiKey: apiKey, analytics: analytics)
         case .blockscout(let apiKey, let url):
-            let transactionBuilder = TransactionBuilder(
-                tokensDataStore: tokensDataStore,
-                server: server,
-                ercTokenProvider: ercTokenProvider)
-
-            return BlockscoutApiNetworking(
-                server: server,
-                transporter: transporter,
-                transactionBuilder: transactionBuilder,
-                apiKey: apiKey,
-                baseUrl: url)
+            let transactionBuilder = TransactionBuilder(tokensDataStore: tokensDataStore, server: server, ercTokenProvider: ercTokenProvider)
+            return BlockscoutApiNetworking(server: server, transporter: transporter, transactionBuilder: transactionBuilder, apiKey: apiKey, baseUrl: url, analytics: analytics)
         case .covalent(let apiKey):
-            return CovalentApiNetworking(
-                server: server,
-                apiKey: apiKey,
-                transporter: transporter)
-
+            return CovalentApiNetworking(server: server, apiKey: apiKey, transporter: transporter, analytics: analytics)
         case .oklink(let apiKey):
-            let transactionBuilder = TransactionBuilder(
-                tokensDataStore: tokensDataStore,
-                server: server,
-                ercTokenProvider: ercTokenProvider)
-
-            return OklinkApiNetworking(
-                server: server,
-                apiKey: apiKey,
-                transporter: transporter,
-                ercTokenProvider: ercTokenProvider,
-                transactionBuilder: transactionBuilder)
+            let transactionBuilder = TransactionBuilder(tokensDataStore: tokensDataStore, server: server, ercTokenProvider: ercTokenProvider)
+            return OklinkApiNetworking(server: server, apiKey: apiKey, transporter: transporter, ercTokenProvider: ercTokenProvider, transactionBuilder: transactionBuilder, analytics: analytics)
         case .unknown:
             return FallbackApiNetworking()
         }


### PR DESCRIPTION
Also trap and log Etherscan rate limiting errors, which are still returned as `200`