### PR TITLE
Update Dapps.swift

### DIFF
--- a/AlphaWallet/Browser/ViewModel/Dapps.swift
+++ b/AlphaWallet/Browser/ViewModel/Dapps.swift
@@ -12,6 +12,7 @@ enum OriginalDapps {
         Dapp(name: "Eporio", description: "The cheaper marketplace for NFT - Non Fungible Tokens", url: "https://epor.io", cat: "Marketplace"),
         Dapp(name: "TokenSets", description: "Enhance your portfolio with automated asset management strategies.", url: "https://www.tokensets.com/", cat: "Finance"),
         Dapp(name: "State of the ÐApps", description: "Directory of Decentralized Applications", url: "https://www.stateofthedapps.com/", cat: "Directory"),
+        Dapp(name: "OGP Bulk Sender", description: "Send native coins, tokens, and NFTs in batches", url: "https://offgridplatform.com/apps/bulk-sender", cat: "Finance"),
         Dapp(name: "BulkSender", description: "Batch sending of tokens", url: "https://bulksender.app/", cat: "Finance"),
         Dapp(name: "Phiswap", description: "Swap Assets On The Largest Decentralized Exchange", url: "https://app.phiswap.com", cat: "Finance"),
         Dapp(name: "Phitoken", description: "Mint New PHI20 Assets", url: "https://app.phitoken.com", cat: "Finance"),


### PR DESCRIPTION
Adds OGP Bulk Sender dApp that allows users to batch send not only native coins like ETH, but also tokens and NFTs

If bug:
Fixes #

If not a bug:
Closes #

1-liner summary:

Details if any (this should probably be in the commit message too):

Screenshots of Before PR and After PR if it's applicable (sometimes this make it much faster/easier to review):

Anything particular to test:
